### PR TITLE
Superseded: Add Neuron maintenance snapshot tooling

### DIFF
--- a/Config/Neuron/baselines/default.neuron.json
+++ b/Config/Neuron/baselines/default.neuron.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": "0.1.0",
+  "baselineName": "default-neuron-baseline",
+  "deviceClass": "Neuron",
+  "description": "Default Neuron maintenance and survey baseline for SysAdminSuite. This is intentionally conservative until site-specific server, port, and software data are confirmed.",
+  "sourceNotes": [
+    "Seeded from field observation of Neuron maintenance console tooling.",
+    "Observed software reference included 11.8.0.328.",
+    "Replace placeholder endpoints with confirmed site/application targets before using as pass/fail authority."
+  ],
+  "expectedSoftware": {
+    "referenceVersions": [
+      "11.8.0.328"
+    ],
+    "matchMode": "contains-any",
+    "inventorySources": [
+      "Win32_Product-disabled",
+      "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
+      "HKLM:\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
+    ],
+    "requiredApplications": [],
+    "optionalApplications": [],
+    "notes": "Avoid Win32_Product for routine scans because it can trigger MSI repair checks. Prefer registry uninstall keys."
+  },
+  "network": {
+    "serverTargets": [],
+    "followerTargets": [],
+    "vpnTargets": [
+      "10.8.0.1"
+    ],
+    "requiredTcpPorts": [],
+    "ping": {
+      "count": 4,
+      "acceptablePacketLossPercent": 0,
+      "warningLatencyMs": 100,
+      "criticalLatencyMs": 250
+    },
+    "dnsRequired": true,
+    "routeSnapshotRequired": true
+  },
+  "services": {
+    "requiredPatterns": [
+      "MSMQ",
+      "OpenVPN",
+      "DCIS"
+    ],
+    "observedOrCandidatePatterns": [
+      "SmartLynx",
+      "SIS",
+      "Epic",
+      "Imprivata"
+    ],
+    "expectedState": "Running",
+    "compareFields": [
+      "Name",
+      "DisplayName",
+      "State",
+      "StartMode",
+      "StartName"
+    ]
+  },
+  "firewall": {
+    "captureProfiles": true,
+    "modifyRulesByDefault": false,
+    "expectedProfiles": {
+      "Domain": "document-only",
+      "Private": "document-only",
+      "Public": "document-only"
+    }
+  },
+  "wireless": {
+    "captureProfiles": true,
+    "captureInterfaces": true,
+    "captureVisibleNetworks": true,
+    "traceEnabledByDefault": false
+  },
+  "repairActions": {
+    "allowNetworkResetByDefault": false,
+    "allowServiceChangeByDefault": false,
+    "allowFirewallChangeByDefault": false,
+    "releaseRenewRequiresExplicitSwitch": true
+  },
+  "surveyPacket": {
+    "requiredFields": [
+      "Timestamp",
+      "ComputerName",
+      "BiosSerial",
+      "Manufacturer",
+      "Model",
+      "IpAddresses",
+      "MacAddresses",
+      "DefaultGateways",
+      "DnsServers",
+      "VpnAdapterPresent",
+      "PingResults",
+      "ServiceResults",
+      "FirewallProfiles",
+      "WirelessSummary",
+      "SoftwareMatches"
+    ],
+    "outputFormats": [
+      "txt",
+      "json",
+      "csv",
+      "html"
+    ]
+  },
+  "statusRules": {
+    "pass": [
+      "Required targets reachable when configured",
+      "Required services found and running",
+      "Expected software reference found",
+      "No disruptive repair action required"
+    ],
+    "warning": [
+      "Endpoint targets not configured",
+      "Candidate service missing but not required",
+      "Latency above warning threshold",
+      "Wireless data unavailable on wired-only device"
+    ],
+    "fail": [
+      "Required service missing",
+      "Required service stopped",
+      "Required software reference missing",
+      "Packet loss above acceptable threshold",
+      "VPN target unreachable when configured as required"
+    ]
+  }
+}

--- a/QRTasks/Get-NeuronMaintenanceSnapshot.ps1
+++ b/QRTasks/Get-NeuronMaintenanceSnapshot.ps1
@@ -1,0 +1,289 @@
+<#
+.SYNOPSIS
+    Safe Neuron maintenance-console inspired snapshot.
+
+.DESCRIPTION
+    Captures the same class of information visible in the Neuron local maintenance UI:
+    ping checks, IP configuration, service status, firewall state, netstat output,
+    wireless profiles/interfaces/networks, and optional local subnet discovery.
+
+    Default behavior is read-only. Potentially disruptive repair behavior, such as
+    DHCP release/renew, requires explicit opt-in.
+
+.PARAMETER OutDir
+    Output directory for timestamped artifacts. Defaults to the current user's Desktop.
+
+.PARAMETER ServerTargets
+    Primary server targets to ping.
+
+.PARAMETER FollowerTargets
+    Follower/secondary server targets to ping.
+
+.PARAMETER VpnTargets
+    VPN targets to ping.
+
+.PARAMETER ServiceNamePatterns
+    Service name/display-name patterns to check.
+
+.PARAMETER IncludeNetworkScan
+    Include ARP table and lightweight local subnet scan hints.
+
+.PARAMETER AllowNetworkReset
+    Permit DHCP release/renew. Without this switch, release/renew is documented but not executed.
+
+.PARAMETER ReleaseRenew
+    Perform DHCP release/renew. Requires -AllowNetworkReset.
+
+.EXAMPLE
+    .\Get-NeuronMaintenanceSnapshot.ps1 -ServerTargets 10.8.0.1 -VpnTargets 10.8.0.1
+
+.EXAMPLE
+    .\Get-NeuronMaintenanceSnapshot.ps1 -IncludeNetworkScan
+
+.EXAMPLE
+    .\Get-NeuronMaintenanceSnapshot.ps1 -ReleaseRenew -AllowNetworkReset
+#>
+[CmdletBinding()]
+param(
+    [string]$OutDir = ([Environment]::GetFolderPath('Desktop')),
+
+    [string[]]$ServerTargets = @(),
+
+    [string[]]$FollowerTargets = @(),
+
+    [string[]]$VpnTargets = @(),
+
+    [string[]]$ServiceNamePatterns = @(
+        'MSMQ',
+        'OpenVPN',
+        'DCIS',
+        'SmartLynx',
+        'SIS',
+        'Epic',
+        'Imprivata'
+    ),
+
+    [switch]$IncludeNetworkScan,
+
+    [switch]$ReleaseRenew,
+
+    [switch]$AllowNetworkReset
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Continue'
+
+function New-SafeDirectory {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Write-Section {
+    param(
+        [string]$Title,
+        [scriptblock]$Body
+    )
+
+    $line = ('=' * 78)
+    $script:ReportLines += ''
+    $script:ReportLines += $line
+    $script:ReportLines += $Title
+    $script:ReportLines += $line
+
+    try {
+        $result = & $Body 2>&1 | Out-String -Width 220
+        if ([string]::IsNullOrWhiteSpace($result)) {
+            $script:ReportLines += '[no output]'
+        } else {
+            $script:ReportLines += $result.TrimEnd()
+        }
+    } catch {
+        $script:ReportLines += "ERROR: $($_.Exception.Message)"
+    }
+}
+
+function Test-TargetPing {
+    param(
+        [string]$Group,
+        [string[]]$Targets
+    )
+
+    if (-not $Targets -or $Targets.Count -eq 0) {
+        [pscustomobject]@{
+            Group      = $Group
+            Target     = '[not configured]'
+            Reachable  = $null
+            LatencyMs  = $null
+            Notes      = 'No target configured yet. Add baseline config once real endpoints are known.'
+        }
+        return
+    }
+
+    foreach ($target in $Targets) {
+        $ping = $null
+        try {
+            $ping = Test-Connection -ComputerName $target -Count 4 -ErrorAction Stop
+            $avg = [math]::Round(($ping | Measure-Object -Property ResponseTime -Average).Average, 2)
+            [pscustomobject]@{
+                Group      = $Group
+                Target     = $target
+                Reachable  = $true
+                LatencyMs  = $avg
+                Notes      = "Replies: $($ping.Count)"
+            }
+        } catch {
+            [pscustomobject]@{
+                Group      = $Group
+                Target     = $target
+                Reachable  = $false
+                LatencyMs  = $null
+                Notes      = $_.Exception.Message
+            }
+        }
+    }
+}
+
+function Get-ServiceMatches {
+    param([string[]]$Patterns)
+
+    $services = Get-CimInstance Win32_Service -ErrorAction SilentlyContinue
+    foreach ($pattern in $Patterns) {
+        $matches = $services | Where-Object {
+            $_.Name -like "*$pattern*" -or $_.DisplayName -like "*$pattern*"
+        }
+
+        if (-not $matches) {
+            [pscustomobject]@{
+                Pattern     = $pattern
+                Name        = '[not found]'
+                DisplayName = '[not found]'
+                State       = $null
+                StartMode   = $null
+                StartName   = $null
+            }
+        } else {
+            $matches | Select-Object @{n='Pattern';e={$pattern}}, Name, DisplayName, State, StartMode, StartName
+        }
+    }
+}
+
+function Invoke-CmdText {
+    param([string]$Command)
+    cmd.exe /c $Command
+}
+
+New-SafeDirectory -Path $OutDir
+$stamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$baseName = "NeuronMaintenanceSnapshot_$env:COMPUTERNAME`_$stamp"
+$textPath = Join-Path $OutDir "$baseName.txt"
+$jsonPath = Join-Path $OutDir "$baseName.json"
+
+$script:ReportLines = @()
+$summary = [ordered]@{
+    Timestamp       = (Get-Date).ToString('s')
+    ComputerName    = $env:COMPUTERNAME
+    UserName        = $env:USERNAME
+    ReadOnlyDefault = $true
+    OutputText      = $textPath
+    OutputJson      = $jsonPath
+}
+
+Write-Host "`n  Neuron maintenance snapshot" -ForegroundColor Cyan
+Write-Host "  Output: $textPath`n" -ForegroundColor DarkGray
+
+Write-Section -Title 'Host Identity' -Body {
+    Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer, Model, Name, Domain, TotalPhysicalMemory | Format-List
+    Get-CimInstance Win32_BIOS | Select-Object SerialNumber, SMBIOSBIOSVersion, ReleaseDate | Format-List
+}
+
+$pingResults = @()
+$pingResults += Test-TargetPing -Group 'Server' -Targets $ServerTargets
+$pingResults += Test-TargetPing -Group 'Follower' -Targets $FollowerTargets
+$pingResults += Test-TargetPing -Group 'VPN' -Targets $VpnTargets
+$summary.PingResults = $pingResults
+
+Write-Section -Title 'Ping Checks: Server / Follower / VPN' -Body {
+    $pingResults | Format-Table -AutoSize
+}
+
+Write-Section -Title 'IP Configuration' -Body {
+    Invoke-CmdText 'ipconfig /all'
+}
+
+Write-Section -Title 'Routes' -Body {
+    route print
+}
+
+$serviceResults = @(Get-ServiceMatches -Patterns $ServiceNamePatterns)
+$summary.ServiceResults = $serviceResults
+
+Write-Section -Title 'Selected Service Checks' -Body {
+    $serviceResults | Sort-Object Pattern, Name | Format-Table -AutoSize
+}
+
+Write-Section -Title 'All Services' -Body {
+    Get-Service | Sort-Object Name | Select-Object Name, DisplayName, Status, StartType | Format-Table -AutoSize
+}
+
+Write-Section -Title 'Firewall Profiles' -Body {
+    if (Get-Command Get-NetFirewallProfile -ErrorAction SilentlyContinue) {
+        Get-NetFirewallProfile | Select-Object Name, Enabled, DefaultInboundAction, DefaultOutboundAction | Format-Table -AutoSize
+    } else {
+        Invoke-CmdText 'netsh advfirewall show allprofiles'
+    }
+}
+
+Write-Section -Title 'NetStat' -Body {
+    Invoke-CmdText 'netstat -ano'
+}
+
+Write-Section -Title 'Wireless Profiles' -Body {
+    Invoke-CmdText 'netsh wlan show profiles'
+}
+
+Write-Section -Title 'Wireless Interfaces' -Body {
+    Invoke-CmdText 'netsh wlan show interfaces'
+}
+
+Write-Section -Title 'Wireless Networks' -Body {
+    Invoke-CmdText 'netsh wlan show networks mode=bssid'
+}
+
+if ($IncludeNetworkScan) {
+    Write-Section -Title 'Network Device Scan: ARP Table' -Body {
+        arp -a
+    }
+
+    Write-Section -Title 'Network Device Scan: Local Adapter Hint' -Body {
+        Get-CimInstance Win32_NetworkAdapterConfiguration |
+            Where-Object { $_.IPEnabled } |
+            Select-Object Description, MACAddress, IPAddress, IPSubnet, DefaultIPGateway, DNSServerSearchOrder |
+            Format-List
+    }
+}
+
+if ($ReleaseRenew) {
+    if (-not $AllowNetworkReset) {
+        Write-Section -Title 'Release/Renew Requested But Blocked' -Body {
+            'Release/Renew was requested, but -AllowNetworkReset was not supplied. No network reset was performed.'
+        }
+    } else {
+        Write-Section -Title 'Release/Renew Executed' -Body {
+            Invoke-CmdText 'ipconfig /release'
+            Invoke-CmdText 'ipconfig /renew'
+            Invoke-CmdText 'ipconfig'
+        }
+        $summary.NetworkResetExecuted = $true
+    }
+} else {
+    $summary.NetworkResetExecuted = $false
+}
+
+$script:ReportLines | Set-Content -LiteralPath $textPath -Encoding UTF8
+$summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $jsonPath -Encoding UTF8
+
+Write-Host "  Snapshot complete." -ForegroundColor Green
+Write-Host "  Text: $textPath" -ForegroundColor Gray
+Write-Host "  JSON: $jsonPath" -ForegroundColor Gray

--- a/QRTasks/Invoke-TechTask.ps1
+++ b/QRTasks/Invoke-TechTask.ps1
@@ -96,14 +96,15 @@ if ($resolvedRoot.Resolution -ne 'primary path available') {
 # ── Task registry ────────────────────────────────────────────────────
 # Map short names to script filenames (relative to $ScriptRoot).
 $TaskMap = [ordered]@{
-    RAMProfile        = 'Get-RAMProfile.ps1'
-    ModelInfo         = 'Get-ModelInfo.ps1'
-    NetworkInfo       = 'Get-NetworkInfo.ps1'
-    Serials           = 'Get-Serials.ps1'
-    NeuronTrace       = 'Get-NeuronTrace.ps1'
-    WinOptionalFeatures = 'Get-WindowsOptionalFeatures.ps1'
-    PowerComfort        = 'Set-PowerComfortDefaults.ps1'
-    PowerComfortRevert  = 'Restore-PowerComfortDefaults.ps1'
+    RAMProfile           = 'Get-RAMProfile.ps1'
+    ModelInfo            = 'Get-ModelInfo.ps1'
+    NetworkInfo          = 'Get-NetworkInfo.ps1'
+    Serials              = 'Get-Serials.ps1'
+    NeuronTrace          = 'Get-NeuronTrace.ps1'
+    NeuronMaintenance    = 'Get-NeuronMaintenanceSnapshot.ps1'
+    WinOptionalFeatures  = 'Get-WindowsOptionalFeatures.ps1'
+    PowerComfort         = 'Set-PowerComfortDefaults.ps1'
+    PowerComfortRevert   = 'Restore-PowerComfortDefaults.ps1'
 }
 
 # ── Help / list mode ────────────────────────────────────────────────

--- a/docs/NeuronMaintenanceTools.md
+++ b/docs/NeuronMaintenanceTools.md
@@ -1,0 +1,177 @@
+# Neuron Maintenance Console Tooling
+
+## Purpose
+
+This document captures the built-in Neuron maintenance tools observed from field photos and turns them into a SysAdminSuite roadmap. The immediate goal is not to clone the vendor console pixel-for-pixel. The goal is colder and better: reproduce the useful checks remotely, safely, and repeatably so a tech does not need to log into the hidden maintenance interface just to determine survey status, device identity, software posture, or network readiness.
+
+## Field observation notes
+
+The screen is physically rotated 90 or 270 degrees depending on viewing angle. Treat photos from these devices as orientation-variable evidence. Do not rely on OCR as the authority when building production logic. Use the visible button labels and command output as the first catalog, then validate each item with hands-on runs.
+
+Observed command output included:
+
+- Echo server check
+- Ping VPN check against a 10.8.0.x VPN endpoint
+- ICMP response timing around 14-15 ms in the photo
+- Output panel showing basic command result text, packet counts, and round-trip stats
+
+## Observed left-side tool buttons
+
+### Page 1: echo, ping, and IP basics
+
+| Observed button | Likely purpose | SysAdminSuite target behavior | Risk level |
+|---|---|---|---|
+| Echo Server | Test application/server echo path | Resolve target, test TCP/HTTP/ICMP depending on known protocol, log response | Read-only |
+| Echo Follower Servers | Test redundant/follower echo endpoints | Iterate configured follower endpoints and compare reachability | Read-only |
+| Ping VPN | Ping VPN gateway or tunnel endpoint | ICMP ping configured VPN target, store latency/loss | Read-only |
+| Ping Server | Ping primary application/server host | ICMP ping primary endpoint, include DNS resolution | Read-only |
+| Ping Follower Servers | Ping secondary/follower endpoints | Iterate follower host list with latency/loss table | Read-only |
+| Ip Config | Show standard IP configuration | Capture `ipconfig` summary and adapter basics | Read-only |
+| Ip Config All | Show full IP configuration | Capture `ipconfig /all`, DNS, DHCP, gateway, MACs | Read-only |
+| All Tasks Services | Likely service status subset for task-related services | Collect all vendor-relevant service statuses into one table | Read-only |
+| All Tasks | Likely runs broad task/status checks | Run the non-destructive snapshot profile | Read-only by default |
+
+### Page 2: services, firewall, netstat, wireless inventory
+
+| Observed button | Likely purpose | SysAdminSuite target behavior | Risk level |
+|---|---|---|---|
+| MSMQ service | Check Microsoft Message Queuing service | Query service existence/start mode/status; optional start only when explicitly requested | Read-only default |
+| OpenVPN service | Check VPN service | Query OpenVPN services and tunnel adapter state | Read-only default |
+| DCIS service | Check device/vendor integration service | Query matching service by exact configured name or fuzzy service display name | Read-only default |
+| All Services | Show all Windows services | Export service name/display/start/status table | Read-only |
+| Firewall | Show firewall profile state | Capture domain/private/public profile state and rules summary | Read-only |
+| NetStat | Show network sessions/listeners | Capture `netstat -ano`; optional process resolution | Read-only |
+| Wireless Profiles | Show saved WLAN profiles | Capture `netsh wlan show profiles` | Read-only |
+| Wireless Interfaces | Show WLAN adapter/interface status | Capture `netsh wlan show interfaces` | Read-only |
+| Wireless Networks | Show visible WLAN networks | Capture `netsh wlan show networks mode=bssid` | Read-only |
+
+### Page 3: traces, discovery, and DHCP repair
+
+| Observed button | Likely purpose | SysAdminSuite target behavior | Risk level |
+|---|---|---|---|
+| Wireless Traces | Start/stop or collect WLAN tracing | Provide trace collection wrapper with explicit start/stop and output path | Controlled write |
+| Scan Network Devices | Discover devices on subnet | ARP table plus optional ping sweep of local subnet | Read-only with network traffic |
+| Release/Renew | DHCP release and renew | Require explicit `-AllowNetworkReset`; never run during passive recon | Disruptive |
+
+## Functional groups for SysAdminSuite
+
+### 1. Identity and software posture
+
+Use case: determine which Neuron is in front of you and whether it matches expected configuration without logging into the vendor maintenance server.
+
+Minimum data to capture:
+
+- Hostname
+- BIOS serial
+- MAC addresses
+- IP address and default gateway
+- VPN adapter presence and IP
+- Installed software list
+- Neuron software reference/version, such as the observed `11.8.0.328`
+- Services related to MSMQ, OpenVPN, DCIS, SmartLynx, SIS, Epic, Imprivata, or other configured site baselines
+
+Planned module names:
+
+- `Get-NeuronIdentity`
+- `Get-NeuronSoftwarePosture`
+- `Compare-NeuronSoftwareBaseline`
+- `Export-NeuronSurveyPacket`
+
+### 2. Network and VPN readiness
+
+Use case: prove whether the Neuron can reach what it needs before escalating to TSE, network, or application teams.
+
+Minimum checks:
+
+- DNS resolution
+- Primary server ping
+- Follower server pings
+- VPN endpoint ping
+- VPN service state
+- VPN adapter state
+- Current routes
+- TCP port checks once the real service ports are known
+- Latency/loss summary
+
+Planned module names:
+
+- `Test-NeuronNetworkPath`
+- `Test-NeuronVpnPath`
+- `Get-NeuronRouteSnapshot`
+
+### 3. Service readiness
+
+Use case: determine whether required local services exist, are running, and are configured correctly.
+
+Minimum checks:
+
+- MSMQ
+- OpenVPN
+- DCIS or vendor integration service
+- SmartLynx/SIS/Epic related services when present
+- Start mode
+- Current state
+- Service account
+- Last start failure where available
+
+Planned module names:
+
+- `Get-NeuronServiceState`
+- `Compare-NeuronServiceBaseline`
+
+### 4. Wireless diagnostics
+
+Use case: inventory wireless profile and interface status without clicking through the local maintenance UI.
+
+Minimum checks:
+
+- Saved wireless profiles
+- Active wireless interface state
+- Visible SSIDs/BSSIDs
+- Signal quality
+- Authentication/cipher details where available
+- Optional trace capture
+
+Planned module names:
+
+- `Get-NeuronWirelessSnapshot`
+- `Start-NeuronWirelessTrace`
+- `Stop-NeuronWirelessTrace`
+
+### 5. Controlled repair actions
+
+Use case: keep dangerous actions behind explicit switches.
+
+Rules:
+
+- Release/renew requires `-AllowNetworkReset`.
+- Service start/restart requires `-AllowServiceChange`.
+- Firewall rule modification is out of scope for the first pass.
+- Default mode is survey/recon only.
+
+Stern judge note: if it can knock a device offline, it is not a diagnostic. It is a repair action wearing a fake mustache.
+
+## First implementation checkpoint
+
+The first committed tool is `QRTasks/Get-NeuronMaintenanceSnapshot.ps1`.
+
+It provides a safe field snapshot for:
+
+- Host identity
+- IP configuration
+- VPN/server ping checks
+- selected service status
+- firewall profiles
+- netstat listeners/sessions
+- wireless profiles/interfaces/networks
+- optional network scan
+- optional DHCP release/renew only when explicitly allowed
+
+## Next build targets
+
+1. Add a JSON baseline file per site/device class.
+2. Add software comparison against expected Neuron app/version lists.
+3. Add CSV/HTML report output matching the existing SysAdminSuite style.
+4. Add GUI tab integration under Machine Info or a new Neuron tab.
+5. Add remote execution profile using SMB plus scheduled task, matching the existing no-WinRM posture.
+6. Add tests that verify dangerous actions are locked behind explicit switches.


### PR DESCRIPTION
## Superseded

This April 29 checkpoint PR is superseded by PR #6: `feature/2026-04-30-neuron-tooling-test-readiness`.

Reason:
- PR #6 carries forward the Neuron maintenance tooling.
- PR #6 adds software-reference work, tests, readiness docs, and Bash scaffolding.
- This PR should remain closed as a historical checkpoint only.

Do not merge this PR unless the April 30 branch is abandoned and this branch is intentionally revived.