### PR TITLE
Bash deployment audit and transport hardening

### DIFF
--- a/bash/transport/README.md
+++ b/bash/transport/README.md
@@ -9,7 +9,7 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 | Legacy PowerShell behavior | Old mechanism | Bash migration posture |
 |---|---|---|
 | Network preflight | `Test-Connection` | `sas-network-preflight.sh` using DNS, ping, TCP checks |
-| Workstation identity | `Win32_BIOS`, `Win32_NetworkAdapterConfiguration`, `WmiMonitorID` | `sas-workstation-identity.sh` with ordered read-only transports; future WMI/RPC bridge where approved |
+| Workstation identity | `Win32_BIOS`, `Win32_NetworkAdapterConfiguration`, `WmiMonitorID` | `sas-workstation-identity.sh` with ordered read-only transports; optional WMI adapter where approved |
 | Remote worker staging | `\\HOST\C$\ProgramData\SysAdminSuite\...` | Future SMB client mount/copy where approved; no mutation by default |
 | Remote execution | `schtasks /Create /S HOST /RU SYSTEM` | Future explicit remote-exec adapter only, disabled unless requested |
 | Printer mapping | `PrintUIEntry /ga`, machine-wide registry connections | Preserve as legacy; Bash starts with recon/validation before mapping |
@@ -25,6 +25,7 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 4. Write CSV outputs that can feed other tools.
 5. Preserve source data and raw evidence.
 6. Treat admin-share, SSH, WMI, RPC, SNMP community strings, and printer raw-port commands as environment-specific privileges.
+7. Do not pass credentials on the command line when environment variables are available.
 
 ## Current Bash Tools
 
@@ -32,7 +33,8 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 |---|---|---|
 | `sas-network-preflight.sh` | DNS, ping, TCP port checks for hosts/printers | None |
 | `sas-printer-probe.sh` | Printer MAC/serial probing via SNMP, HTTP, 9100, ARP | Low/read-only; 9100 sends status request |
-| `sas-workstation-identity.sh` | Workstation/Cybernet identity collection via DNS, ping, ARP, optional SSH | Read-only; SSH disabled by default |
+| `sas-workstation-identity.sh` | Workstation/Cybernet identity collection via DNS, ping, ARP, optional SSH, optional WMI | Read-only; SSH/WMI disabled by default |
+| `sas-wmi-identity.sh` | Optional WMI identity adapter for Windows hosts using approved `wmic` client | Read-only WMI queries only |
 | `survey/sas-collect-cybernet-evidence.sh` | Deployment duplicate Cybernet evidence collection using workstation identity adapter | Read-only; adapter-driven |
 
 ## Workstation Identity Flow
@@ -54,6 +56,27 @@ Optional SSH path, only when approved:
   --output data/outputs/workstation_identity.csv
 ```
 
+Optional WMI path, only when approved:
+
+```bash
+export SAS_WMI_USER='approved_user'
+export SAS_WMI_PASS='prompt-or-secret-store-value'
+export SAS_WMI_DOMAIN='NSLIJHS'
+
+./bash/transport/sas-workstation-identity.sh \
+  --target WMH300OPR134 \
+  --allow-wmi \
+  --output data/outputs/workstation_identity.csv
+```
+
+Direct WMI adapter use:
+
+```bash
+./bash/transport/sas-wmi-identity.sh \
+  --target WMH300OPR134 \
+  --output data/outputs/wmi_identity.csv
+```
+
 The collector emits `IdentityStatus`:
 
 | Status | Meaning |
@@ -62,27 +85,39 @@ The collector emits `IdentityStatus`:
 | `ReachableNeedsApprovedIdentityTransport` | Device responds, but current transport cannot collect full identity |
 | `UnreachableOrBlocked` | DNS/ping/available transport could not confirm the target |
 
+The WMI adapter emits `WmiStatus`:
+
+| Status | Meaning |
+|---|---|
+| `WmiIdentityCollected` | WMI returned host, serial, or MAC evidence |
+| `WmiClientMissing` | No approved `wmic` client exists on the Bash host |
+| `WmiQueryFailed` | Firewall, permissions, DCOM/RPC, or query failure blocked collection |
+| `WmiNoIdentityReturned` | WMI ran but did not return identity fields |
+
 ## Risks Addressed
 
 | Risk | Mitigation |
 |---|---|
 | Accidentally extending PowerShell | Bash transport docs and tool locations make Bash the current path |
 | Unsafe remote mutation | Recon tools are read-only by default |
+| Credential leakage | WMI supports environment variables and does not write credentials to output |
 | Revisit without evidence | Tools emit status/evidence CSVs first |
 | Network ambiguity | Preflight separates DNS, ping, and TCP reachability |
 | Printer identity uncertainty | Printer probe records source method for MAC/serial evidence |
 | Cybernet identity uncertainty | Workstation identity adapter centralizes target identity collection |
-| Duplicate audit drift | Deployment evidence collector now calls the identity adapter instead of embedding one-off probe logic |
+| Windows identity gap | Optional WMI adapter gives a stronger approved path when available |
+| Duplicate audit drift | Deployment evidence collector calls the identity adapter instead of embedding one-off probe logic |
 | Data leakage | Live outputs are ignored by `.gitignore`; commit sanitized examples only |
 
 ## Known Limitations
 
 | Limitation | Impact | Handling |
 |---|---|---|
-| Bash cannot natively perform Windows WMI/DCOM without extra tools | Workstation serial/MAC collection may need approved remote bridge | Use SSH when approved; add WMI/RPC adapter later |
+| Bash cannot natively perform Windows WMI/DCOM without extra tools | Workstation serial/MAC collection needs an approved WMI client | Use `--allow-wmi` only where approved client/policy exists |
+| WMI often fails across firewalls or restricted DCOM/RPC policy | Identity may remain unavailable even when device is online | Output `WmiStatus`; fall back to `NeedsPrivilegedSurvey` rather than false certainty |
 | ICMP may be blocked | Ping failure does not prove device is offline | Use TCP checks and DNS result too |
 | ARP only helps on local L2 or after traffic | MAC may be missing across routed networks | Treat ARP as fallback, not proof of absence |
-| SSH collection is not universal | Many Windows/Cybernet devices will not support SSH | SSH requires explicit opt-in; future approved collector needed |
+| SSH collection is not universal | Many Windows/Cybernet devices will not support SSH | SSH requires explicit opt-in |
 | SSH output is platform-dependent | Linux, Windows OpenSSH, and appliances return different identity formats | Output includes `TransportUsed`, `IdentityStatus`, and notes |
 | SNMP may be disabled or community strings unknown | Printer serial/MAC may be unavailable | Try HTTP, 9100, and ARP fallbacks |
 | Port 9100 probes are printer-specific | Non-Zebra or locked printers may ignore commands | Record source and notes clearly |
@@ -90,11 +125,10 @@ The collector emits `IdentityStatus`:
 
 ## Next Transport Upgrades
 
-1. Add an approved WMI/RPC adapter for Windows Cybernet identity collection.
-2. Add SMB admin-share recon that only lists/stages when explicitly enabled.
-3. Add printer queue inventory against print servers.
-4. Add JSON outputs alongside CSV for downstream automation.
-5. Add dry-run/apply split for any future remediation command.
-6. Add a reconciliation joiner that compares deployment audit conflicts against collected identity evidence and produces final `NoRevisit`, `NeedsPrivilegedSurvey`, or `RevisitJustified` verdicts.
+1. Add SMB admin-share read-only recon that only lists/reads approved evidence paths when explicitly enabled.
+2. Add printer queue inventory against print servers.
+3. Add JSON outputs alongside CSV for downstream automation.
+4. Add dry-run/apply split for any future remediation command.
+5. Add a private/sanitized sample fixture set for repeatable tests without live identifiers.
 
 The rule is simple: scout first, shoot never, fix only with orders.

--- a/bash/transport/README.md
+++ b/bash/transport/README.md
@@ -9,11 +9,11 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 | Legacy PowerShell behavior | Old mechanism | Bash migration posture |
 |---|---|---|
 | Network preflight | `Test-Connection` | `sas-network-preflight.sh` using DNS, ping, TCP checks |
-| Workstation identity | `Win32_BIOS`, `Win32_NetworkAdapterConfiguration`, `WmiMonitorID` | SSH/remote command where approved, future WMI/RPC bridge where allowed |
-| Remote worker staging | `\\HOST\C$\ProgramData\SysAdminSuite\...` | SMB client mount/copy where approved; no mutation by default |
-| Remote execution | `schtasks /Create /S HOST /RU SYSTEM` | Explicit remote-exec adapter only, disabled unless requested |
+| Workstation identity | `Win32_BIOS`, `Win32_NetworkAdapterConfiguration`, `WmiMonitorID` | `sas-workstation-identity.sh` with ordered read-only transports; future WMI/RPC bridge where approved |
+| Remote worker staging | `\\HOST\C$\ProgramData\SysAdminSuite\...` | Future SMB client mount/copy where approved; no mutation by default |
+| Remote execution | `schtasks /Create /S HOST /RU SYSTEM` | Future explicit remote-exec adapter only, disabled unless requested |
 | Printer mapping | `PrintUIEntry /ga`, machine-wide registry connections | Preserve as legacy; Bash starts with recon/validation before mapping |
-| Printer queue inventory | `Get-Printer`, `Win32_Printer` | SMB/RPC/CUPS/SNMP paths depending on environment |
+| Printer queue inventory | `Get-Printer`, `Win32_Printer` | Future SMB/RPC/CUPS/SNMP paths depending on environment |
 | Printer identity | SNMP, HTTP scrape, port 9100/ZPL, ARP | `sas-printer-probe.sh` using SNMP/HTTP/9100/ARP |
 | Central logs | per-host log collection | CSV evidence outputs and run directories |
 
@@ -32,7 +32,35 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 |---|---|---|
 | `sas-network-preflight.sh` | DNS, ping, TCP port checks for hosts/printers | None |
 | `sas-printer-probe.sh` | Printer MAC/serial probing via SNMP, HTTP, 9100, ARP | Low/read-only; 9100 sends status request |
-| `survey/sas-collect-cybernet-evidence.sh` | Deployment duplicate Cybernet evidence collection | Read-only; SSH disabled by default |
+| `sas-workstation-identity.sh` | Workstation/Cybernet identity collection via DNS, ping, ARP, optional SSH | Read-only; SSH disabled by default |
+| `survey/sas-collect-cybernet-evidence.sh` | Deployment duplicate Cybernet evidence collection using workstation identity adapter | Read-only; adapter-driven |
+
+## Workstation Identity Flow
+
+```bash
+./bash/transport/sas-workstation-identity.sh \
+  --target WMH300OPR134 \
+  --output data/outputs/workstation_identity.csv
+```
+
+Optional SSH path, only when approved:
+
+```bash
+./bash/transport/sas-workstation-identity.sh \
+  --target WMH300OPR134 \
+  --allow-ssh \
+  --ssh-user approved_user \
+  --ssh-key ~/.ssh/approved_key \
+  --output data/outputs/workstation_identity.csv
+```
+
+The collector emits `IdentityStatus`:
+
+| Status | Meaning |
+|---|---|
+| `IdentityCollected` | At least one hostname, serial, or MAC value was collected |
+| `ReachableNeedsApprovedIdentityTransport` | Device responds, but current transport cannot collect full identity |
+| `UnreachableOrBlocked` | DNS/ping/available transport could not confirm the target |
 
 ## Risks Addressed
 
@@ -43,6 +71,8 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 | Revisit without evidence | Tools emit status/evidence CSVs first |
 | Network ambiguity | Preflight separates DNS, ping, and TCP reachability |
 | Printer identity uncertainty | Printer probe records source method for MAC/serial evidence |
+| Cybernet identity uncertainty | Workstation identity adapter centralizes target identity collection |
+| Duplicate audit drift | Deployment evidence collector now calls the identity adapter instead of embedding one-off probe logic |
 | Data leakage | Live outputs are ignored by `.gitignore`; commit sanitized examples only |
 
 ## Known Limitations
@@ -51,17 +81,20 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 |---|---|---|
 | Bash cannot natively perform Windows WMI/DCOM without extra tools | Workstation serial/MAC collection may need approved remote bridge | Use SSH when approved; add WMI/RPC adapter later |
 | ICMP may be blocked | Ping failure does not prove device is offline | Use TCP checks and DNS result too |
-| SNMP may be disabled or community strings unknown | Printer serial/MAC may be unavailable | Try HTTP, 9100, and ARP fallbacks |
 | ARP only helps on local L2 or after traffic | MAC may be missing across routed networks | Treat ARP as fallback, not proof of absence |
-| Port 9100 probes are printer-specific | Non-Zebra or locked printers may ignore commands | Record source and notes clearly |
 | SSH collection is not universal | Many Windows/Cybernet devices will not support SSH | SSH requires explicit opt-in; future approved collector needed |
+| SSH output is platform-dependent | Linux, Windows OpenSSH, and appliances return different identity formats | Output includes `TransportUsed`, `IdentityStatus`, and notes |
+| SNMP may be disabled or community strings unknown | Printer serial/MAC may be unavailable | Try HTTP, 9100, and ARP fallbacks |
+| Port 9100 probes are printer-specific | Non-Zebra or locked printers may ignore commands | Record source and notes clearly |
+| Admin-share and scheduled-task patterns are not yet ported | No Bash equivalent for remote staging/execution yet | Keep mutation/re-exec out until explicitly approved |
 
 ## Next Transport Upgrades
 
-1. Add WMI/RPC adapter if approved tooling exists from the Bash host.
+1. Add an approved WMI/RPC adapter for Windows Cybernet identity collection.
 2. Add SMB admin-share recon that only lists/stages when explicitly enabled.
 3. Add printer queue inventory against print servers.
 4. Add JSON outputs alongside CSV for downstream automation.
 5. Add dry-run/apply split for any future remediation command.
+6. Add a reconciliation joiner that compares deployment audit conflicts against collected identity evidence and produces final `NoRevisit`, `NeedsPrivilegedSurvey`, or `RevisitJustified` verdicts.
 
 The rule is simple: scout first, shoot never, fix only with orders.

--- a/bash/transport/README.md
+++ b/bash/transport/README.md
@@ -10,7 +10,7 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 |---|---|---|
 | Network preflight | `Test-Connection` | `sas-network-preflight.sh` using DNS, ping, TCP checks |
 | Workstation identity | `Win32_BIOS`, `Win32_NetworkAdapterConfiguration`, `WmiMonitorID` | `sas-workstation-identity.sh` with ordered read-only transports; optional WMI adapter where approved |
-| Remote worker staging | `\\HOST\C$\ProgramData\SysAdminSuite\...` | Future SMB client mount/copy where approved; no mutation by default |
+| Remote worker staging | `\\HOST\C$\ProgramData\SysAdminSuite\...` | `sas-smb-readonly-recon.sh` for read-only admin-share evidence checks; no staging yet |
 | Remote execution | `schtasks /Create /S HOST /RU SYSTEM` | Future explicit remote-exec adapter only, disabled unless requested |
 | Printer mapping | `PrintUIEntry /ga`, machine-wide registry connections | Preserve as legacy; Bash starts with recon/validation before mapping |
 | Printer queue inventory | `Get-Printer`, `Win32_Printer` | Future SMB/RPC/CUPS/SNMP paths depending on environment |
@@ -35,6 +35,7 @@ PowerShell remains in the repo as legacy/reference tooling. For Northwell-target
 | `sas-printer-probe.sh` | Printer MAC/serial probing via SNMP, HTTP, 9100, ARP | Low/read-only; 9100 sends status request |
 | `sas-workstation-identity.sh` | Workstation/Cybernet identity collection via DNS, ping, ARP, optional SSH, optional WMI | Read-only; SSH/WMI disabled by default |
 | `sas-wmi-identity.sh` | Optional WMI identity adapter for Windows hosts using approved `wmic` client | Read-only WMI queries only |
+| `sas-smb-readonly-recon.sh` | Optional SMB admin-share reachability/list recon for approved evidence paths | Read-only; no writes/staging/tasks |
 | `survey/sas-collect-cybernet-evidence.sh` | Deployment duplicate Cybernet evidence collection using workstation identity adapter | Read-only; adapter-driven |
 
 ## Workstation Identity Flow
@@ -77,6 +78,20 @@ Direct WMI adapter use:
   --output data/outputs/wmi_identity.csv
 ```
 
+Optional SMB admin-share read-only recon, only when approved:
+
+```bash
+export SAS_SMB_USER='approved_user'
+export SAS_SMB_PASS='prompt-or-secret-store-value'
+export SAS_SMB_DOMAIN='NSLIJHS'
+
+./bash/transport/sas-smb-readonly-recon.sh \
+  --target WMH300OPR134 \
+  --allow-list \
+  --approved-paths 'ProgramData/SysAdminSuite,ProgramData/SysAdminSuite/Mapping/logs' \
+  --output data/outputs/smb_readonly_recon.csv
+```
+
 The collector emits `IdentityStatus`:
 
 | Status | Meaning |
@@ -94,18 +109,29 @@ The WMI adapter emits `WmiStatus`:
 | `WmiQueryFailed` | Firewall, permissions, DCOM/RPC, or query failure blocked collection |
 | `WmiNoIdentityReturned` | WMI ran but did not return identity fields |
 
+The SMB adapter emits `ReconStatus`:
+
+| Status | Meaning |
+|---|---|
+| `EvidencePathReachable` | Approved SMB evidence path exists and is reachable/listable |
+| `NeedsApprovedCredentialsOrPolicy` | SMB authentication or policy blocked access |
+| `SMBUnavailable` | Host/share could not be reached |
+| `EvidencePathMissing` | Host/share reachable, but approved path missing |
+| `ReviewRequired` | SMB response was ambiguous |
+
 ## Risks Addressed
 
 | Risk | Mitigation |
 |---|---|
 | Accidentally extending PowerShell | Bash transport docs and tool locations make Bash the current path |
 | Unsafe remote mutation | Recon tools are read-only by default |
-| Credential leakage | WMI supports environment variables and does not write credentials to output |
+| Credential leakage | WMI/SMB support environment variables and do not write credentials to output |
 | Revisit without evidence | Tools emit status/evidence CSVs first |
 | Network ambiguity | Preflight separates DNS, ping, and TCP reachability |
 | Printer identity uncertainty | Printer probe records source method for MAC/serial evidence |
 | Cybernet identity uncertainty | Workstation identity adapter centralizes target identity collection |
 | Windows identity gap | Optional WMI adapter gives a stronger approved path when available |
+| Admin-share uncertainty | SMB recon verifies approved evidence paths without staging or executing anything |
 | Duplicate audit drift | Deployment evidence collector calls the identity adapter instead of embedding one-off probe logic |
 | Data leakage | Live outputs are ignored by `.gitignore`; commit sanitized examples only |
 
@@ -115,20 +141,22 @@ The WMI adapter emits `WmiStatus`:
 |---|---|---|
 | Bash cannot natively perform Windows WMI/DCOM without extra tools | Workstation serial/MAC collection needs an approved WMI client | Use `--allow-wmi` only where approved client/policy exists |
 | WMI often fails across firewalls or restricted DCOM/RPC policy | Identity may remain unavailable even when device is online | Output `WmiStatus`; fall back to `NeedsPrivilegedSurvey` rather than false certainty |
+| SMB admin shares may be disabled or blocked | Evidence path reachability may be unavailable | Output `ReconStatus`; do not assume host absence |
+| SMB listing is not the same as identity proof | It proves path access, not Cybernet identity | Use as support evidence, not replacement for serial/MAC identity |
 | ICMP may be blocked | Ping failure does not prove device is offline | Use TCP checks and DNS result too |
 | ARP only helps on local L2 or after traffic | MAC may be missing across routed networks | Treat ARP as fallback, not proof of absence |
 | SSH collection is not universal | Many Windows/Cybernet devices will not support SSH | SSH requires explicit opt-in |
 | SSH output is platform-dependent | Linux, Windows OpenSSH, and appliances return different identity formats | Output includes `TransportUsed`, `IdentityStatus`, and notes |
 | SNMP may be disabled or community strings unknown | Printer serial/MAC may be unavailable | Try HTTP, 9100, and ARP fallbacks |
 | Port 9100 probes are printer-specific | Non-Zebra or locked printers may ignore commands | Record source and notes clearly |
-| Admin-share and scheduled-task patterns are not yet ported | No Bash equivalent for remote staging/execution yet | Keep mutation/re-exec out until explicitly approved |
+| Remote staging and scheduled-task execution are not ported | No Bash mutation/remediation path yet | Keep mutation/re-exec out until explicitly approved |
 
 ## Next Transport Upgrades
 
-1. Add SMB admin-share read-only recon that only lists/reads approved evidence paths when explicitly enabled.
-2. Add printer queue inventory against print servers.
-3. Add JSON outputs alongside CSV for downstream automation.
-4. Add dry-run/apply split for any future remediation command.
-5. Add a private/sanitized sample fixture set for repeatable tests without live identifiers.
+1. Add printer queue inventory against print servers.
+2. Add JSON outputs alongside CSV for downstream automation.
+3. Add dry-run/apply split for any future remediation command.
+4. Add a private/sanitized sample fixture set for repeatable tests without live identifiers.
+5. Add explicit file allowlist support for SMB read checks, still read-only.
 
 The rule is simple: scout first, shoot never, fix only with orders.

--- a/bash/transport/README.md
+++ b/bash/transport/README.md
@@ -1,0 +1,67 @@
+# Bash Transport Layer
+
+This folder contains Bash-first replacements for the old PowerShell workstation and printer access patterns.
+
+PowerShell remains in the repo as legacy/reference tooling. For Northwell-targeted SysAdminSuite workflows, new work belongs here or in another Bash-oriented path.
+
+## Legacy Patterns Mined
+
+| Legacy PowerShell behavior | Old mechanism | Bash migration posture |
+|---|---|---|
+| Network preflight | `Test-Connection` | `sas-network-preflight.sh` using DNS, ping, TCP checks |
+| Workstation identity | `Win32_BIOS`, `Win32_NetworkAdapterConfiguration`, `WmiMonitorID` | SSH/remote command where approved, future WMI/RPC bridge where allowed |
+| Remote worker staging | `\\HOST\C$\ProgramData\SysAdminSuite\...` | SMB client mount/copy where approved; no mutation by default |
+| Remote execution | `schtasks /Create /S HOST /RU SYSTEM` | Explicit remote-exec adapter only, disabled unless requested |
+| Printer mapping | `PrintUIEntry /ga`, machine-wide registry connections | Preserve as legacy; Bash starts with recon/validation before mapping |
+| Printer queue inventory | `Get-Printer`, `Win32_Printer` | SMB/RPC/CUPS/SNMP paths depending on environment |
+| Printer identity | SNMP, HTTP scrape, port 9100/ZPL, ARP | `sas-printer-probe.sh` using SNMP/HTTP/9100/ARP |
+| Central logs | per-host log collection | CSV evidence outputs and run directories |
+
+## Safety Rules
+
+1. Default to read-only.
+2. Never mutate remote machines unless a tool has an explicit `--apply`, `--execute`, or similarly loud flag.
+3. Keep survey/recon separate from remediation.
+4. Write CSV outputs that can feed other tools.
+5. Preserve source data and raw evidence.
+6. Treat admin-share, SSH, WMI, RPC, SNMP community strings, and printer raw-port commands as environment-specific privileges.
+
+## Current Bash Tools
+
+| Tool | Purpose | Mutation risk |
+|---|---|---|
+| `sas-network-preflight.sh` | DNS, ping, TCP port checks for hosts/printers | None |
+| `sas-printer-probe.sh` | Printer MAC/serial probing via SNMP, HTTP, 9100, ARP | Low/read-only; 9100 sends status request |
+| `survey/sas-collect-cybernet-evidence.sh` | Deployment duplicate Cybernet evidence collection | Read-only; SSH disabled by default |
+
+## Risks Addressed
+
+| Risk | Mitigation |
+|---|---|
+| Accidentally extending PowerShell | Bash transport docs and tool locations make Bash the current path |
+| Unsafe remote mutation | Recon tools are read-only by default |
+| Revisit without evidence | Tools emit status/evidence CSVs first |
+| Network ambiguity | Preflight separates DNS, ping, and TCP reachability |
+| Printer identity uncertainty | Printer probe records source method for MAC/serial evidence |
+| Data leakage | Live outputs are ignored by `.gitignore`; commit sanitized examples only |
+
+## Known Limitations
+
+| Limitation | Impact | Handling |
+|---|---|---|
+| Bash cannot natively perform Windows WMI/DCOM without extra tools | Workstation serial/MAC collection may need approved remote bridge | Use SSH when approved; add WMI/RPC adapter later |
+| ICMP may be blocked | Ping failure does not prove device is offline | Use TCP checks and DNS result too |
+| SNMP may be disabled or community strings unknown | Printer serial/MAC may be unavailable | Try HTTP, 9100, and ARP fallbacks |
+| ARP only helps on local L2 or after traffic | MAC may be missing across routed networks | Treat ARP as fallback, not proof of absence |
+| Port 9100 probes are printer-specific | Non-Zebra or locked printers may ignore commands | Record source and notes clearly |
+| SSH collection is not universal | Many Windows/Cybernet devices will not support SSH | SSH requires explicit opt-in; future approved collector needed |
+
+## Next Transport Upgrades
+
+1. Add WMI/RPC adapter if approved tooling exists from the Bash host.
+2. Add SMB admin-share recon that only lists/stages when explicitly enabled.
+3. Add printer queue inventory against print servers.
+4. Add JSON outputs alongside CSV for downstream automation.
+5. Add dry-run/apply split for any future remediation command.
+
+The rule is simple: scout first, shoot never, fix only with orders.

--- a/bash/transport/sas-network-preflight.sh
+++ b/bash/transport/sas-network-preflight.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# SysAdminSuite Bash network preflight
+# Read-only DNS, ping, and TCP checks for workstations/printers.
+
+set -euo pipefail
+
+TARGETS=()
+TARGET_FILE=""
+OUTPUT="bash/transport/output/network_preflight.csv"
+PORTS="135,139,445,3389,515,631,9100"
+TIMEOUT=3
+PASS_THRU=0
+
+usage(){ cat <<'USAGE'
+SysAdminSuite Network Preflight
+
+Usage:
+  ./bash/transport/sas-network-preflight.sh [options] TARGET...
+
+Options:
+  --target VALUE       Add target hostname/IP
+  --targets-file PATH  TXT/CSV-ish file with targets, one per line or first comma field
+  --ports CSV          TCP ports to check. Default: 135,139,445,3389,515,631,9100
+  --output PATH        Output CSV path
+  --timeout SEC        Per-check timeout. Default: 3
+  --pass-thru          Print CSV after writing
+  -h, --help           Show help
+
+Read-only. No remote mutation.
+USAGE
+}
+fail(){ printf '[network-preflight] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[network-preflight] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGETS+=("${2:?missing value for --target}"); shift 2 ;;
+    --targets-file) TARGET_FILE="${2:?missing value for --targets-file}"; shift 2 ;;
+    --ports) PORTS="${2:?missing value for --ports}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
+    -*) fail "Unknown option: $1" ;;
+    *) TARGETS+=("$1"); shift ;;
+  esac
+done
+
+[[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
+if [[ -n "$TARGET_FILE" ]]; then
+  [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(trim "$line")"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    line="${line%%,*}"
+    line="$(trim "$line")"
+    [[ -n "$line" ]] && TARGETS+=("$line")
+  done < "$TARGET_FILE"
+fi
+[[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
+mkdir -p "$(dirname "$OUTPUT")"
+
+IFS=',' read -r -a PORT_ARRAY <<< "$PORTS"
+
+resolve_ip(){
+  local t="$1"
+  if has_cmd getent; then getent ahostsv4 "$t" 2>/dev/null | awk 'NR==1{print $1; exit}'; return; fi
+  if has_cmd nslookup; then nslookup "$t" 2>/dev/null | awk '/^Address: /{print $2}' | tail -n 1; return; fi
+  printf ''
+}
+
+ping_status(){
+  local t="$1"
+  if ping -c 1 -W "$TIMEOUT" "$t" >/dev/null 2>&1; then printf 'Reachable'; else printf 'NoPing'; fi
+}
+
+tcp_status(){
+  local host="$1" port="$2"
+  if has_cmd nc; then
+    if nc -z -w "$TIMEOUT" "$host" "$port" >/dev/null 2>&1; then printf 'Open'; else printf 'ClosedOrFiltered'; fi
+    return
+  fi
+  if has_cmd timeout; then
+    if timeout "$TIMEOUT" bash -c "</dev/tcp/$host/$port" >/dev/null 2>&1; then printf 'Open'; else printf 'ClosedOrFiltered'; fi
+    return
+  fi
+  printf 'NotChecked'
+}
+
+{
+  printf 'Timestamp,Target,ResolvedAddress,PingStatus,Port,PortStatus\n'
+  for target in "${TARGETS[@]}"; do
+    ip="$(resolve_ip "$target")"
+    ping="$(ping_status "${ip:-$target}")"
+    for port in "${PORT_ARRAY[@]}"; do
+      port="$(trim "$port")"
+      [[ -z "$port" ]] && continue
+      status="$(tcp_status "${ip:-$target}" "$port")"
+      printf '"%s","%s","%s","%s","%s","%s"\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$target" "$ip" "$ping" "$port" "$status"
+    done
+  done
+} > "$OUTPUT"
+
+log "Wrote preflight CSV: $OUTPUT"
+[[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-printer-probe.sh
+++ b/bash/transport/sas-printer-probe.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# SysAdminSuite Bash printer identity probe
+# Read-only-ish printer recon: ping, SNMP, HTTP scrape, TCP/9100/ZPL, ARP fallback.
+# 9100 sends a status/config request and should only be used where approved.
+
+set -euo pipefail
+
+TARGETS=()
+TARGET_FILE=""
+OUTPUT="bash/transport/output/printer_probe.csv"
+COMMUNITIES="public,private,northwell,zebra,netadmin"
+TIMEOUT=3
+SNMP_ONLY=0
+SKIP_9100=0
+PASS_THRU=0
+
+usage(){ cat <<'USAGE'
+SysAdminSuite Printer Probe
+
+Usage:
+  ./bash/transport/sas-printer-probe.sh [options] TARGET...
+
+Options:
+  --target VALUE       Add printer hostname/IP
+  --targets-file PATH  TXT/CSV-ish file with targets, one per line or first comma field
+  --communities CSV    SNMP communities to try. Default: public,private,northwell,zebra,netadmin
+  --snmp-only          Skip HTTP, 9100, and ARP fallbacks
+  --skip-9100          Do not send raw-port/ZPL request
+  --output PATH        Output CSV path
+  --timeout SEC        Timeout. Default: 3
+  --pass-thru          Print CSV after writing
+  -h, --help           Show help
+
+Output columns:
+  Timestamp,Target,ResolvedAddress,PingStatus,MAC,Serial,Source,Notes
+
+Risks:
+  - SNMP community strings are sensitive and environment-specific.
+  - HTTP scrape may expose banners only, not serials.
+  - ARP is local-L2 only and not proof of absence.
+  - Port 9100/ZPL should be used only where approved; use --skip-9100 if unsure.
+USAGE
+}
+fail(){ printf '[printer-probe] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[printer-probe] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGETS+=("${2:?missing value for --target}"); shift 2 ;;
+    --targets-file) TARGET_FILE="${2:?missing value for --targets-file}"; shift 2 ;;
+    --communities) COMMUNITIES="${2:?missing value for --communities}"; shift 2 ;;
+    --snmp-only) SNMP_ONLY=1; shift ;;
+    --skip-9100) SKIP_9100=1; shift ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
+    -*) fail "Unknown option: $1" ;;
+    *) TARGETS+=("$1"); shift ;;
+  esac
+done
+[[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
+if [[ -n "$TARGET_FILE" ]]; then
+  [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(trim "$line")"; [[ -z "$line" || "$line" == \#* ]] && continue
+    line="${line%%,*}"; line="$(trim "$line")"; [[ -n "$line" ]] && TARGETS+=("$line")
+  done < "$TARGET_FILE"
+fi
+[[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
+mkdir -p "$(dirname "$OUTPUT")"
+IFS=',' read -r -a COMMUNITY_ARRAY <<< "$COMMUNITIES"
+
+norm_mac(){
+  local raw="${1:-}" hx out i
+  hx="$(printf '%s' "$raw" | tr -cd '[:xdigit:]' | tr '[:lower:]' '[:upper:]')"
+  if [[ ${#hx} -ge 12 ]]; then
+    hx="${hx:0:12}"; out=""
+    for ((i=0;i<12;i+=2)); do [[ -n "$out" ]] && out+=":"; out+="${hx:i:2}"; done
+    printf '%s' "$out"
+  else printf ''; fi
+}
+resolve_ip(){ if has_cmd getent; then getent ahostsv4 "$1" 2>/dev/null | awk 'NR==1{print $1; exit}'; else printf ''; fi; }
+ping_status(){ if ping -c 1 -W "$TIMEOUT" "$1" >/dev/null 2>&1; then printf 'Reachable'; else printf 'NoPing'; fi; }
+
+try_snmp_serial(){
+  local ip="$1" comm out val
+  has_cmd snmpget || return 0
+  for comm in "${COMMUNITY_ARRAY[@]}"; do
+    comm="$(trim "$comm")"; [[ -z "$comm" ]] && continue
+    out="$(snmpget -v 2c -c "$comm" -t "$TIMEOUT" -r 0 "$ip" 1.3.6.1.2.1.43.5.1.1.17.1 2>/dev/null || true)"
+    [[ -z "$out" ]] && out="$(snmpget -v 1 -c "$comm" -t "$TIMEOUT" -r 0 "$ip" 1.3.6.1.2.1.43.5.1.1.17.1 2>/dev/null || true)"
+    if [[ -n "$out" ]]; then
+      val="$(printf '%s' "$out" | sed -E 's/.*STRING: "?([^" ]+)"?.*/\1/')"
+      [[ -n "$val" && "$val" != "$out" ]] && printf '%s|SNMP serial (%s)' "$val" "$comm" && return 0
+    fi
+  done
+}
+try_snmp_mac(){
+  local ip="$1" comm out mac
+  has_cmd snmpwalk || return 0
+  for comm in "${COMMUNITY_ARRAY[@]}"; do
+    comm="$(trim "$comm")"; [[ -z "$comm" ]] && continue
+    out="$(snmpwalk -v 2c -c "$comm" -t "$TIMEOUT" -r 0 -On "$ip" 1.3.6.1.2.1.2.2.1.6 2>/dev/null || true)"
+    [[ -z "$out" ]] && out="$(snmpwalk -v 1 -c "$comm" -t "$TIMEOUT" -r 0 -On "$ip" 1.3.6.1.2.1.2.2.1.6 2>/dev/null || true)"
+    mac="$(norm_mac "$out")"
+    [[ -n "$mac" && "$mac" != "00:00:00:00:00:00" ]] && printf '%s|SNMP ifPhysAddress (%s)' "$mac" "$comm" && return 0
+  done
+}
+try_http(){
+  local ip="$1" html mac serial
+  has_cmd curl || return 0
+  html="$(curl -m "$TIMEOUT" -fsS "http://$ip" 2>/dev/null || true)"
+  [[ -z "$html" ]] && return 0
+  mac="$(printf '%s' "$html" | grep -Eio '([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}' | head -n1 || true)"
+  mac="$(norm_mac "$mac")"
+  serial="$(printf '%s' "$html" | grep -Eio '(Serial Number|Serial|S/N)[^A-Za-z0-9]{0,12}[A-Za-z0-9_/-]{5,}' | head -n1 | sed -E 's/.*[^A-Za-z0-9_/-]([A-Za-z0-9_/-]{5,})$/\1/' || true)"
+  [[ -n "$mac" || -n "$serial" ]] && printf '%s|%s|HTTP scrape' "$mac" "$serial"
+}
+try_9100(){
+  local ip="$1" txt mac serial
+  [[ "$SKIP_9100" -eq 1 ]] && return 0
+  has_cmd nc || return 0
+  txt="$(printf '^XA^HH^XZ\r\n' | nc -w "$TIMEOUT" "$ip" 9100 2>/dev/null || true)"
+  [[ -z "$txt" ]] && return 0
+  mac="$(printf '%s' "$txt" | grep -Eio '([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}|[0-9A-Fa-f]{12}' | head -n1 || true)"
+  mac="$(norm_mac "$mac")"
+  serial="$(printf '%s' "$txt" | grep -Eio '(Serial Number|Serial|S/N)[^A-Za-z0-9]{0,12}[A-Za-z0-9_/-]{5,}' | head -n1 | sed -E 's/.*[^A-Za-z0-9_/-]([A-Za-z0-9_/-]{5,})$/\1/' || true)"
+  [[ -n "$mac" || -n "$serial" ]] && printf '%s|%s|9100 ZPL ^HH' "$mac" "$serial"
+}
+try_arp(){
+  local ip="$1" out mac
+  out="$(arp -a "$ip" 2>/dev/null || true)"
+  mac="$(printf '%s' "$out" | grep -Eio '([0-9a-f]{2}[:-]){5}[0-9a-f]{2}' | head -n1 || true)"
+  mac="$(norm_mac "$mac")"
+  [[ -n "$mac" ]] && printf '%s|ARP cache' "$mac"
+}
+
+csv_escape(){ local s="${1:-}"; s="${s//"/""}"; printf '"%s"' "$s"; }
+{
+  printf 'Timestamp,Target,ResolvedAddress,PingStatus,MAC,Serial,Source,Notes\n'
+  for target in "${TARGETS[@]}"; do
+    ip="$(resolve_ip "$target")"; [[ -z "$ip" ]] && ip="$target"
+    ping="$(ping_status "$ip")"
+    mac=""; serial=""; source=(); notes=()
+    snmp_s="$(try_snmp_serial "$ip" || true)"; if [[ -n "$snmp_s" ]]; then serial="${snmp_s%%|*}"; source+=("${snmp_s#*|}"); fi
+    snmp_m="$(try_snmp_mac "$ip" || true)"; if [[ -n "$snmp_m" ]]; then mac="${snmp_m%%|*}"; source+=("${snmp_m#*|}"); fi
+    if [[ "$SNMP_ONLY" -eq 0 ]]; then
+      if [[ -z "$mac" || -z "$serial" ]]; then
+        http="$(try_http "$ip" || true)"; if [[ -n "$http" ]]; then IFS='|' read -r hmac hserial hsrc <<< "$http"; [[ -z "$mac" ]] && mac="$hmac"; [[ -z "$serial" ]] && serial="$hserial"; source+=("$hsrc"); fi
+      fi
+      if [[ -z "$mac" || -z "$serial" ]]; then
+        zpl="$(try_9100 "$ip" || true)"; if [[ -n "$zpl" ]]; then IFS='|' read -r zmac zserial zsrc <<< "$zpl"; [[ -z "$mac" ]] && mac="$zmac"; [[ -z "$serial" ]] && serial="$zserial"; source+=("$zsrc"); fi
+      fi
+      if [[ -z "$mac" ]]; then
+        arpval="$(try_arp "$ip" || true)"; if [[ -n "$arpval" ]]; then mac="${arpval%%|*}"; source+=("${arpval#*|}"); fi
+      fi
+    fi
+    [[ -z "$mac" ]] && notes+=("MAC unavailable")
+    [[ -z "$serial" ]] && notes+=("Serial unavailable")
+    [[ "$ping" != "Reachable" ]] && notes+=("Ping failed or ICMP blocked")
+    csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$ip"; printf ','; csv_escape "$ping"; printf ','; csv_escape "$mac"; printf ','; csv_escape "$serial"; printf ','; csv_escape "$(IFS=' | '; echo "${source[*]:-}")"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
+  done
+} > "$OUTPUT"
+log "Wrote printer probe CSV: $OUTPUT"
+[[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-smb-readonly-recon.sh
+++ b/bash/transport/sas-smb-readonly-recon.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SysAdminSuite SMB read-only recon adapter
+# Purpose: verify approved admin-share reachability and optionally list/read approved evidence paths.
+# No writes. No staging. No scheduled tasks. No deletion.
+
+set -euo pipefail
+
+TARGETS=()
+TARGET_FILE=""
+OUTPUT="bash/transport/output/smb_readonly_recon.csv"
+TIMEOUT=8
+SHARE="C$"
+APPROVED_PATHS="ProgramData/SysAdminSuite,ProgramData/SysAdminSuite/Mapping,ProgramData/SysAdminSuite/Mapping/logs"
+ALLOW_LIST=0
+ALLOW_READ=0
+SMB_USER=""
+SMB_PASS=""
+SMB_DOMAIN=""
+PASS_THRU=0
+
+usage(){ cat <<'USAGE'
+SysAdminSuite SMB Read-Only Recon
+
+Usage:
+  ./bash/transport/sas-smb-readonly-recon.sh [options] TARGET...
+
+Options:
+  --target VALUE        Add hostname/IP target
+  --targets-file PATH   TXT/CSV-ish file with targets, one per line or first comma field
+  --output PATH         Output CSV path
+  --timeout SEC         SMB command timeout. Default: 8
+  --share NAME          SMB share. Default: C$
+  --approved-paths CSV  Approved paths under the share to inspect
+  --allow-list          Permit directory listing of approved paths
+  --allow-read          Permit read-only fetch test of files under approved paths when explicitly listed later
+  --smb-user USER       Optional SMB username. Prefer SAS_SMB_USER
+  --smb-pass PASS       Optional SMB password. Prefer SAS_SMB_PASS
+  --smb-domain DOMAIN   Optional SMB domain. Prefer SAS_SMB_DOMAIN
+  --pass-thru           Print CSV after writing
+  -h, --help            Show help
+
+Environment variables:
+  SAS_SMB_USER
+  SAS_SMB_PASS
+  SAS_SMB_DOMAIN
+
+Output columns:
+  Timestamp,Target,Share,ApprovedPath,Reachable,ListStatus,ReadStatus,Evidence,ReconStatus,Notes
+
+Safety:
+  - Read-only.
+  - Does not create directories.
+  - Does not copy files to the target.
+  - Does not create scheduled tasks.
+  - Does not delete or modify remote files.
+  - Credentials are not written to output.
+
+Known limitations:
+  - Requires smbclient.
+  - Admin shares may be disabled or blocked by firewall/policy.
+  - Listing may be denied even when the host is online.
+  - Read checks are intentionally conservative in this first adapter.
+USAGE
+}
+
+fail(){ printf '[smb-recon] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[smb-recon] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
+csv_escape(){ local s="${1:-}"; s="${s//"/""}"; printf '"%s"' "$s"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGETS+=("${2:?missing value for --target}"); shift 2 ;;
+    --targets-file) TARGET_FILE="${2:?missing value for --targets-file}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
+    --share) SHARE="${2:?missing value for --share}"; shift 2 ;;
+    --approved-paths) APPROVED_PATHS="${2:?missing value for --approved-paths}"; shift 2 ;;
+    --allow-list) ALLOW_LIST=1; shift ;;
+    --allow-read) ALLOW_READ=1; shift ;;
+    --smb-user) SMB_USER="${2:?missing value for --smb-user}"; shift 2 ;;
+    --smb-pass) SMB_PASS="${2:?missing value for --smb-pass}"; shift 2 ;;
+    --smb-domain) SMB_DOMAIN="${2:?missing value for --smb-domain}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
+    -*) fail "Unknown option: $1" ;;
+    *) TARGETS+=("$1"); shift ;;
+  esac
+done
+
+SMB_USER="${SMB_USER:-${SAS_SMB_USER:-}}"
+SMB_PASS="${SMB_PASS:-${SAS_SMB_PASS:-}}"
+SMB_DOMAIN="${SMB_DOMAIN:-${SAS_SMB_DOMAIN:-}}"
+[[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
+if [[ -n "$TARGET_FILE" ]]; then
+  [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(trim "$line")"; [[ -z "$line" || "$line" == \#* ]] && continue
+    line="${line%%,*}"; line="$(trim "$line")"; [[ -n "$line" ]] && TARGETS+=("$line")
+  done < "$TARGET_FILE"
+fi
+[[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
+mkdir -p "$(dirname "$OUTPUT")"
+IFS=',' read -r -a PATH_ARRAY <<< "$APPROVED_PATHS"
+
+smb_auth_args(){
+  local args=()
+  if [[ -n "$SMB_USER" ]]; then
+    args+=(-U "${SMB_USER}%${SMB_PASS}")
+  else
+    args+=(-N)
+  fi
+  [[ -n "$SMB_DOMAIN" ]] && args+=(-W "$SMB_DOMAIN")
+  printf '%s\0' "${args[@]}"
+}
+
+run_smb(){
+  local target="$1" command="$2" args=() part
+  if ! has_cmd smbclient; then printf 'SMBCLIENT_MISSING'; return 127; fi
+  while IFS= read -r -d '' part; do args+=("$part"); done < <(smb_auth_args)
+  if has_cmd timeout; then
+    timeout "$TIMEOUT" smbclient "//$target/$SHARE" "${args[@]}" -c "$command" 2>&1 || true
+  else
+    smbclient "//$target/$SHARE" "${args[@]}" -c "$command" 2>&1 || true
+  fi
+}
+
+classify(){
+  local out="$1"
+  if [[ "$out" == "SMBCLIENT_MISSING" ]]; then printf 'ClientMissing'; return; fi
+  if printf '%s' "$out" | grep -Eiq 'NT_STATUS_ACCESS_DENIED|LOGON_FAILURE|Authentication'; then printf 'AccessDenied'; return; fi
+  if printf '%s' "$out" | grep -Eiq 'NT_STATUS_BAD_NETWORK_NAME|NT_STATUS_HOST_UNREACHABLE|Connection.*failed|timed out|NT_STATUS_IO_TIMEOUT'; then printf 'UnreachableOrBlocked'; return; fi
+  if printf '%s' "$out" | grep -Eiq 'NT_STATUS_OBJECT_NAME_NOT_FOUND|No such file|ERRDOS'; then printf 'PathMissing'; return; fi
+  if printf '%s' "$out" | grep -Eiq 'blocks of size|Disk|\s+D\s+|\s+A\s+'; then printf 'OK'; return; fi
+  printf 'Unknown'
+}
+
+{
+  printf 'Timestamp,Target,Share,ApprovedPath,Reachable,ListStatus,ReadStatus,Evidence,ReconStatus,Notes\n'
+  for target in "${TARGETS[@]}"; do
+    for raw_path in "${PATH_ARRAY[@]}"; do
+      path="$(trim "$raw_path")"; [[ -z "$path" ]] && continue
+      path="${path//\\//}"
+      path="${path#/}"
+      path="${path%/}"
+      reachable="NotChecked"; list_status="Skipped"; read_status="Skipped"; evidence=""; notes=()
+      if [[ "$ALLOW_LIST" -eq 1 ]]; then
+        cmd="cd \"$path\"; dir"
+      else
+        cmd="cd \"$path\"; pwd"
+      fi
+      out="$(run_smb "$target" "$cmd")"
+      status="$(classify "$out")"
+      case "$status" in
+        OK) reachable="Yes"; list_status=$([[ "$ALLOW_LIST" -eq 1 ]] && printf 'Listed' || printf 'PathReachable') ;;
+        ClientMissing) reachable="Unknown"; list_status="NotChecked"; notes+=("smbclient not installed") ;;
+        AccessDenied) reachable="Unknown"; list_status="AccessDenied"; notes+=("SMB/auth denied") ;;
+        UnreachableOrBlocked) reachable="No"; list_status="UnreachableOrBlocked"; notes+=("SMB blocked or host unreachable") ;;
+        PathMissing) reachable="Yes"; list_status="PathMissing"; notes+=("Approved path missing") ;;
+        *) reachable="Unknown"; list_status="Unknown"; notes+=("Unclassified smbclient response") ;;
+      esac
+      if [[ "$ALLOW_LIST" -eq 1 && "$status" == "OK" ]]; then
+        evidence="$(printf '%s' "$out" | sed -E 's/[[:cntrl:]]//g' | head -n 12 | paste -sd ' ' - | cut -c1-240)"
+      fi
+      if [[ "$ALLOW_READ" -eq 1 ]]; then
+        read_status="DeferredNoFileSpecified"
+        notes+=("Read mode requires a future explicit file allowlist; not implemented as broad read")
+      fi
+      recon="ReviewRequired"
+      [[ "$list_status" == "Listed" || "$list_status" == "PathReachable" ]] && recon="EvidencePathReachable"
+      [[ "$list_status" == "AccessDenied" ]] && recon="NeedsApprovedCredentialsOrPolicy"
+      [[ "$list_status" == "UnreachableOrBlocked" ]] && recon="SMBUnavailable"
+      [[ "$list_status" == "PathMissing" ]] && recon="EvidencePathMissing"
+      csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$SHARE"; printf ','; csv_escape "$path"; printf ','; csv_escape "$reachable"; printf ','; csv_escape "$list_status"; printf ','; csv_escape "$read_status"; printf ','; csv_escape "$evidence"; printf ','; csv_escape "$recon"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
+    done
+  done
+} > "$OUTPUT"
+log "Wrote SMB read-only recon CSV: $OUTPUT"
+[[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-wmi-identity.sh
+++ b/bash/transport/sas-wmi-identity.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# SysAdminSuite optional WMI identity adapter
+# Read-only Windows identity collection through an approved wmic-compatible client.
+# This is disabled unless called directly or wired via --allow-wmi from sas-workstation-identity.sh.
+
+set -euo pipefail
+
+TARGETS=()
+TARGET_FILE=""
+OUTPUT="bash/transport/output/wmi_identity.csv"
+TIMEOUT=8
+WMI_USER=""
+WMI_PASS=""
+WMI_DOMAIN=""
+PASS_THRU=0
+
+usage(){ cat <<'USAGE'
+SysAdminSuite WMI Identity Adapter
+
+Usage:
+  ./bash/transport/sas-wmi-identity.sh [options] TARGET...
+
+Options:
+  --target VALUE       Add hostname/IP target
+  --targets-file PATH  TXT/CSV-ish file with targets, one per line or first comma field
+  --output PATH        Output CSV path
+  --timeout SEC        Per-query timeout. Default: 8
+  --wmi-user USER      Optional WMI username. Prefer environment variable SAS_WMI_USER.
+  --wmi-pass PASS      Optional WMI password. Prefer environment variable SAS_WMI_PASS.
+  --wmi-domain DOMAIN  Optional domain. Prefer environment variable SAS_WMI_DOMAIN.
+  --pass-thru          Print CSV after writing
+  -h, --help           Show help
+
+Environment variables:
+  SAS_WMI_USER
+  SAS_WMI_PASS
+  SAS_WMI_DOMAIN
+
+Output columns:
+  Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes
+
+Safety:
+  - Read-only WMI queries only.
+  - No remote staging.
+  - No scheduled tasks.
+  - No registry edits.
+  - No credentials are written to output.
+
+Known limitations:
+  - Requires an approved `wmic`/Samba WMI client on the Bash host.
+  - Firewalls, DCOM/RPC policy, and permissions may block collection.
+  - This adapter is optional. Failure should produce NeedsPrivilegedSurvey, not silent confidence.
+USAGE
+}
+
+fail(){ printf '[wmi-identity] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[wmi-identity] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
+csv_escape(){ local s="${1:-}"; s="${s//"/""}"; printf '"%s"' "$s"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGETS+=("${2:?missing value for --target}"); shift 2 ;;
+    --targets-file) TARGET_FILE="${2:?missing value for --targets-file}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
+    --wmi-user) WMI_USER="${2:?missing value for --wmi-user}"; shift 2 ;;
+    --wmi-pass) WMI_PASS="${2:?missing value for --wmi-pass}"; shift 2 ;;
+    --wmi-domain) WMI_DOMAIN="${2:?missing value for --wmi-domain}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
+    -*) fail "Unknown option: $1" ;;
+    *) TARGETS+=("$1"); shift ;;
+  esac
+done
+
+WMI_USER="${WMI_USER:-${SAS_WMI_USER:-}}"
+WMI_PASS="${WMI_PASS:-${SAS_WMI_PASS:-}}"
+WMI_DOMAIN="${WMI_DOMAIN:-${SAS_WMI_DOMAIN:-}}"
+[[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
+if [[ -n "$TARGET_FILE" ]]; then
+  [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(trim "$line")"; [[ -z "$line" || "$line" == \#* ]] && continue
+    line="${line%%,*}"; line="$(trim "$line")"; [[ -n "$line" ]] && TARGETS+=("$line")
+  done < "$TARGET_FILE"
+fi
+[[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
+mkdir -p "$(dirname "$OUTPUT")"
+
+norm_mac(){
+  local raw="${1:-}" hx out i
+  hx="$(printf '%s' "$raw" | tr -cd '[:xdigit:]' | tr '[:lower:]' '[:upper:]')"
+  if [[ ${#hx} -eq 12 ]]; then
+    out=""; for ((i=0;i<12;i+=2)); do [[ -n "$out" ]] && out+=":"; out+="${hx:i:2}"; done; printf '%s' "$out"
+  else printf ''; fi
+}
+
+wmi_base_args(){
+  local target="$1" auth=""
+  if [[ -n "$WMI_USER" ]]; then
+    if [[ -n "$WMI_DOMAIN" ]]; then auth="${WMI_DOMAIN}\\${WMI_USER}%${WMI_PASS}"; else auth="${WMI_USER}%${WMI_PASS}"; fi
+    printf -- '-U
+%s
+//%s
+' "$auth" "$target"
+  else
+    printf -- '//%s
+' "$target"
+  fi
+}
+
+run_wmic_query(){
+  local target="$1" query="$2" args=() line
+  if ! has_cmd wmic; then printf 'WMIC_NOT_INSTALLED'; return; fi
+  while IFS= read -r line; do [[ -n "$line" ]] && args+=("$line"); done < <(wmi_base_args "$target")
+  if has_cmd timeout; then
+    timeout "$TIMEOUT" wmic "${args[@]}" "$query" 2>&1 || true
+  else
+    wmic "${args[@]}" "$query" 2>&1 || true
+  fi
+}
+
+extract_first_value(){
+  awk -F'|' 'NF>1 && NR>1 {for(i=2;i<=NF;i++){gsub(/^[ \t]+|[ \t]+$/, "", $i); if($i != ""){print $i; exit}}}'
+}
+
+extract_macs(){
+  grep -Eio '([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}' | while read -r m; do norm_mac "$m"; done | awk 'NF' | sort -u | paste -sd ';' -
+}
+
+{
+  printf 'Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes\n'
+  for target in "${TARGETS[@]}"; do
+    notes=(); status="NotChecked"; host=""; serial=""; macs=""
+    if ! has_cmd wmic; then
+      status="WmiClientMissing"; notes+=("wmic client not installed")
+    else
+      host_raw="$(run_wmic_query "$target" 'SELECT Name FROM Win32_ComputerSystem')"
+      serial_raw="$(run_wmic_query "$target" 'SELECT SerialNumber FROM Win32_BIOS')"
+      mac_raw="$(run_wmic_query "$target" 'SELECT MACAddress FROM Win32_NetworkAdapterConfiguration WHERE IPEnabled=True')"
+      if printf '%s%s%s' "$host_raw" "$serial_raw" "$mac_raw" | grep -Eiq 'NT_STATUS|ERROR|failed|denied|timed out|timeout'; then
+        status="WmiQueryFailed"; notes+=("WMI query failed or denied")
+      else
+        host="$(printf '%s
+' "$host_raw" | extract_first_value | head -n1)"
+        serial="$(printf '%s
+' "$serial_raw" | extract_first_value | head -n1)"
+        macs="$(printf '%s
+' "$mac_raw" | extract_macs)"
+        if [[ -n "$host" || -n "$serial" || -n "$macs" ]]; then status="WmiIdentityCollected"; else status="WmiNoIdentityReturned"; fi
+      fi
+    fi
+    csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$host"; printf ','; csv_escape "$serial"; printf ','; csv_escape "$macs"; printf ','; csv_escape "$status"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
+  done
+} > "$OUTPUT"
+log "Wrote WMI identity CSV: $OUTPUT"
+[[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-workstation-identity.sh
+++ b/bash/transport/sas-workstation-identity.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SysAdminSuite Bash workstation/Cybernet identity adapter
 # Read-only identity collection with ordered transports.
-# Current transports: DNS, ping, ARP, optional SSH. Future: WMI/RPC, SMB, WinRM, vendor/API.
+# Current transports: DNS, ping, ARP, optional SSH, optional WMI adapter.
 
 set -euo pipefail
 
@@ -10,8 +10,13 @@ TARGET_FILE=""
 OUTPUT="bash/transport/output/workstation_identity.csv"
 TIMEOUT=5
 ALLOW_SSH=0
+ALLOW_WMI=0
 SSH_USER=""
 SSH_KEY=""
+WMI_USER=""
+WMI_PASS=""
+WMI_DOMAIN=""
+WMI_ADAPTER=""
 PASS_THRU=0
 
 usage(){ cat <<'USAGE'
@@ -28,6 +33,11 @@ Options:
   --allow-ssh          Enable SSH read-only identity commands
   --ssh-user USER      SSH username, required when --allow-ssh is used
   --ssh-key PATH       Optional SSH private key
+  --allow-wmi          Enable optional read-only WMI identity adapter
+  --wmi-user USER      Optional WMI username. Prefer SAS_WMI_USER
+  --wmi-pass PASS      Optional WMI password. Prefer SAS_WMI_PASS
+  --wmi-domain DOMAIN  Optional WMI domain. Prefer SAS_WMI_DOMAIN
+  --wmi-adapter PATH   Optional WMI adapter path. Defaults to bash/transport/sas-wmi-identity.sh
   --pass-thru          Print CSV after writing
   -h, --help           Show help
 
@@ -36,11 +46,12 @@ Output columns:
 
 Safety:
   - Read-only.
-  - SSH is disabled unless explicitly enabled.
+  - SSH and WMI are disabled unless explicitly enabled.
   - No remote staging, no scheduled tasks, no registry edits, no printer mapping.
+  - Credentials are not written to output.
 
 Known limitation:
-  Bash alone cannot natively perform Windows WMI/DCOM. This adapter is structured so an approved WMI/RPC/SMB bridge can be added later without changing downstream audit tools.
+  Bash cannot natively perform Windows WMI/DCOM without an approved WMI client. Use --allow-wmi only where that client and policy are approved.
 USAGE
 }
 
@@ -49,6 +60,9 @@ log(){ printf '[workstation-identity] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
 csv_escape(){ local s="${1:-}"; s="${s//"/""}"; printf '"%s"' "$s"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_WMI_ADAPTER="$SCRIPT_DIR/sas-wmi-identity.sh"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -59,6 +73,11 @@ while [[ $# -gt 0 ]]; do
     --allow-ssh) ALLOW_SSH=1; shift ;;
     --ssh-user) SSH_USER="${2:?missing value for --ssh-user}"; shift 2 ;;
     --ssh-key) SSH_KEY="${2:?missing value for --ssh-key}"; shift 2 ;;
+    --allow-wmi) ALLOW_WMI=1; shift ;;
+    --wmi-user) WMI_USER="${2:?missing value for --wmi-user}"; shift 2 ;;
+    --wmi-pass) WMI_PASS="${2:?missing value for --wmi-pass}"; shift 2 ;;
+    --wmi-domain) WMI_DOMAIN="${2:?missing value for --wmi-domain}"; shift 2 ;;
+    --wmi-adapter) WMI_ADAPTER="${2:?missing value for --wmi-adapter}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
@@ -69,6 +88,10 @@ done
 
 [[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
 if [[ "$ALLOW_SSH" -eq 1 && -z "$SSH_USER" ]]; then fail "--ssh-user is required with --allow-ssh"; fi
+if [[ "$ALLOW_WMI" -eq 1 ]]; then
+  [[ -z "$WMI_ADAPTER" ]] && WMI_ADAPTER="$DEFAULT_WMI_ADAPTER"
+  [[ -f "$WMI_ADAPTER" ]] || fail "WMI adapter not found: $WMI_ADAPTER"
+fi
 if [[ -n "$TARGET_FILE" ]]; then
   [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -78,6 +101,12 @@ if [[ -n "$TARGET_FILE" ]]; then
 fi
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
 mkdir -p "$(dirname "$OUTPUT")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+TARGETS_TMP="$TMP_DIR/targets.txt"
+WMI_OUT="$TMP_DIR/wmi_identity.csv"
+printf '%s
+' "${TARGETS[@]}" > "$TARGETS_TMP"
 
 norm_mac(){
   local raw="${1:-}" hx out i
@@ -107,6 +136,33 @@ ssh_identity(){
   host="$(trim "${lines[0]:-}")"; serial="$(trim "${lines[1]:-}")"; macs="$(trim "${lines[2]:-}")"
   printf '%s|%s|%s|SSH' "$host" "$serial" "$macs"
 }
+
+if [[ "$ALLOW_WMI" -eq 1 ]]; then
+  wmi_args=("$WMI_ADAPTER" --targets-file "$TARGETS_TMP" --output "$WMI_OUT" --timeout "$TIMEOUT")
+  [[ -n "$WMI_USER" ]] && wmi_args+=(--wmi-user "$WMI_USER")
+  [[ -n "$WMI_PASS" ]] && wmi_args+=(--wmi-pass "$WMI_PASS")
+  [[ -n "$WMI_DOMAIN" ]] && wmi_args+=(--wmi-domain "$WMI_DOMAIN")
+  bash "${wmi_args[@]}" >/dev/null || true
+else
+  printf 'Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes\n' > "$WMI_OUT"
+fi
+
+python_join_wmi(){
+  python3 - "$WMI_OUT" <<'PY'
+import csv, json, sys
+path=sys.argv[1]
+out={}
+try:
+    with open(path, newline='', encoding='utf-8-sig') as f:
+        for row in csv.DictReader(f):
+            out[(row.get('Target') or '').upper()] = row
+except FileNotFoundError:
+    pass
+print(json.dumps(out))
+PY
+}
+WMI_JSON="$(python_join_wmi)"
+
 identity_status(){
   local ping="$1" host="$2" serial="$3" macs="$4"
   if [[ -n "$host" || -n "$serial" || -n "$macs" ]]; then printf 'IdentityCollected'; return; fi
@@ -114,12 +170,29 @@ identity_status(){
   printf 'UnreachableOrBlocked'
 }
 
+lookup_wmi_field(){
+  local target="$1" field="$2"
+  python3 - "$WMI_JSON" "$target" "$field" <<'PY'
+import json, sys
+data=json.loads(sys.argv[1]); target=sys.argv[2].upper(); field=sys.argv[3]
+print((data.get(target, {}) or {}).get(field, ''))
+PY
+}
+
 {
   printf 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes\n'
   for target in "${TARGETS[@]}"; do
     ip="$(resolve_ip "$target")"; dns="$(resolve_name "${ip:-$target}")"; ping="$(ping_status "${ip:-$target}")"
     observed_host=""; observed_serial=""; observed_macs=""; transport=""; notes=()
-    if [[ "$ALLOW_SSH" -eq 1 ]]; then
+    if [[ "$ALLOW_WMI" -eq 1 ]]; then
+      whost="$(lookup_wmi_field "$target" ObservedHostName)"; wserial="$(lookup_wmi_field "$target" ObservedSerial)"; wmacs="$(lookup_wmi_field "$target" ObservedMACs)"; wstatus="$(lookup_wmi_field "$target" WmiStatus)"; wnotes="$(lookup_wmi_field "$target" Notes)"
+      if [[ "$wstatus" == "WmiIdentityCollected" ]]; then
+        observed_host="$whost"; observed_serial="$wserial"; observed_macs="$wmacs"; transport="WMI"
+      elif [[ -n "$wstatus" ]]; then
+        notes+=("$wstatus${wnotes:+: $wnotes}")
+      fi
+    fi
+    if [[ -z "$observed_host$observed_serial$observed_macs" && "$ALLOW_SSH" -eq 1 ]]; then
       ssh_out="$(ssh_identity "${ip:-$target}")"
       IFS='|' read -r observed_host observed_serial observed_macs transport <<< "$ssh_out"
       [[ "$transport" == SSHFailed:* || "$transport" == SSHNotInstalled || "$transport" == SSHDisabled ]] && notes+=("$transport") && transport=""

--- a/bash/transport/sas-workstation-identity.sh
+++ b/bash/transport/sas-workstation-identity.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SysAdminSuite Bash workstation/Cybernet identity adapter
+# Read-only identity collection with ordered transports.
+# Current transports: DNS, ping, ARP, optional SSH. Future: WMI/RPC, SMB, WinRM, vendor/API.
+
+set -euo pipefail
+
+TARGETS=()
+TARGET_FILE=""
+OUTPUT="bash/transport/output/workstation_identity.csv"
+TIMEOUT=5
+ALLOW_SSH=0
+SSH_USER=""
+SSH_KEY=""
+PASS_THRU=0
+
+usage(){ cat <<'USAGE'
+SysAdminSuite Workstation Identity Adapter
+
+Usage:
+  ./bash/transport/sas-workstation-identity.sh [options] TARGET...
+
+Options:
+  --target VALUE       Add hostname/IP target
+  --targets-file PATH  TXT/CSV-ish file with targets, one per line or first comma field
+  --output PATH        Output CSV path
+  --timeout SEC        Per-target timeout. Default: 5
+  --allow-ssh          Enable SSH read-only identity commands
+  --ssh-user USER      SSH username, required when --allow-ssh is used
+  --ssh-key PATH       Optional SSH private key
+  --pass-thru          Print CSV after writing
+  -h, --help           Show help
+
+Output columns:
+  Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes
+
+Safety:
+  - Read-only.
+  - SSH is disabled unless explicitly enabled.
+  - No remote staging, no scheduled tasks, no registry edits, no printer mapping.
+
+Known limitation:
+  Bash alone cannot natively perform Windows WMI/DCOM. This adapter is structured so an approved WMI/RPC/SMB bridge can be added later without changing downstream audit tools.
+USAGE
+}
+
+fail(){ printf '[workstation-identity] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[workstation-identity] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
+csv_escape(){ local s="${1:-}"; s="${s//"/""}"; printf '"%s"' "$s"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) TARGETS+=("${2:?missing value for --target}"); shift 2 ;;
+    --targets-file) TARGET_FILE="${2:?missing value for --targets-file}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
+    --allow-ssh) ALLOW_SSH=1; shift ;;
+    --ssh-user) SSH_USER="${2:?missing value for --ssh-user}"; shift 2 ;;
+    --ssh-key) SSH_KEY="${2:?missing value for --ssh-key}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
+    -*) fail "Unknown option: $1" ;;
+    *) TARGETS+=("$1"); shift ;;
+  esac
+done
+
+[[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
+if [[ "$ALLOW_SSH" -eq 1 && -z "$SSH_USER" ]]; then fail "--ssh-user is required with --allow-ssh"; fi
+if [[ -n "$TARGET_FILE" ]]; then
+  [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(trim "$line")"; [[ -z "$line" || "$line" == \#* ]] && continue
+    line="${line%%,*}"; line="$(trim "$line")"; [[ -n "$line" ]] && TARGETS+=("$line")
+  done < "$TARGET_FILE"
+fi
+[[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
+mkdir -p "$(dirname "$OUTPUT")"
+
+norm_mac(){
+  local raw="${1:-}" hx out i
+  hx="$(printf '%s' "$raw" | tr -cd '[:xdigit:]' | tr '[:lower:]' '[:upper:]')"
+  if [[ ${#hx} -eq 12 ]]; then
+    out=""; for ((i=0;i<12;i+=2)); do [[ -n "$out" ]] && out+=":"; out+="${hx:i:2}"; done; printf '%s' "$out"
+  else printf '%s' "$(trim "$raw")"; fi
+}
+resolve_ip(){ if has_cmd getent; then getent ahostsv4 "$1" 2>/dev/null | awk 'NR==1{print $1; exit}'; else printf ''; fi; }
+resolve_name(){ if has_cmd getent; then getent hosts "$1" 2>/dev/null | awk 'NR==1{print $2; exit}'; else printf ''; fi; }
+ping_status(){ if ping -c 1 -W "$TIMEOUT" "$1" >/dev/null 2>&1; then printf 'Reachable'; else printf 'NoPing'; fi; }
+arp_mac(){ local out mac; out="$(arp -a "$1" 2>/dev/null || true)"; mac="$(printf '%s' "$out" | grep -Eio '([0-9a-f]{2}[:-]){5}[0-9a-f]{2}' | head -n1 || true)"; norm_mac "$mac"; }
+ssh_identity(){
+  local target="$1" dest cmd result lines host serial macs note
+  [[ "$ALLOW_SSH" -eq 1 ]] || { printf '|||SSHDisabled'; return; }
+  has_cmd ssh || { printf '|||SSHNotInstalled'; return; }
+  dest="${SSH_USER}@${target}"
+  cmd=(ssh -o BatchMode=yes -o ConnectTimeout="$TIMEOUT")
+  [[ -n "$SSH_KEY" ]] && cmd+=(-i "$SSH_KEY")
+  cmd+=("$dest" "hostname; (cat /sys/class/dmi/id/product_serial 2>/dev/null || dmidecode -s system-serial-number 2>/dev/null || wmic bios get serialnumber 2>/dev/null | awk 'NR==2{print}' || true); (ip link 2>/dev/null | awk '/link\/ether/ {print \$2}' | paste -sd ';' - || getmac 2>/dev/null | awk '/[0-9A-Fa-f][:-]/{print \$1}' | paste -sd ';' - || true)")
+  if ! result="$("${cmd[@]}" 2>&1)"; then
+    note="SSHFailed:$(printf '%s' "$result" | head -c 120)"
+    printf '|||%s' "$note"
+    return
+  fi
+  mapfile -t lines <<< "$result"
+  host="$(trim "${lines[0]:-}")"; serial="$(trim "${lines[1]:-}")"; macs="$(trim "${lines[2]:-}")"
+  printf '%s|%s|%s|SSH' "$host" "$serial" "$macs"
+}
+identity_status(){
+  local ping="$1" host="$2" serial="$3" macs="$4"
+  if [[ -n "$host" || -n "$serial" || -n "$macs" ]]; then printf 'IdentityCollected'; return; fi
+  if [[ "$ping" == "Reachable" ]]; then printf 'ReachableNeedsApprovedIdentityTransport'; return; fi
+  printf 'UnreachableOrBlocked'
+}
+
+{
+  printf 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes\n'
+  for target in "${TARGETS[@]}"; do
+    ip="$(resolve_ip "$target")"; dns="$(resolve_name "${ip:-$target}")"; ping="$(ping_status "${ip:-$target}")"
+    observed_host=""; observed_serial=""; observed_macs=""; transport=""; notes=()
+    if [[ "$ALLOW_SSH" -eq 1 ]]; then
+      ssh_out="$(ssh_identity "${ip:-$target}")"
+      IFS='|' read -r observed_host observed_serial observed_macs transport <<< "$ssh_out"
+      [[ "$transport" == SSHFailed:* || "$transport" == SSHNotInstalled || "$transport" == SSHDisabled ]] && notes+=("$transport") && transport=""
+    fi
+    if [[ -z "$observed_macs" ]]; then
+      amac="$(arp_mac "${ip:-$target}")"; [[ -n "$amac" ]] && observed_macs="$amac" && transport="${transport:+$transport+}ARP"
+    fi
+    [[ -z "$ip" ]] && notes+=("DNS unresolved")
+    [[ "$ping" != "Reachable" ]] && notes+=("ICMP failed or blocked")
+    status="$(identity_status "$ping" "$observed_host" "$observed_serial" "$observed_macs")"
+    csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$ip"; printf ','; csv_escape "$ping"; printf ','; csv_escape "$dns"; printf ','; csv_escape "$observed_host"; printf ','; csv_escape "$observed_serial"; printf ','; csv_escape "$observed_macs"; printf ','; csv_escape "$transport"; printf ','; csv_escape "$status"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
+  done
+} > "$OUTPUT"
+log "Wrote workstation identity CSV: $OUTPUT"
+[[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/tests/test_transport_contracts.sh
+++ b/bash/transport/tests/test_transport_contracts.sh
@@ -8,6 +8,7 @@ PREFLIGHT="$ROOT_DIR/bash/transport/sas-network-preflight.sh"
 PRINTER="$ROOT_DIR/bash/transport/sas-printer-probe.sh"
 IDENTITY="$ROOT_DIR/bash/transport/sas-workstation-identity.sh"
 WMI="$ROOT_DIR/bash/transport/sas-wmi-identity.sh"
+SMB="$ROOT_DIR/bash/transport/sas-smb-readonly-recon.sh"
 
 fail(){ printf '[transport-tests] FAIL: %s\n' "$*" >&2; exit 1; }
 pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
@@ -16,11 +17,13 @@ pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
 [[ -f "$PRINTER" ]] || fail "Missing printer probe tool"
 [[ -f "$IDENTITY" ]] || fail "Missing workstation identity adapter"
 [[ -f "$WMI" ]] || fail "Missing WMI identity adapter"
+[[ -f "$SMB" ]] || fail "Missing SMB read-only recon adapter"
 
 bash -n "$PREFLIGHT" || fail "Network preflight has Bash syntax errors"
 bash -n "$PRINTER" || fail "Printer probe has Bash syntax errors"
 bash -n "$IDENTITY" || fail "Identity adapter has Bash syntax errors"
 bash -n "$WMI" || fail "WMI adapter has Bash syntax errors"
+bash -n "$SMB" || fail "SMB adapter has Bash syntax errors"
 
 PREFLIGHT_HELP="$($PREFLIGHT --help)"
 [[ "$PREFLIGHT_HELP" == *"Read-only"* || "$PREFLIGHT_HELP" == *"read-only"* ]] || fail "Preflight help must document read-only posture"
@@ -46,12 +49,20 @@ WMI_HELP="$($WMI --help)"
 [[ "$WMI_HELP" == *"No credentials are written"* ]] || fail "WMI help must document credential output safety"
 [[ "$WMI_HELP" == *"WmiStatus"* ]] || fail "WMI help must document WmiStatus output"
 
+SMB_HELP="$($SMB --help)"
+[[ "$SMB_HELP" == *"Read-only"* || "$SMB_HELP" == *"read-only"* ]] || fail "SMB help must document read-only posture"
+[[ "$SMB_HELP" == *"Does not create scheduled tasks"* ]] || fail "SMB help must forbid scheduled tasks"
+[[ "$SMB_HELP" == *"Does not copy files to the target"* ]] || fail "SMB help must forbid remote writes"
+[[ "$SMB_HELP" == *"SAS_SMB_USER"* ]] || fail "SMB help must document env credential path"
+[[ "$SMB_HELP" == *"ReconStatus"* ]] || fail "SMB help must document ReconStatus output"
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 PREFLIGHT_OUT="$TMP_DIR/network_preflight.csv"
 PRINTER_OUT="$TMP_DIR/printer_probe.csv"
 IDENTITY_OUT="$TMP_DIR/workstation_identity.csv"
 WMI_OUT="$TMP_DIR/wmi_identity.csv"
+SMB_OUT="$TMP_DIR/smb_readonly_recon.csv"
 
 bash "$PREFLIGHT" --target 127.0.0.1 --ports 80 --timeout 1 --output "$PREFLIGHT_OUT" >/dev/null
 [[ -f "$PREFLIGHT_OUT" ]] || fail "Preflight did not create CSV"
@@ -74,6 +85,12 @@ bash "$WMI" --target 127.0.0.1 --timeout 1 --output "$WMI_OUT" >/dev/null
 grep -q 'Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes' "$WMI_OUT" || fail "WMI CSV header changed"
 grep -q '127.0.0.1' "$WMI_OUT" || fail "WMI CSV missing target"
 grep -Eq 'WmiClientMissing|WmiQueryFailed|WmiIdentityCollected|WmiNoIdentityReturned' "$WMI_OUT" || fail "WMI CSV missing WmiStatus verdict"
+
+bash "$SMB" --target 127.0.0.1 --timeout 1 --output "$SMB_OUT" >/dev/null
+[[ -f "$SMB_OUT" ]] || fail "SMB adapter did not create CSV"
+grep -q 'Timestamp,Target,Share,ApprovedPath,Reachable,ListStatus,ReadStatus,Evidence,ReconStatus,Notes' "$SMB_OUT" || fail "SMB CSV header changed"
+grep -q '127.0.0.1' "$SMB_OUT" || fail "SMB CSV missing target"
+grep -Eq 'EvidencePathReachable|NeedsApprovedCredentialsOrPolicy|SMBUnavailable|EvidencePathMissing|ReviewRequired' "$SMB_OUT" || fail "SMB CSV missing ReconStatus verdict"
 
 pass "Bash syntax checks passed"
 pass "Help contracts passed"

--- a/bash/transport/tests/test_transport_contracts.sh
+++ b/bash/transport/tests/test_transport_contracts.sh
@@ -7,6 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 PREFLIGHT="$ROOT_DIR/bash/transport/sas-network-preflight.sh"
 PRINTER="$ROOT_DIR/bash/transport/sas-printer-probe.sh"
 IDENTITY="$ROOT_DIR/bash/transport/sas-workstation-identity.sh"
+WMI="$ROOT_DIR/bash/transport/sas-wmi-identity.sh"
 
 fail(){ printf '[transport-tests] FAIL: %s\n' "$*" >&2; exit 1; }
 pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
@@ -14,10 +15,12 @@ pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
 [[ -f "$PREFLIGHT" ]] || fail "Missing network preflight tool"
 [[ -f "$PRINTER" ]] || fail "Missing printer probe tool"
 [[ -f "$IDENTITY" ]] || fail "Missing workstation identity adapter"
+[[ -f "$WMI" ]] || fail "Missing WMI identity adapter"
 
 bash -n "$PREFLIGHT" || fail "Network preflight has Bash syntax errors"
 bash -n "$PRINTER" || fail "Printer probe has Bash syntax errors"
 bash -n "$IDENTITY" || fail "Identity adapter has Bash syntax errors"
+bash -n "$WMI" || fail "WMI adapter has Bash syntax errors"
 
 PREFLIGHT_HELP="$($PREFLIGHT --help)"
 [[ "$PREFLIGHT_HELP" == *"Read-only"* || "$PREFLIGHT_HELP" == *"read-only"* ]] || fail "Preflight help must document read-only posture"
@@ -33,13 +36,22 @@ IDENTITY_HELP="$($IDENTITY --help)"
 [[ "$IDENTITY_HELP" == *"Read-only"* || "$IDENTITY_HELP" == *"read-only"* ]] || fail "Identity help must document read-only posture"
 [[ "$IDENTITY_HELP" == *"WMI/DCOM"* ]] || fail "Identity help must document WMI/DCOM limitation"
 [[ "$IDENTITY_HELP" == *"--allow-ssh"* ]] || fail "Identity help must require explicit SSH enablement"
+[[ "$IDENTITY_HELP" == *"--allow-wmi"* ]] || fail "Identity help must require explicit WMI enablement"
+[[ "$IDENTITY_HELP" == *"Credentials are not written"* ]] || fail "Identity help must document credential output safety"
 [[ "$IDENTITY_HELP" == *"IdentityStatus"* ]] || fail "Identity help must document IdentityStatus output"
+
+WMI_HELP="$($WMI --help)"
+[[ "$WMI_HELP" == *"Read-only"* || "$WMI_HELP" == *"read-only"* ]] || fail "WMI help must document read-only posture"
+[[ "$WMI_HELP" == *"SAS_WMI_USER"* ]] || fail "WMI help must document env credential path"
+[[ "$WMI_HELP" == *"No credentials are written"* ]] || fail "WMI help must document credential output safety"
+[[ "$WMI_HELP" == *"WmiStatus"* ]] || fail "WMI help must document WmiStatus output"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 PREFLIGHT_OUT="$TMP_DIR/network_preflight.csv"
 PRINTER_OUT="$TMP_DIR/printer_probe.csv"
 IDENTITY_OUT="$TMP_DIR/workstation_identity.csv"
+WMI_OUT="$TMP_DIR/wmi_identity.csv"
 
 bash "$PREFLIGHT" --target 127.0.0.1 --ports 80 --timeout 1 --output "$PREFLIGHT_OUT" >/dev/null
 [[ -f "$PREFLIGHT_OUT" ]] || fail "Preflight did not create CSV"
@@ -56,6 +68,12 @@ bash "$IDENTITY" --target 127.0.0.1 --timeout 1 --output "$IDENTITY_OUT" >/dev/n
 grep -q 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes' "$IDENTITY_OUT" || fail "Identity CSV header changed"
 grep -q '127.0.0.1' "$IDENTITY_OUT" || fail "Identity CSV missing target"
 grep -Eq 'IdentityCollected|ReachableNeedsApprovedIdentityTransport|UnreachableOrBlocked' "$IDENTITY_OUT" || fail "Identity CSV missing status verdict"
+
+bash "$WMI" --target 127.0.0.1 --timeout 1 --output "$WMI_OUT" >/dev/null
+[[ -f "$WMI_OUT" ]] || fail "WMI adapter did not create CSV"
+grep -q 'Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes' "$WMI_OUT" || fail "WMI CSV header changed"
+grep -q '127.0.0.1' "$WMI_OUT" || fail "WMI CSV missing target"
+grep -Eq 'WmiClientMissing|WmiQueryFailed|WmiIdentityCollected|WmiNoIdentityReturned' "$WMI_OUT" || fail "WMI CSV missing WmiStatus verdict"
 
 pass "Bash syntax checks passed"
 pass "Help contracts passed"

--- a/bash/transport/tests/test_transport_contracts.sh
+++ b/bash/transport/tests/test_transport_contracts.sh
@@ -6,15 +6,18 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 PREFLIGHT="$ROOT_DIR/bash/transport/sas-network-preflight.sh"
 PRINTER="$ROOT_DIR/bash/transport/sas-printer-probe.sh"
+IDENTITY="$ROOT_DIR/bash/transport/sas-workstation-identity.sh"
 
 fail(){ printf '[transport-tests] FAIL: %s\n' "$*" >&2; exit 1; }
 pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
 
 [[ -f "$PREFLIGHT" ]] || fail "Missing network preflight tool"
 [[ -f "$PRINTER" ]] || fail "Missing printer probe tool"
+[[ -f "$IDENTITY" ]] || fail "Missing workstation identity adapter"
 
 bash -n "$PREFLIGHT" || fail "Network preflight has Bash syntax errors"
 bash -n "$PRINTER" || fail "Printer probe has Bash syntax errors"
+bash -n "$IDENTITY" || fail "Identity adapter has Bash syntax errors"
 
 PREFLIGHT_HELP="$($PREFLIGHT --help)"
 [[ "$PREFLIGHT_HELP" == *"Read-only"* || "$PREFLIGHT_HELP" == *"read-only"* ]] || fail "Preflight help must document read-only posture"
@@ -26,10 +29,17 @@ PRINTER_HELP="$($PRINTER --help)"
 [[ "$PRINTER_HELP" == *"--skip-9100"* ]] || fail "Printer help must document 9100 risk control"
 [[ "$PRINTER_HELP" == *"ARP"* ]] || fail "Printer help must document ARP fallback"
 
+IDENTITY_HELP="$($IDENTITY --help)"
+[[ "$IDENTITY_HELP" == *"Read-only"* || "$IDENTITY_HELP" == *"read-only"* ]] || fail "Identity help must document read-only posture"
+[[ "$IDENTITY_HELP" == *"WMI/DCOM"* ]] || fail "Identity help must document WMI/DCOM limitation"
+[[ "$IDENTITY_HELP" == *"--allow-ssh"* ]] || fail "Identity help must require explicit SSH enablement"
+[[ "$IDENTITY_HELP" == *"IdentityStatus"* ]] || fail "Identity help must document IdentityStatus output"
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 PREFLIGHT_OUT="$TMP_DIR/network_preflight.csv"
 PRINTER_OUT="$TMP_DIR/printer_probe.csv"
+IDENTITY_OUT="$TMP_DIR/workstation_identity.csv"
 
 bash "$PREFLIGHT" --target 127.0.0.1 --ports 80 --timeout 1 --output "$PREFLIGHT_OUT" >/dev/null
 [[ -f "$PREFLIGHT_OUT" ]] || fail "Preflight did not create CSV"
@@ -40,6 +50,12 @@ bash "$PRINTER" --target 127.0.0.1 --snmp-only --timeout 1 --output "$PRINTER_OU
 [[ -f "$PRINTER_OUT" ]] || fail "Printer probe did not create CSV"
 grep -q 'Timestamp,Target,ResolvedAddress,PingStatus,MAC,Serial,Source,Notes' "$PRINTER_OUT" || fail "Printer CSV header changed"
 grep -q '127.0.0.1' "$PRINTER_OUT" || fail "Printer CSV missing target"
+
+bash "$IDENTITY" --target 127.0.0.1 --timeout 1 --output "$IDENTITY_OUT" >/dev/null
+[[ -f "$IDENTITY_OUT" ]] || fail "Identity adapter did not create CSV"
+grep -q 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes' "$IDENTITY_OUT" || fail "Identity CSV header changed"
+grep -q '127.0.0.1' "$IDENTITY_OUT" || fail "Identity CSV missing target"
+grep -Eq 'IdentityCollected|ReachableNeedsApprovedIdentityTransport|UnreachableOrBlocked' "$IDENTITY_OUT" || fail "Identity CSV missing status verdict"
 
 pass "Bash syntax checks passed"
 pass "Help contracts passed"

--- a/bash/transport/tests/test_transport_contracts.sh
+++ b/bash/transport/tests/test_transport_contracts.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Contract tests for Bash transport tools.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PREFLIGHT="$ROOT_DIR/bash/transport/sas-network-preflight.sh"
+PRINTER="$ROOT_DIR/bash/transport/sas-printer-probe.sh"
+
+fail(){ printf '[transport-tests] FAIL: %s\n' "$*" >&2; exit 1; }
+pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
+
+[[ -f "$PREFLIGHT" ]] || fail "Missing network preflight tool"
+[[ -f "$PRINTER" ]] || fail "Missing printer probe tool"
+
+bash -n "$PREFLIGHT" || fail "Network preflight has Bash syntax errors"
+bash -n "$PRINTER" || fail "Printer probe has Bash syntax errors"
+
+PREFLIGHT_HELP="$($PREFLIGHT --help)"
+[[ "$PREFLIGHT_HELP" == *"Read-only"* || "$PREFLIGHT_HELP" == *"read-only"* ]] || fail "Preflight help must document read-only posture"
+[[ "$PREFLIGHT_HELP" == *"--ports"* ]] || fail "Preflight help must document TCP port checks"
+[[ "$PREFLIGHT_HELP" == *"--targets-file"* ]] || fail "Preflight help must document target file input"
+
+PRINTER_HELP="$($PRINTER --help)"
+[[ "$PRINTER_HELP" == *"SNMP"* ]] || fail "Printer help must document SNMP"
+[[ "$PRINTER_HELP" == *"--skip-9100"* ]] || fail "Printer help must document 9100 risk control"
+[[ "$PRINTER_HELP" == *"ARP"* ]] || fail "Printer help must document ARP fallback"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+PREFLIGHT_OUT="$TMP_DIR/network_preflight.csv"
+PRINTER_OUT="$TMP_DIR/printer_probe.csv"
+
+bash "$PREFLIGHT" --target 127.0.0.1 --ports 80 --timeout 1 --output "$PREFLIGHT_OUT" >/dev/null
+[[ -f "$PREFLIGHT_OUT" ]] || fail "Preflight did not create CSV"
+grep -q 'Timestamp,Target,ResolvedAddress,PingStatus,Port,PortStatus' "$PREFLIGHT_OUT" || fail "Preflight CSV header changed"
+grep -q '127.0.0.1' "$PREFLIGHT_OUT" || fail "Preflight CSV missing target"
+
+bash "$PRINTER" --target 127.0.0.1 --snmp-only --timeout 1 --output "$PRINTER_OUT" >/dev/null
+[[ -f "$PRINTER_OUT" ]] || fail "Printer probe did not create CSV"
+grep -q 'Timestamp,Target,ResolvedAddress,PingStatus,MAC,Serial,Source,Notes' "$PRINTER_OUT" || fail "Printer CSV header changed"
+grep -q '127.0.0.1' "$PRINTER_OUT" || fail "Printer CSV missing target"
+
+pass "Bash syntax checks passed"
+pass "Help contracts passed"
+pass "Fixture CSV contracts passed"

--- a/deployment-audit/README.md
+++ b/deployment-audit/README.md
@@ -1,0 +1,107 @@
+# Deployment Audit
+
+Bash-first tooling for auditing the `Deployments` tab in the deployment tracker.
+
+This audit does **not** trust Excel conditional formatting. It reads workbook cell values directly and builds reports from the data itself.
+
+## Core Duplicate Rule
+
+A duplicate is only real when:
+
+1. Both/all matching records have `Deployed = Yes`.
+2. The same unique identifier appears on more than one deployed row.
+3. The rows represent different deployment locations unless same-location warnings are explicitly requested.
+
+Repeated identifiers on non-deployed, spare, staged, historical, placeholder, or incomplete rows are not automatically real duplicates.
+
+## Primary Tool
+
+```bash
+./deployment-audit/sas-audit-deployments.sh \
+  --workbook data/raw/DeploymentTracker_2026-04-20_SOURCE.xlsx \
+  --sheet Deployments \
+  --output-dir data/outputs/deployment_audit_2026-05-02
+```
+
+## Outputs
+
+| Output | Purpose |
+|---|---|
+| `deployed_records_normalized.csv` | Normalized deployed rows only |
+| `real_duplicate_values_deployed_yes.csv` | Identifier values repeated across deployed records |
+| `real_duplicate_pairs_deployed_yes.csv` | Row-pair view of real duplicate conflicts |
+| `real_duplicate_clusters.csv` | Connected duplicate row groups |
+| `survey_requests_duplicate_resolution.csv` | Rows that need remote Cybernet survey before any physical revisit |
+| `ref_errors.csv` | `#REF!` failures found in the deployment tab |
+| `audit_summary.txt` | Human-readable summary |
+
+## Remote Survey Bridge
+
+Use this when duplicate conflicts require more Cybernet evidence before approving a site revisit.
+
+```bash
+./deployment-audit/sas-build-survey-manifest.sh \
+  --requests data/outputs/deployment_audit_2026-05-02/survey_requests_duplicate_resolution.csv \
+  --output data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv
+```
+
+Then feed the manifest into the survey side of SysAdminSuite.
+
+```bash
+./survey/sas-survey-targets.sh \
+  --device-type Cybernet \
+  --csv data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv \
+  --output data/outputs/deployment_audit_2026-05-02/normalized_remote_survey_targets.csv
+```
+
+## Risks Addressed
+
+| Risk | Mitigation |
+|---|---|
+| Conditional formatting rule drift | Audit reads workbook values directly instead of relying on Excel CF |
+| False duplicates from staged/spare rows | Audit only treats `Deployed = Yes` rows as real duplicate candidates |
+| False duplicates from shared part numbers/cables | Default key list excludes connector cable fields |
+| Duplicate caused by moved anesthesia workstation | Audit generates remote Cybernet survey requests before physical revisit |
+| Raw tracker corruption | Data policy requires raw files to remain untouched, with backups and candidate outputs separated |
+| Public repo data leakage | `.gitignore` blocks live workbooks, CSVs, ZIPs, and output artifacts by default |
+| Human interpretation gap | Outputs include row numbers, conflict field/value, location context, and missing resolution fields |
+
+## Known Limitations
+
+| Limitation | Impact | Current Handling |
+|---|---|---|
+| Location text may differ for the same physical room | Can flag a same-room wording mismatch as a real conflict | Output includes both location strings for human review |
+| `Deployed` must equal `Yes` exactly after trimming/case normalization | Other values like `Y`, `TRUE`, or `1` are not currently treated as deployed | Keep tracker values standardized or extend parser deliberately |
+| XLSX formulas are not recalculated | The audit reads stored workbook values, not Excel's live calculation engine | Open/save in Excel first when formulas are stale |
+| Hidden rows are still read | Hidden bad records can be surfaced, which is usually desirable | Treat hidden data as auditable unless a future flag excludes it |
+| Merged cells can produce sparse values | Some context fields may appear blank if Excel stores the value only once | Use row numbers and tracker review to confirm |
+| Remote survey may fail if host is offline or unreachable | The tool can generate targets, but cannot guarantee remote reachability | Revisit requires failed remote survey or conflicting remote evidence |
+| Public repo cannot safely store live trackers | Real hostnames, MACs, serials, and locations may be sensitive | Store live data locally, encrypted, or in a private repo |
+
+## Physical Revisit Standard
+
+Do not approve a physical revisit merely because a duplicate appears.
+
+A revisit is justified only when at least one of these is true:
+
+1. Remote Cybernet survey cannot reach the target.
+2. Remote survey returns conflicting Cybernet identifiers.
+3. Tracker says deployed, but no network/device evidence supports the deployment.
+4. The client explicitly requests onsite validation.
+5. The duplicate affects a patient-care workflow and cannot be resolved through available data.
+
+Otherwise, the next action is remote reconciliation.
+
+## Data Hygiene Rule
+
+Use the `data/` workspace contract:
+
+```text
+data/raw/          untouched source workbooks
+data/backups/      timestamped backup copies
+data/experiments/  scratch workbooks and parser tests
+data/outputs/      generated audit outputs
+data/updated/      candidate fixed workbooks
+```
+
+Never modify `data/raw/`.

--- a/deployment-audit/README.md
+++ b/deployment-audit/README.md
@@ -14,13 +14,51 @@ A duplicate is only real when:
 
 Repeated identifiers on non-deployed, spare, staged, historical, placeholder, or incomplete rows are not automatically real duplicates.
 
-## Primary Tool
+## Full Workflow
+
+### 1. Audit the Deployments tab
 
 ```bash
 ./deployment-audit/sas-audit-deployments.sh \
   --workbook data/raw/DeploymentTracker_2026-04-20_SOURCE.xlsx \
   --sheet Deployments \
   --output-dir data/outputs/deployment_audit_2026-05-02
+```
+
+### 2. Build a remote survey manifest from duplicate-resolution requests
+
+```bash
+./deployment-audit/sas-build-survey-manifest.sh \
+  --requests data/outputs/deployment_audit_2026-05-02/survey_requests_duplicate_resolution.csv \
+  --output data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv
+```
+
+### 3. Normalize the survey targets
+
+```bash
+./survey/sas-survey-targets.sh \
+  --device-type Cybernet \
+  --csv data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv \
+  --output data/outputs/deployment_audit_2026-05-02/normalized_remote_survey_targets.csv
+```
+
+### 4. Collect remote Cybernet evidence
+
+```bash
+./survey/sas-collect-cybernet-evidence.sh \
+  --manifest data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv \
+  --output data/outputs/deployment_audit_2026-05-02/cybernet_evidence.csv
+```
+
+SSH is disabled by default. If an approved SSH-capable path exists, enable it explicitly:
+
+```bash
+./survey/sas-collect-cybernet-evidence.sh \
+  --manifest data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv \
+  --output data/outputs/deployment_audit_2026-05-02/cybernet_evidence.csv \
+  --allow-ssh \
+  --ssh-user approved_user \
+  --ssh-key ~/.ssh/approved_key
 ```
 
 ## Outputs
@@ -32,27 +70,19 @@ Repeated identifiers on non-deployed, spare, staged, historical, placeholder, or
 | `real_duplicate_pairs_deployed_yes.csv` | Row-pair view of real duplicate conflicts |
 | `real_duplicate_clusters.csv` | Connected duplicate row groups |
 | `survey_requests_duplicate_resolution.csv` | Rows that need remote Cybernet survey before any physical revisit |
+| `remote_survey_manifest.csv` | Target list generated from survey requests |
+| `cybernet_evidence.csv` | Remote evidence and revisit recommendation |
 | `ref_errors.csv` | `#REF!` failures found in the deployment tab |
 | `audit_summary.txt` | Human-readable summary |
 
-## Remote Survey Bridge
+## Evidence Verdicts
 
-Use this when duplicate conflicts require more Cybernet evidence before approving a site revisit.
-
-```bash
-./deployment-audit/sas-build-survey-manifest.sh \
-  --requests data/outputs/deployment_audit_2026-05-02/survey_requests_duplicate_resolution.csv \
-  --output data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv
-```
-
-Then feed the manifest into the survey side of SysAdminSuite.
-
-```bash
-./survey/sas-survey-targets.sh \
-  --device-type Cybernet \
-  --csv data/outputs/deployment_audit_2026-05-02/remote_survey_manifest.csv \
-  --output data/outputs/deployment_audit_2026-05-02/normalized_remote_survey_targets.csv
-```
+| EvidenceStatus | Meaning | Revisit posture |
+|---|---|---|
+| `Confirmed` | Expected Cybernet evidence matches collected evidence | No revisit needed |
+| `Conflict` | Collected Cybernet evidence conflicts with tracker expectation | Revisit or privileged remote review justified |
+| `ReachableNeedsPrivilegedSurvey` | Device responds, but current transport cannot collect serial/MAC | Try approved remote-management path before revisit |
+| `Unreachable` | Target cannot be resolved/reached by lightweight checks | Revisit only after network/remote-management path is exhausted |
 
 ## Risks Addressed
 
@@ -65,6 +95,8 @@ Then feed the manifest into the survey side of SysAdminSuite.
 | Raw tracker corruption | Data policy requires raw files to remain untouched, with backups and candidate outputs separated |
 | Public repo data leakage | `.gitignore` blocks live workbooks, CSVs, ZIPs, and output artifacts by default |
 | Human interpretation gap | Outputs include row numbers, conflict field/value, location context, and missing resolution fields |
+| Weak revisit justification | Evidence collector emits a revisit recommendation instead of leaving a vague duplicate flag |
+| Unsafe remote actions | Collector is read-only; SSH is disabled unless explicitly enabled |
 
 ## Known Limitations
 
@@ -76,6 +108,8 @@ Then feed the manifest into the survey side of SysAdminSuite.
 | Hidden rows are still read | Hidden bad records can be surfaced, which is usually desirable | Treat hidden data as auditable unless a future flag excludes it |
 | Merged cells can produce sparse values | Some context fields may appear blank if Excel stores the value only once | Use row numbers and tracker review to confirm |
 | Remote survey may fail if host is offline or unreachable | The tool can generate targets, but cannot guarantee remote reachability | Revisit requires failed remote survey or conflicting remote evidence |
+| Lightweight probes cannot always collect serial/MAC | Ping/DNS may prove reachability without proving identity | Use approved privileged remote path before physical revisit |
+| SSH collection is environment-dependent | Many Cybernet/Windows targets will not support SSH | SSH is optional and explicit; future collectors can add WMI/RPC/SNMP/API paths |
 | Public repo cannot safely store live trackers | Real hostnames, MACs, serials, and locations may be sensitive | Store live data locally, encrypted, or in a private repo |
 
 ## Physical Revisit Standard
@@ -84,7 +118,7 @@ Do not approve a physical revisit merely because a duplicate appears.
 
 A revisit is justified only when at least one of these is true:
 
-1. Remote Cybernet survey cannot reach the target.
+1. Remote Cybernet survey cannot reach the target after approved network/remote-management checks.
 2. Remote survey returns conflicting Cybernet identifiers.
 3. Tracker says deployed, but no network/device evidence supports the deployment.
 4. The client explicitly requests onsite validation.

--- a/deployment-audit/README.md
+++ b/deployment-audit/README.md
@@ -61,6 +61,17 @@ SSH is disabled by default. If an approved SSH-capable path exists, enable it ex
   --ssh-key ~/.ssh/approved_key
 ```
 
+### 5. Reconcile evidence into a final revisit verdict
+
+```bash
+./deployment-audit/sas-reconcile-evidence.sh \
+  --duplicates data/outputs/deployment_audit_2026-05-02/real_duplicate_values_deployed_yes.csv \
+  --requests data/outputs/deployment_audit_2026-05-02/survey_requests_duplicate_resolution.csv \
+  --evidence data/outputs/deployment_audit_2026-05-02/cybernet_evidence.csv \
+  --output data/outputs/deployment_audit_2026-05-02/reconciliation_verdicts.csv \
+  --summary data/outputs/deployment_audit_2026-05-02/reconciliation_summary.txt
+```
+
 ## Outputs
 
 | Output | Purpose |
@@ -72,8 +83,10 @@ SSH is disabled by default. If an approved SSH-capable path exists, enable it ex
 | `survey_requests_duplicate_resolution.csv` | Rows that need remote Cybernet survey before any physical revisit |
 | `remote_survey_manifest.csv` | Target list generated from survey requests |
 | `cybernet_evidence.csv` | Remote evidence and revisit recommendation |
+| `reconciliation_verdicts.csv` | Management-facing final action verdicts |
+| `reconciliation_summary.txt` | Verdict counts and meaning |
 | `ref_errors.csv` | `#REF!` failures found in the deployment tab |
-| `audit_summary.txt` | Human-readable summary |
+| `audit_summary.txt` | Human-readable audit summary |
 
 ## Evidence Verdicts
 
@@ -81,8 +94,20 @@ SSH is disabled by default. If an approved SSH-capable path exists, enable it ex
 |---|---|---|
 | `Confirmed` | Expected Cybernet evidence matches collected evidence | No revisit needed |
 | `Conflict` | Collected Cybernet evidence conflicts with tracker expectation | Revisit or privileged remote review justified |
+| `IdentityCollectedNeedsComparisonData` | Identity was collected, but tracker lacks enough expected fields for a hard comparison | Fill tracker fields or use privileged survey before revisit |
 | `ReachableNeedsPrivilegedSurvey` | Device responds, but current transport cannot collect serial/MAC | Try approved remote-management path before revisit |
 | `Unreachable` | Target cannot be resolved/reached by lightweight checks | Revisit only after network/remote-management path is exhausted |
+
+## Final Reconciliation Verdicts
+
+| FinalVerdict | Meaning | Action |
+|---|---|---|
+| `NoRevisit` | Evidence supports remote reconciliation | Update/reconcile tracker remotely |
+| `NeedsPrivilegedSurvey` | More remote identity evidence is needed | Use approved stronger remote transport first |
+| `RevisitJustified` | Evidence conflict or unreachable target supports onsite work | Prepare revisit justification with row/evidence attachments |
+| `ReviewRequired` | Evidence shape is incomplete or ambiguous | Human review before action |
+
+These verdicts are decision support. They do not replace field judgment, client instructions, or patient-care urgency. They prevent weak revisits, not necessary ones.
 
 ## Risks Addressed
 
@@ -95,8 +120,9 @@ SSH is disabled by default. If an approved SSH-capable path exists, enable it ex
 | Raw tracker corruption | Data policy requires raw files to remain untouched, with backups and candidate outputs separated |
 | Public repo data leakage | `.gitignore` blocks live workbooks, CSVs, ZIPs, and output artifacts by default |
 | Human interpretation gap | Outputs include row numbers, conflict field/value, location context, and missing resolution fields |
-| Weak revisit justification | Evidence collector emits a revisit recommendation instead of leaving a vague duplicate flag |
+| Weak revisit justification | Evidence collector and reconciler emit final action recommendations instead of leaving vague duplicate flags |
 | Unsafe remote actions | Collector is read-only; SSH is disabled unless explicitly enabled |
+| Over-trusting automation | Reconciler emits `ReviewRequired` when evidence/data shape is ambiguous |
 
 ## Known Limitations
 
@@ -110,6 +136,7 @@ SSH is disabled by default. If an approved SSH-capable path exists, enable it ex
 | Remote survey may fail if host is offline or unreachable | The tool can generate targets, but cannot guarantee remote reachability | Revisit requires failed remote survey or conflicting remote evidence |
 | Lightweight probes cannot always collect serial/MAC | Ping/DNS may prove reachability without proving identity | Use approved privileged remote path before physical revisit |
 | SSH collection is environment-dependent | Many Cybernet/Windows targets will not support SSH | SSH is optional and explicit; future collectors can add WMI/RPC/SNMP/API paths |
+| Reconciler depends on input CSV contracts | Missing or stale files can produce `ReviewRequired` | Contract tests pin headers and expected verdict categories |
 | Public repo cannot safely store live trackers | Real hostnames, MACs, serials, and locations may be sensitive | Store live data locally, encrypted, or in a private repo |
 
 ## Physical Revisit Standard

--- a/deployment-audit/sas-build-survey-manifest.sh
+++ b/deployment-audit/sas-build-survey-manifest.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Build a remote survey manifest from deployment-audit duplicate resolution requests.
+# Input: survey_requests_duplicate_resolution.csv
+# Output: CSV compatible with survey/sas-survey-targets.sh
+
+set -euo pipefail
+
+REQUESTS=""
+OUTPUT="deployment-audit/output/remote_survey_manifest.csv"
+DEVICE_TYPE="Cybernet"
+INCLUDE_COMPLETE=0
+
+usage() {
+  cat <<'USAGE'
+Build Remote Survey Manifest
+
+Usage:
+  ./deployment-audit/sas-build-survey-manifest.sh --requests survey_requests_duplicate_resolution.csv [options]
+
+Options:
+  --requests PATH       CSV from sas-audit-deployments.sh
+  --output PATH         Destination survey manifest CSV
+  --device-type TYPE    Device type to emit. Default: Cybernet
+  --include-complete    Include rows that already have all resolution identifiers
+  -h, --help            Show help
+
+Output columns:
+  Identifier,Target,HostName,Serial,MACAddress,DeviceType,Source,Reason,ExcelRow,ConflictField,ConflictValue,LocationKey,MissingResolutionIdentifiers
+
+The output can be passed to:
+
+  ./survey/sas-survey-targets.sh --csv remote_survey_manifest.csv --output normalized_remote_survey_targets.csv
+USAGE
+}
+
+fail(){ printf '[survey-manifest] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[survey-manifest] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --requests) REQUESTS="${2:?missing value for --requests}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --device-type) DEVICE_TYPE="${2:?missing value for --device-type}"; shift 2 ;;
+    --include-complete) INCLUDE_COMPLETE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$REQUESTS" ]] || fail "--requests is required"
+[[ -f "$REQUESTS" ]] || fail "Requests CSV not found: $REQUESTS"
+has_cmd python3 || fail "python3 is required"
+mkdir -p "$(dirname "$OUTPUT")"
+
+python3 - "$REQUESTS" "$OUTPUT" "$DEVICE_TYPE" "$INCLUDE_COMPLETE" <<'PY'
+import csv
+import re
+import sys
+
+requests_path, output_path, device_type, include_complete_raw = sys.argv[1:5]
+include_complete = include_complete_raw == '1'
+
+fields = [
+    'Identifier','Target','HostName','Serial','MACAddress','DeviceType','Source','Reason',
+    'ExcelRow','ConflictField','ConflictValue','LocationKey','MissingResolutionIdentifiers'
+]
+
+def parse_known(value):
+    out = {}
+    for part in (value or '').split(';'):
+        part = part.strip()
+        if not part or '=' not in part:
+            continue
+        k, v = part.split('=', 1)
+        out[k.strip().lower()] = v.strip()
+    return out
+
+def norm_mac(v):
+    hx = re.sub(r'[^0-9A-Fa-f]', '', v or '').upper()
+    return ':'.join(hx[i:i+2] for i in range(0, 12, 2)) if len(hx) == 12 else (v or '').strip().upper()
+
+def choose_target(row, known):
+    for key in ['cybernet hostname', 'cybernet serial', 'cybernet mac']:
+        if known.get(key):
+            return known[key]
+    return row.get('SurveyTargetHint') or row.get('ConflictValue') or ''
+
+seen = set()
+written = 0
+with open(requests_path, newline='', encoding='utf-8-sig') as src, open(output_path, 'w', newline='', encoding='utf-8') as dst:
+    reader = csv.DictReader(src)
+    writer = csv.DictWriter(dst, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator='\n')
+    writer.writeheader()
+    for row in reader:
+        missing = (row.get('MissingResolutionIdentifiers') or '').strip()
+        if missing == '' and not include_complete:
+            continue
+        known = parse_known(row.get('KnownResolutionIdentifiers'))
+        target = choose_target(row, known).strip()
+        host = known.get('cybernet hostname', '')
+        serial = known.get('cybernet serial', '')
+        mac = norm_mac(known.get('cybernet mac', '')) if known.get('cybernet mac') else ''
+        identifier = target or host or serial or mac or row.get('ConflictValue', '')
+        key = (identifier, row.get('ExcelRow'), row.get('ConflictField'), row.get('ConflictValue'))
+        if key in seen:
+            continue
+        seen.add(key)
+        writer.writerow({
+            'Identifier': identifier,
+            'Target': target,
+            'HostName': host,
+            'Serial': serial,
+            'MACAddress': mac,
+            'DeviceType': device_type,
+            'Source': 'deployment-audit',
+            'Reason': 'Resolve deployed duplicate before physical revisit',
+            'ExcelRow': row.get('ExcelRow', ''),
+            'ConflictField': row.get('ConflictField', ''),
+            'ConflictValue': row.get('ConflictValue', ''),
+            'LocationKey': row.get('LocationKey', ''),
+            'MissingResolutionIdentifiers': missing,
+        })
+        written += 1
+print(f'Wrote {written} survey target(s) to {output_path}')
+PY
+
+log "Manifest ready: $OUTPUT"

--- a/deployment-audit/sas-reconcile-evidence.sh
+++ b/deployment-audit/sas-reconcile-evidence.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# SysAdminSuite deployment evidence reconciler
+# Joins duplicate conflicts, survey requests, and collected Cybernet identity evidence into final revisit verdicts.
+
+set -euo pipefail
+
+DUPLICATES=""
+REQUESTS=""
+EVIDENCE=""
+OUTPUT="deployment-audit/output/reconciliation_verdicts.csv"
+SUMMARY=""
+PASS_THRU=0
+
+usage(){ cat <<'USAGE'
+Deployment Evidence Reconciler
+
+Usage:
+  ./deployment-audit/sas-reconcile-evidence.sh --duplicates real_duplicate_values_deployed_yes.csv --requests survey_requests_duplicate_resolution.csv --evidence cybernet_evidence.csv [options]
+
+Options:
+  --duplicates PATH    CSV from sas-audit-deployments.sh: real_duplicate_values_deployed_yes.csv
+  --requests PATH      CSV from sas-audit-deployments.sh: survey_requests_duplicate_resolution.csv
+  --evidence PATH      CSV from sas-collect-cybernet-evidence.sh: cybernet_evidence.csv
+  --output PATH        Output verdict CSV. Default: deployment-audit/output/reconciliation_verdicts.csv
+  --summary PATH       Optional text summary path. Default: same base as output + .txt
+  --pass-thru          Print verdict CSV after writing
+  -h, --help           Show help
+
+Final verdicts:
+  NoRevisit              Evidence confirms the tracker can be reconciled remotely.
+  NeedsPrivilegedSurvey  Target is reachable or partially known, but current evidence is insufficient.
+  RevisitJustified       Conflict, unreachable after available checks, or no usable evidence.
+  ReviewRequired         Data shape is incomplete or ambiguous and needs human review.
+
+Safety:
+  - Read-only.
+  - Does not modify the workbook.
+  - Produces management-facing verdicts from audit/evidence outputs.
+USAGE
+}
+
+fail(){ printf '[evidence-reconcile] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[evidence-reconcile] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --duplicates) DUPLICATES="${2:?missing value for --duplicates}"; shift 2 ;;
+    --requests) REQUESTS="${2:?missing value for --requests}"; shift 2 ;;
+    --evidence) EVIDENCE="${2:?missing value for --evidence}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --summary) SUMMARY="${2:?missing value for --summary}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$DUPLICATES" ]] || fail "--duplicates is required"
+[[ -n "$REQUESTS" ]] || fail "--requests is required"
+[[ -n "$EVIDENCE" ]] || fail "--evidence is required"
+[[ -f "$DUPLICATES" ]] || fail "duplicates CSV not found: $DUPLICATES"
+[[ -f "$REQUESTS" ]] || fail "requests CSV not found: $REQUESTS"
+[[ -f "$EVIDENCE" ]] || fail "evidence CSV not found: $EVIDENCE"
+has_cmd python3 || fail "python3 is required"
+mkdir -p "$(dirname "$OUTPUT")"
+if [[ -z "$SUMMARY" ]]; then SUMMARY="${OUTPUT%.*}.txt"; fi
+
+python3 - "$DUPLICATES" "$REQUESTS" "$EVIDENCE" "$OUTPUT" "$SUMMARY" <<'PY'
+import csv
+import sys
+from collections import Counter, defaultdict
+
+duplicates_path, requests_path, evidence_path, output_path, summary_path = sys.argv[1:6]
+
+def rows(path):
+    with open(path, newline='', encoding='utf-8-sig') as f:
+        return list(csv.DictReader(f))
+
+def first(row, names):
+    lower = {k.lower(): v for k, v in row.items()}
+    for name in names:
+        v = lower.get(name.lower())
+        if v is not None and str(v).strip():
+            return str(v).strip()
+    return ''
+
+def key_for(row):
+    return (first(row, ['ConflictField']), first(row, ['ConflictValue']), first(row, ['ExcelRow']))
+
+def conflict_key(row):
+    return (first(row, ['ConflictField']), first(row, ['ConflictValue']))
+
+def verdict_for(evidence_status, ping_status, missing_resolution, observed_serial, observed_macs, expected_serial, expected_mac):
+    evidence_status = (evidence_status or '').strip()
+    ping_status = (ping_status or '').strip()
+    missing_resolution = (missing_resolution or '').strip()
+    has_observed_identity = bool((observed_serial or '').strip() or (observed_macs or '').strip())
+    has_expected_identity = bool((expected_serial or '').strip() or (expected_mac or '').strip())
+
+    if evidence_status == 'Confirmed':
+        return 'NoRevisit', 'Cybernet evidence matches tracker expectation.'
+    if evidence_status == 'Conflict':
+        return 'RevisitJustified', 'Collected Cybernet evidence conflicts with tracker expectation.'
+    if evidence_status == 'IdentityCollectedNeedsComparisonData':
+        if missing_resolution:
+            return 'NeedsPrivilegedSurvey', 'Identity was collected, but tracker lacks enough expected Cybernet identifiers for a hard comparison.'
+        return 'ReviewRequired', 'Identity was collected but comparison data is ambiguous.'
+    if evidence_status == 'ReachableNeedsPrivilegedSurvey':
+        return 'NeedsPrivilegedSurvey', 'Target is reachable but current transport did not collect serial/MAC identity.'
+    if evidence_status == 'Unreachable':
+        return 'RevisitJustified', 'Target could not be reached by available remote checks.'
+    if has_observed_identity and not has_expected_identity:
+        return 'NeedsPrivilegedSurvey', 'Observed identity exists but tracker lacks expected Cybernet fields.'
+    if ping_status == 'Reachable':
+        return 'NeedsPrivilegedSurvey', 'Reachable target requires approved identity transport before onsite revisit.'
+    return 'ReviewRequired', 'Insufficient evidence to decide automatically.'
+
+duplicates = rows(duplicates_path)
+requests = rows(requests_path)
+evidence = rows(evidence_path)
+request_by_key = {key_for(r): r for r in requests}
+evidence_by_key = {key_for(r): r for r in evidence}
+requests_by_conflict = defaultdict(list)
+evidence_by_conflict = defaultdict(list)
+for r in requests:
+    requests_by_conflict[conflict_key(r)].append(r)
+for r in evidence:
+    evidence_by_conflict[conflict_key(r)].append(r)
+
+out_fields = [
+    'ConflictField','ConflictValue','ConflictRows','DuplicateSeverity','DuplicateLocations',
+    'ExcelRow','LocationKey','Target','ExpectedSerial','ExpectedMAC','ObservedSerial','ObservedMACs','PingStatus','EvidenceStatus','FinalVerdict','Reason','RecommendedNextAction','Notes'
+]
+out = []
+
+for dup in duplicates:
+    ckey = conflict_key(dup)
+    reqs = requests_by_conflict.get(ckey, [])
+    evs = evidence_by_conflict.get(ckey, [])
+    if not reqs and not evs:
+        out.append({
+            'ConflictField': ckey[0], 'ConflictValue': ckey[1], 'ConflictRows': first(dup, ['Rows']),
+            'DuplicateSeverity': first(dup, ['Severity']), 'DuplicateLocations': first(dup, ['Locations']),
+            'ExcelRow': '', 'LocationKey': '', 'Target': '', 'ExpectedSerial': '', 'ExpectedMAC': '',
+            'ObservedSerial': '', 'ObservedMACs': '', 'PingStatus': '', 'EvidenceStatus': '',
+            'FinalVerdict': 'ReviewRequired', 'Reason': 'No survey request/evidence rows found for duplicate conflict.',
+            'RecommendedNextAction': 'Regenerate survey requests and collect remote evidence.', 'Notes': ''
+        })
+        continue
+    row_keys = sorted(set([key_for(r) for r in reqs] + [key_for(r) for r in evs]), key=lambda x: x[2])
+    for rk in row_keys:
+        req = request_by_key.get(rk, {})
+        ev = evidence_by_key.get(rk, {})
+        expected_serial = first(ev, ['ExpectedSerial']) or ''
+        expected_mac = first(ev, ['ExpectedMAC']) or ''
+        observed_serial = first(ev, ['ObservedSerial'])
+        observed_macs = first(ev, ['ObservedMACs'])
+        evidence_status = first(ev, ['EvidenceStatus'])
+        ping_status = first(ev, ['PingStatus'])
+        missing = first(req, ['MissingResolutionIdentifiers'])
+        verdict, reason = verdict_for(evidence_status, ping_status, missing, observed_serial, observed_macs, expected_serial, expected_mac)
+        if verdict == 'NoRevisit':
+            action = 'Update/reconcile tracker remotely; no physical revisit indicated.'
+        elif verdict == 'NeedsPrivilegedSurvey':
+            action = 'Use approved privileged identity transport before requesting onsite revisit.'
+        elif verdict == 'RevisitJustified':
+            action = 'Prepare onsite revisit justification with conflict/evidence rows attached.'
+        else:
+            action = 'Human review required; data/evidence shape is incomplete.'
+        out.append({
+            'ConflictField': ckey[0],
+            'ConflictValue': ckey[1],
+            'ConflictRows': first(dup, ['Rows']),
+            'DuplicateSeverity': first(dup, ['Severity']),
+            'DuplicateLocations': first(dup, ['Locations']),
+            'ExcelRow': rk[2],
+            'LocationKey': first(req, ['LocationKey']) or first(ev, ['LocationKey']),
+            'Target': first(ev, ['Target']) or first(req, ['SurveyTargetHint']),
+            'ExpectedSerial': expected_serial,
+            'ExpectedMAC': expected_mac,
+            'ObservedSerial': observed_serial,
+            'ObservedMACs': observed_macs,
+            'PingStatus': ping_status,
+            'EvidenceStatus': evidence_status,
+            'FinalVerdict': verdict,
+            'Reason': reason,
+            'RecommendedNextAction': action,
+            'Notes': first(ev, ['Notes']),
+        })
+
+with open(output_path, 'w', newline='', encoding='utf-8') as f:
+    writer = csv.DictWriter(f, fieldnames=out_fields, quoting=csv.QUOTE_ALL, lineterminator='\n')
+    writer.writeheader()
+    writer.writerows(out)
+
+counts = Counter(r['FinalVerdict'] for r in out)
+with open(summary_path, 'w', encoding='utf-8') as f:
+    f.write('SysAdminSuite Deployment Evidence Reconciliation\n')
+    f.write('===============================================\n\n')
+    f.write(f'Duplicate conflicts: {len(duplicates)}\n')
+    f.write(f'Survey request rows: {len(requests)}\n')
+    f.write(f'Evidence rows: {len(evidence)}\n')
+    f.write(f'Verdict rows: {len(out)}\n\n')
+    f.write('Final verdict counts:\n')
+    for verdict, count in counts.most_common():
+        f.write(f'  {verdict}: {count}\n')
+    f.write('\nVerdict meanings:\n')
+    f.write('  NoRevisit: reconcile remotely; evidence supports avoiding physical revisit.\n')
+    f.write('  NeedsPrivilegedSurvey: use approved stronger remote transport first.\n')
+    f.write('  RevisitJustified: conflict/unreachable condition supports onsite justification.\n')
+    f.write('  ReviewRequired: insufficient or ambiguous evidence.\n')
+
+print(f'Wrote {len(out)} verdict row(s) to {output_path}')
+print(f'Wrote summary to {summary_path}')
+PY
+
+log "Reconciliation complete: $OUTPUT"
+log "Summary: $SUMMARY"
+[[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/deployment-audit/tests/test_deployment_audit_contracts.sh
+++ b/deployment-audit/tests/test_deployment_audit_contracts.sh
@@ -7,6 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 AUDIT="$ROOT_DIR/deployment-audit/sas-audit-deployments.sh"
 MANIFEST="$ROOT_DIR/deployment-audit/sas-build-survey-manifest.sh"
 COLLECTOR="$ROOT_DIR/survey/sas-collect-cybernet-evidence.sh"
+RECONCILER="$ROOT_DIR/deployment-audit/sas-reconcile-evidence.sh"
 
 fail(){ printf '[deployment-audit-tests] FAIL: %s\n' "$*" >&2; exit 1; }
 pass(){ printf '[deployment-audit-tests] PASS: %s\n' "$*"; }
@@ -14,10 +15,12 @@ pass(){ printf '[deployment-audit-tests] PASS: %s\n' "$*"; }
 [[ -f "$AUDIT" ]] || fail "Missing audit script"
 [[ -f "$MANIFEST" ]] || fail "Missing survey manifest builder"
 [[ -f "$COLLECTOR" ]] || fail "Missing Cybernet evidence collector"
+[[ -f "$RECONCILER" ]] || fail "Missing evidence reconciler"
 
 bash -n "$AUDIT" || fail "Audit script has Bash syntax errors"
 bash -n "$MANIFEST" || fail "Manifest builder has Bash syntax errors"
 bash -n "$COLLECTOR" || fail "Collector script has Bash syntax errors"
+bash -n "$RECONCILER" || fail "Reconciler script has Bash syntax errors"
 
 HELP="$($AUDIT --help)"
 [[ "$HELP" == *"Deployed = Yes"* ]] || fail "Audit help must document deployed-only duplicate rule"
@@ -33,15 +36,28 @@ COLLECTOR_HELP="$($COLLECTOR --help)"
 [[ "$COLLECTOR_HELP" == *"RevisitRecommendation"* ]] || fail "Collector help must document revisit verdict output"
 [[ "$COLLECTOR_HELP" == *"--allow-ssh"* ]] || fail "Collector help must require explicit SSH enablement"
 
+RECONCILER_HELP="$($RECONCILER --help)"
+[[ "$RECONCILER_HELP" == *"NoRevisit"* ]] || fail "Reconciler help must document NoRevisit"
+[[ "$RECONCILER_HELP" == *"NeedsPrivilegedSurvey"* ]] || fail "Reconciler help must document NeedsPrivilegedSurvey"
+[[ "$RECONCILER_HELP" == *"RevisitJustified"* ]] || fail "Reconciler help must document RevisitJustified"
+[[ "$RECONCILER_HELP" == *"Read-only"* || "$RECONCILER_HELP" == *"read-only"* ]] || fail "Reconciler help must document read-only posture"
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 REQ="$TMP_DIR/survey_requests_duplicate_resolution.csv"
 OUT="$TMP_DIR/remote_survey_manifest.csv"
 EVIDENCE="$TMP_DIR/cybernet_evidence.csv"
+DUPS="$TMP_DIR/real_duplicate_values_deployed_yes.csv"
+VERDICTS="$TMP_DIR/reconciliation_verdicts.csv"
+SUMMARY="$TMP_DIR/reconciliation_summary.txt"
 cat > "$REQ" <<'CSV'
 ConflictField,ConflictValue,ExcelRow,DeviceType,CurrentBuilding,InstallBuilding,AreaUnitDept,Room,Bay,LocationKey,KnownResolutionIdentifiers,MissingResolutionIdentifiers,RecommendedAction,SurveyTargetHint
 Neuron MAC,00:18:7D:E0:AD:F1,134,Neuron,LIJ,LIJ,OR,OR21,,LIJ | LIJ | OR | OR21,Cybernet Hostname=WMH300OPR134,Cybernet Serial=ABC134,Cybernet MAC=00:AA:BB:CC:DD:01,,Remote survey Cybernet identifiers before physical revisit,WMH300OPR134
 Neuron MAC,00:18:7D:E0:AD:F1,168,Neuron,LIJ,LIJ,Proc,OR21,,LIJ | LIJ | Proc | OR21,,Cybernet Hostname; Cybernet Serial; Cybernet MAC,Remote survey Cybernet identifiers before physical revisit,00:18:7D:E0:AD:F1
+CSV
+cat > "$DUPS" <<'CSV'
+Field,Value,Rows,Count,DistinctLocations,Severity,Locations
+Neuron MAC,00:18:7D:E0:AD:F1,134;168,2,2,RealDuplicate,LIJ | LIJ | OR | OR21 || LIJ | LIJ | Proc | OR21
 CSV
 
 bash "$MANIFEST" --requests "$REQ" --output "$OUT" >/dev/null
@@ -54,10 +70,18 @@ grep -q '00:18:7D:E0:AD:F1' "$OUT" || fail "Manifest output missing fallback sur
 bash "$COLLECTOR" --manifest "$OUT" --output "$EVIDENCE" --timeout 1 >/dev/null
 [[ -f "$EVIDENCE" ]] || fail "Collector did not create evidence CSV"
 grep -q 'RevisitRecommendation' "$EVIDENCE" || fail "Evidence CSV missing RevisitRecommendation column"
-grep -Eq 'Unreachable|ReachableNeedsPrivilegedSurvey|Confirmed|Conflict' "$EVIDENCE" || fail "Evidence CSV missing evidence status verdict"
+grep -Eq 'Unreachable|ReachableNeedsPrivilegedSurvey|Confirmed|Conflict|ReachableNeedsApprovedIdentityTransport|IdentityCollectedNeedsComparisonData' "$EVIDENCE" || fail "Evidence CSV missing evidence status verdict"
 grep -q '00:18:7D:E0:AD:F1' "$EVIDENCE" || fail "Evidence CSV missing conflict value trace"
+
+bash "$RECONCILER" --duplicates "$DUPS" --requests "$REQ" --evidence "$EVIDENCE" --output "$VERDICTS" --summary "$SUMMARY" >/dev/null
+[[ -f "$VERDICTS" ]] || fail "Reconciler did not create verdict CSV"
+[[ -f "$SUMMARY" ]] || fail "Reconciler did not create summary"
+grep -q 'FinalVerdict' "$VERDICTS" || fail "Verdict CSV missing FinalVerdict column"
+grep -Eq 'NoRevisit|NeedsPrivilegedSurvey|RevisitJustified|ReviewRequired' "$VERDICTS" || fail "Verdict CSV missing known final verdict"
+grep -q 'Verdict meanings' "$SUMMARY" || fail "Summary missing verdict meanings"
 
 pass "Bash syntax checks passed"
 pass "Help contracts passed"
 pass "Survey manifest builder fixture passed"
 pass "Cybernet evidence collector fixture passed"
+pass "Evidence reconciler fixture passed"

--- a/deployment-audit/tests/test_deployment_audit_contracts.sh
+++ b/deployment-audit/tests/test_deployment_audit_contracts.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Lightweight contract tests for deployment-audit Bash tooling.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AUDIT="$ROOT_DIR/deployment-audit/sas-audit-deployments.sh"
+MANIFEST="$ROOT_DIR/deployment-audit/sas-build-survey-manifest.sh"
+
+fail(){ printf '[deployment-audit-tests] FAIL: %s\n' "$*" >&2; exit 1; }
+pass(){ printf '[deployment-audit-tests] PASS: %s\n' "$*"; }
+
+[[ -f "$AUDIT" ]] || fail "Missing audit script"
+[[ -f "$MANIFEST" ]] || fail "Missing survey manifest builder"
+
+bash -n "$AUDIT" || fail "Audit script has Bash syntax errors"
+bash -n "$MANIFEST" || fail "Manifest builder has Bash syntax errors"
+
+HELP="$($AUDIT --help)"
+[[ "$HELP" == *"Deployed = Yes"* ]] || fail "Audit help must document deployed-only duplicate rule"
+[[ "$HELP" == *"survey_requests_duplicate_resolution.csv"* ]] || fail "Audit help must document survey request output"
+[[ "$HELP" == *"--resolution-keys"* ]] || fail "Audit help must document resolution keys"
+
+MANIFEST_HELP="$($MANIFEST --help)"
+[[ "$MANIFEST_HELP" == *"survey_requests_duplicate_resolution.csv"* ]] || fail "Manifest help must name expected input"
+[[ "$MANIFEST_HELP" == *"sas-survey-targets.sh"* ]] || fail "Manifest help must point to survey target resolver"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+REQ="$TMP_DIR/survey_requests_duplicate_resolution.csv"
+OUT="$TMP_DIR/remote_survey_manifest.csv"
+cat > "$REQ" <<'CSV'
+ConflictField,ConflictValue,ExcelRow,DeviceType,CurrentBuilding,InstallBuilding,AreaUnitDept,Room,Bay,LocationKey,KnownResolutionIdentifiers,MissingResolutionIdentifiers,RecommendedAction,SurveyTargetHint
+Neuron MAC,00:18:7D:E0:AD:F1,134,Neuron,LIJ,LIJ,OR,OR21,,LIJ | LIJ | OR | OR21,Cybernet Hostname=WMH300OPR134,Cybernet Serial=ABC134,Cybernet MAC=00:AA:BB:CC:DD:01,,Remote survey Cybernet identifiers before physical revisit,WMH300OPR134
+Neuron MAC,00:18:7D:E0:AD:F1,168,Neuron,LIJ,LIJ,Proc,OR21,,LIJ | LIJ | Proc | OR21,,Cybernet Hostname; Cybernet Serial; Cybernet MAC,Remote survey Cybernet identifiers before physical revisit,00:18:7D:E0:AD:F1
+CSV
+
+bash "$MANIFEST" --requests "$REQ" --output "$OUT" >/dev/null
+[[ -f "$OUT" ]] || fail "Manifest builder did not create output CSV"
+LINE_COUNT="$(wc -l < "$OUT" | tr -d ' ')"
+[[ "$LINE_COUNT" -eq 2 ]] || fail "Manifest builder should skip complete rows by default and emit one pending survey row plus header"
+grep -q 'Resolve deployed duplicate before physical revisit' "$OUT" || fail "Manifest output missing revisit-avoidance reason"
+grep -q '00:18:7D:E0:AD:F1' "$OUT" || fail "Manifest output missing fallback survey target hint"
+
+pass "Bash syntax checks passed"
+pass "Help contracts passed"
+pass "Survey manifest builder fixture passed"

--- a/deployment-audit/tests/test_deployment_audit_contracts.sh
+++ b/deployment-audit/tests/test_deployment_audit_contracts.sh
@@ -6,15 +6,18 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 AUDIT="$ROOT_DIR/deployment-audit/sas-audit-deployments.sh"
 MANIFEST="$ROOT_DIR/deployment-audit/sas-build-survey-manifest.sh"
+COLLECTOR="$ROOT_DIR/survey/sas-collect-cybernet-evidence.sh"
 
 fail(){ printf '[deployment-audit-tests] FAIL: %s\n' "$*" >&2; exit 1; }
 pass(){ printf '[deployment-audit-tests] PASS: %s\n' "$*"; }
 
 [[ -f "$AUDIT" ]] || fail "Missing audit script"
 [[ -f "$MANIFEST" ]] || fail "Missing survey manifest builder"
+[[ -f "$COLLECTOR" ]] || fail "Missing Cybernet evidence collector"
 
 bash -n "$AUDIT" || fail "Audit script has Bash syntax errors"
 bash -n "$MANIFEST" || fail "Manifest builder has Bash syntax errors"
+bash -n "$COLLECTOR" || fail "Collector script has Bash syntax errors"
 
 HELP="$($AUDIT --help)"
 [[ "$HELP" == *"Deployed = Yes"* ]] || fail "Audit help must document deployed-only duplicate rule"
@@ -25,10 +28,16 @@ MANIFEST_HELP="$($MANIFEST --help)"
 [[ "$MANIFEST_HELP" == *"survey_requests_duplicate_resolution.csv"* ]] || fail "Manifest help must name expected input"
 [[ "$MANIFEST_HELP" == *"sas-survey-targets.sh"* ]] || fail "Manifest help must point to survey target resolver"
 
+COLLECTOR_HELP="$($COLLECTOR --help)"
+[[ "$COLLECTOR_HELP" == *"read-only"* || "$COLLECTOR_HELP" == *"Read-only"* ]] || fail "Collector help must document read-only posture"
+[[ "$COLLECTOR_HELP" == *"RevisitRecommendation"* ]] || fail "Collector help must document revisit verdict output"
+[[ "$COLLECTOR_HELP" == *"--allow-ssh"* ]] || fail "Collector help must require explicit SSH enablement"
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 REQ="$TMP_DIR/survey_requests_duplicate_resolution.csv"
 OUT="$TMP_DIR/remote_survey_manifest.csv"
+EVIDENCE="$TMP_DIR/cybernet_evidence.csv"
 cat > "$REQ" <<'CSV'
 ConflictField,ConflictValue,ExcelRow,DeviceType,CurrentBuilding,InstallBuilding,AreaUnitDept,Room,Bay,LocationKey,KnownResolutionIdentifiers,MissingResolutionIdentifiers,RecommendedAction,SurveyTargetHint
 Neuron MAC,00:18:7D:E0:AD:F1,134,Neuron,LIJ,LIJ,OR,OR21,,LIJ | LIJ | OR | OR21,Cybernet Hostname=WMH300OPR134,Cybernet Serial=ABC134,Cybernet MAC=00:AA:BB:CC:DD:01,,Remote survey Cybernet identifiers before physical revisit,WMH300OPR134
@@ -42,6 +51,13 @@ LINE_COUNT="$(wc -l < "$OUT" | tr -d ' ')"
 grep -q 'Resolve deployed duplicate before physical revisit' "$OUT" || fail "Manifest output missing revisit-avoidance reason"
 grep -q '00:18:7D:E0:AD:F1' "$OUT" || fail "Manifest output missing fallback survey target hint"
 
+bash "$COLLECTOR" --manifest "$OUT" --output "$EVIDENCE" --timeout 1 >/dev/null
+[[ -f "$EVIDENCE" ]] || fail "Collector did not create evidence CSV"
+grep -q 'RevisitRecommendation' "$EVIDENCE" || fail "Evidence CSV missing RevisitRecommendation column"
+grep -Eq 'Unreachable|ReachableNeedsPrivilegedSurvey|Confirmed|Conflict' "$EVIDENCE" || fail "Evidence CSV missing evidence status verdict"
+grep -q '00:18:7D:E0:AD:F1' "$EVIDENCE" || fail "Evidence CSV missing conflict value trace"
+
 pass "Bash syntax checks passed"
 pass "Help contracts passed"
 pass "Survey manifest builder fixture passed"
+pass "Cybernet evidence collector fixture passed"

--- a/survey/sas-collect-cybernet-evidence.sh
+++ b/survey/sas-collect-cybernet-evidence.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# SysAdminSuite Cybernet remote evidence collector
+# Reads a survey manifest and collects hostname/serial/MAC evidence without mutating targets.
+# Transport strategy is conservative: ping, DNS, optional SSH command, and optional vendor/API hook later.
+
+set -euo pipefail
+
+MANIFEST=""
+OUTPUT="survey/output/cybernet_evidence.csv"
+TIMEOUT_SEC=5
+SSH_USER=""
+SSH_KEY=""
+ALLOW_SSH=0
+PASS_THRU=0
+
+usage() {
+  cat <<'USAGE'
+Cybernet Remote Evidence Collector
+
+Usage:
+  ./survey/sas-collect-cybernet-evidence.sh --manifest remote_survey_manifest.csv [options]
+
+Options:
+  --manifest PATH      Survey manifest CSV from deployment-audit/sas-build-survey-manifest.sh or survey/sas-survey-targets.sh
+  --output PATH        Output evidence CSV. Default: survey/output/cybernet_evidence.csv
+  --timeout SEC        Network timeout for lightweight probes. Default: 5
+  --ssh-user USER      Optional SSH username for Linux/SSH-capable targets
+  --ssh-key PATH       Optional SSH private key
+  --allow-ssh          Permit SSH read-only commands when HostName/Target is reachable
+  --pass-thru          Print evidence CSV after writing
+  -h, --help           Show help
+
+Safety:
+  - Read-only.
+  - Does not change devices.
+  - SSH is disabled unless --allow-ssh is passed.
+  - If no trusted transport is available, the tool still emits an evidence row with a clear status.
+
+Output columns:
+  Timestamp,ExcelRow,ConflictField,ConflictValue,InputIdentifier,Target,HostName,ExpectedSerial,ExpectedMAC,
+  ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,EvidenceStatus,RevisitRecommendation,Notes
+USAGE
+}
+
+fail(){ printf '[cybernet-evidence] ERROR: %s\n' "$*" >&2; exit 1; }
+log(){ printf '[cybernet-evidence] %s\n' "$*" >&2; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:?missing value for --manifest}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --timeout) TIMEOUT_SEC="${2:?missing value for --timeout}"; shift 2 ;;
+    --ssh-user) SSH_USER="${2:?missing value for --ssh-user}"; shift 2 ;;
+    --ssh-key) SSH_KEY="${2:?missing value for --ssh-key}"; shift 2 ;;
+    --allow-ssh) ALLOW_SSH=1; shift ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$MANIFEST" ]] || fail "--manifest is required"
+[[ -f "$MANIFEST" ]] || fail "Manifest not found: $MANIFEST"
+[[ "$TIMEOUT_SEC" =~ ^[0-9]+$ && "$TIMEOUT_SEC" -ge 1 ]] || fail "--timeout must be a positive integer"
+has_cmd python3 || fail "python3 is required"
+mkdir -p "$(dirname "$OUTPUT")"
+
+python3 - "$MANIFEST" "$OUTPUT" "$TIMEOUT_SEC" "$ALLOW_SSH" "$SSH_USER" "$SSH_KEY" <<'PY'
+import csv
+import datetime as dt
+import os
+import platform
+import re
+import socket
+import subprocess
+import sys
+
+manifest, output, timeout_raw, allow_ssh_raw, ssh_user, ssh_key = sys.argv[1:7]
+timeout = int(timeout_raw)
+allow_ssh = allow_ssh_raw == '1'
+
+fields = [
+    'Timestamp','ExcelRow','ConflictField','ConflictValue','InputIdentifier','Target','HostName','ExpectedSerial','ExpectedMAC',
+    'ResolvedAddress','PingStatus','DnsName','ObservedHostName','ObservedSerial','ObservedMACs','EvidenceStatus','RevisitRecommendation','Notes'
+]
+
+def first(row, names):
+    lower = {k.lower(): v for k, v in row.items()}
+    for name in names:
+        v = lower.get(name.lower())
+        if v and str(v).strip():
+            return str(v).strip()
+    return ''
+
+def norm_mac(v):
+    hx = re.sub(r'[^0-9A-Fa-f]', '', v or '').upper()
+    return ':'.join(hx[i:i+2] for i in range(0, 12, 2)) if len(hx) == 12 else (v or '').strip().upper()
+
+def resolve_host(target):
+    if not target:
+        return '', ''
+    try:
+        address = socket.gethostbyname(target)
+    except Exception:
+        return '', ''
+    try:
+        dns_name = socket.getfqdn(address)
+    except Exception:
+        dns_name = ''
+    return address, dns_name
+
+def ping(address_or_host):
+    if not address_or_host:
+        return 'NoTarget'
+    count_flag = '-n' if platform.system().lower().startswith('win') else '-c'
+    timeout_flag = '-w' if platform.system().lower().startswith('win') else '-W'
+    cmd = ['ping', count_flag, '1', timeout_flag, str(timeout), address_or_host]
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout + 2)
+        return 'Reachable' if result.returncode == 0 else 'NoPing'
+    except Exception:
+        return 'PingFailed'
+
+def run_ssh(host):
+    if not allow_ssh or not host:
+        return '', '', 'SSHDisabled'
+    if not ssh_user:
+        return '', '', 'SSHUserMissing'
+    if not shutil_which('ssh'):
+        return '', '', 'SSHNotInstalled'
+    dest = f'{ssh_user}@{host}'
+    cmd = ['ssh', '-o', 'BatchMode=yes', '-o', f'ConnectTimeout={timeout}']
+    if ssh_key:
+        cmd.extend(['-i', ssh_key])
+    script = "hostname; (cat /sys/class/dmi/id/product_serial 2>/dev/null || dmidecode -s system-serial-number 2>/dev/null || true); (ip link 2>/dev/null | awk '/link\/ether/ {print $2}' | paste -sd ';' - || true)"
+    cmd.extend([dest, script])
+    try:
+        result = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout + 5)
+        if result.returncode != 0:
+            return '', '', 'SSHFailed:' + (result.stderr.strip()[:120] if result.stderr else str(result.returncode))
+        lines = [x.strip() for x in result.stdout.splitlines()]
+        observed_host = lines[0] if len(lines) > 0 else ''
+        observed_serial = lines[1] if len(lines) > 1 else ''
+        observed_macs = lines[2] if len(lines) > 2 else ''
+        return observed_host, observed_serial, observed_macs
+    except Exception as exc:
+        return '', '', 'SSHError:' + str(exc)[:120]
+
+def shutil_which(name):
+    from shutil import which
+    return which(name)
+
+def verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, notes):
+    evidence = []
+    if expected_serial and observed_serial:
+        evidence.append('SerialMatch' if expected_serial.upper() == observed_serial.strip().upper() else 'SerialConflict')
+    if expected_mac and observed_macs:
+        normalized = [norm_mac(x) for x in re.split(r'[;\s,]+', observed_macs) if x.strip()]
+        evidence.append('MACMatch' if norm_mac(expected_mac) in normalized else 'MACConflict')
+    if any(x.endswith('Conflict') for x in evidence):
+        return 'Conflict', 'Physical revisit or privileged remote review justified'
+    if evidence and all(x.endswith('Match') for x in evidence):
+        return 'Confirmed', 'No revisit needed based on collected evidence'
+    if ping_status == 'Reachable':
+        return 'ReachableNeedsPrivilegedSurvey', 'Try approved remote management path before revisit'
+    return 'Unreachable', 'Revisit justified only after network/remote-management path is exhausted'
+
+rows = []
+with open(manifest, newline='', encoding='utf-8-sig') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        now = dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        target = first(row, ['Target','HostName','Identifier','SurveyTargetHint'])
+        host = first(row, ['HostName'])
+        expected_serial = first(row, ['Serial','ExpectedSerial','Cybernet Serial'])
+        expected_mac = norm_mac(first(row, ['MACAddress','ExpectedMAC','Cybernet MAC']))
+        lookup = host or target
+        resolved, dns_name = resolve_host(lookup)
+        ping_status = ping(resolved or lookup)
+        observed_host, observed_serial, observed_macs_or_note = run_ssh(lookup)
+        notes = ''
+        observed_macs = observed_macs_or_note
+        if observed_macs_or_note.startswith('SSH'):
+            notes = observed_macs_or_note
+            observed_macs = ''
+        evidence_status, recommendation = verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, notes)
+        rows.append({
+            'Timestamp': now,
+            'ExcelRow': first(row, ['ExcelRow']),
+            'ConflictField': first(row, ['ConflictField']),
+            'ConflictValue': first(row, ['ConflictValue']),
+            'InputIdentifier': first(row, ['Identifier']),
+            'Target': target,
+            'HostName': host,
+            'ExpectedSerial': expected_serial,
+            'ExpectedMAC': expected_mac,
+            'ResolvedAddress': resolved,
+            'PingStatus': ping_status,
+            'DnsName': dns_name,
+            'ObservedHostName': observed_host,
+            'ObservedSerial': observed_serial,
+            'ObservedMACs': observed_macs,
+            'EvidenceStatus': evidence_status,
+            'RevisitRecommendation': recommendation,
+            'Notes': notes,
+        })
+
+with open(output, 'w', newline='', encoding='utf-8') as f:
+    writer = csv.DictWriter(f, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator='\n')
+    writer.writeheader()
+    writer.writerows(rows)
+print(f'Wrote {len(rows)} evidence row(s) to {output}')
+PY
+
+log "Evidence collection complete: $OUTPUT"
+if [[ "$PASS_THRU" -eq 1 ]]; then cat "$OUTPUT"; fi

--- a/survey/sas-collect-cybernet-evidence.sh
+++ b/survey/sas-collect-cybernet-evidence.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SysAdminSuite Cybernet remote evidence collector
 # Reads a survey manifest and collects hostname/serial/MAC evidence without mutating targets.
-# Transport strategy is conservative: ping, DNS, optional SSH command, and optional vendor/API hook later.
+# Uses bash/transport/sas-workstation-identity.sh when available.
 
 set -euo pipefail
 
@@ -12,6 +12,7 @@ SSH_USER=""
 SSH_KEY=""
 ALLOW_SSH=0
 PASS_THRU=0
+IDENTITY_ADAPTER=""
 
 usage() {
   cat <<'USAGE'
@@ -21,14 +22,15 @@ Usage:
   ./survey/sas-collect-cybernet-evidence.sh --manifest remote_survey_manifest.csv [options]
 
 Options:
-  --manifest PATH      Survey manifest CSV from deployment-audit/sas-build-survey-manifest.sh or survey/sas-survey-targets.sh
-  --output PATH        Output evidence CSV. Default: survey/output/cybernet_evidence.csv
-  --timeout SEC        Network timeout for lightweight probes. Default: 5
-  --ssh-user USER      Optional SSH username for Linux/SSH-capable targets
-  --ssh-key PATH       Optional SSH private key
-  --allow-ssh          Permit SSH read-only commands when HostName/Target is reachable
-  --pass-thru          Print evidence CSV after writing
-  -h, --help           Show help
+  --manifest PATH          Survey manifest CSV from deployment-audit/sas-build-survey-manifest.sh or survey/sas-survey-targets.sh
+  --output PATH            Output evidence CSV. Default: survey/output/cybernet_evidence.csv
+  --identity-adapter PATH  Optional workstation identity adapter. Defaults to bash/transport/sas-workstation-identity.sh when present
+  --timeout SEC            Network timeout for lightweight probes. Default: 5
+  --ssh-user USER          Optional SSH username for SSH-capable targets
+  --ssh-key PATH           Optional SSH private key
+  --allow-ssh              Permit SSH read-only commands through the identity adapter
+  --pass-thru              Print evidence CSV after writing
+  -h, --help               Show help
 
 Safety:
   - Read-only.
@@ -38,7 +40,7 @@ Safety:
 
 Output columns:
   Timestamp,ExcelRow,ConflictField,ConflictValue,InputIdentifier,Target,HostName,ExpectedSerial,ExpectedMAC,
-  ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,EvidenceStatus,RevisitRecommendation,Notes
+  ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,EvidenceStatus,RevisitRecommendation,Notes
 USAGE
 }
 
@@ -46,10 +48,15 @@ fail(){ printf '[cybernet-evidence] ERROR: %s\n' "$*" >&2; exit 1; }
 log(){ printf '[cybernet-evidence] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULT_ADAPTER="$REPO_ROOT/bash/transport/sas-workstation-identity.sh"
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --manifest) MANIFEST="${2:?missing value for --manifest}"; shift 2 ;;
     --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
+    --identity-adapter) IDENTITY_ADAPTER="${2:?missing value for --identity-adapter}"; shift 2 ;;
     --timeout) TIMEOUT_SEC="${2:?missing value for --timeout}"; shift 2 ;;
     --ssh-user) SSH_USER="${2:?missing value for --ssh-user}"; shift 2 ;;
     --ssh-key) SSH_KEY="${2:?missing value for --ssh-key}"; shift 2 ;;
@@ -64,129 +71,90 @@ done
 [[ -f "$MANIFEST" ]] || fail "Manifest not found: $MANIFEST"
 [[ "$TIMEOUT_SEC" =~ ^[0-9]+$ && "$TIMEOUT_SEC" -ge 1 ]] || fail "--timeout must be a positive integer"
 has_cmd python3 || fail "python3 is required"
+[[ -z "$IDENTITY_ADAPTER" && -f "$DEFAULT_ADAPTER" ]] && IDENTITY_ADAPTER="$DEFAULT_ADAPTER"
+if [[ -n "$IDENTITY_ADAPTER" && ! -f "$IDENTITY_ADAPTER" ]]; then fail "identity adapter not found: $IDENTITY_ADAPTER"; fi
 mkdir -p "$(dirname "$OUTPUT")"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+TARGETS_FILE="$TMP_DIR/cybernet_targets.txt"
+IDENTITY_CSV="$TMP_DIR/workstation_identity.csv"
 
-python3 - "$MANIFEST" "$OUTPUT" "$TIMEOUT_SEC" "$ALLOW_SSH" "$SSH_USER" "$SSH_KEY" <<'PY'
-import csv
-import datetime as dt
-import os
-import platform
-import re
-import socket
-import subprocess
-import sys
-
-manifest, output, timeout_raw, allow_ssh_raw, ssh_user, ssh_key = sys.argv[1:7]
-timeout = int(timeout_raw)
-allow_ssh = allow_ssh_raw == '1'
-
-fields = [
-    'Timestamp','ExcelRow','ConflictField','ConflictValue','InputIdentifier','Target','HostName','ExpectedSerial','ExpectedMAC',
-    'ResolvedAddress','PingStatus','DnsName','ObservedHostName','ObservedSerial','ObservedMACs','EvidenceStatus','RevisitRecommendation','Notes'
-]
-
+python3 - "$MANIFEST" "$TARGETS_FILE" <<'PY'
+import csv, sys
+manifest, out = sys.argv[1:3]
 def first(row, names):
-    lower = {k.lower(): v for k, v in row.items()}
+    lower={k.lower():v for k,v in row.items()}
     for name in names:
-        v = lower.get(name.lower())
-        if v and str(v).strip():
-            return str(v).strip()
+        v=lower.get(name.lower())
+        if v and str(v).strip(): return str(v).strip()
     return ''
-
-def norm_mac(v):
-    hx = re.sub(r'[^0-9A-Fa-f]', '', v or '').upper()
-    return ':'.join(hx[i:i+2] for i in range(0, 12, 2)) if len(hx) == 12 else (v or '').strip().upper()
-
-def resolve_host(target):
-    if not target:
-        return '', ''
-    try:
-        address = socket.gethostbyname(target)
-    except Exception:
-        return '', ''
-    try:
-        dns_name = socket.getfqdn(address)
-    except Exception:
-        dns_name = ''
-    return address, dns_name
-
-def ping(address_or_host):
-    if not address_or_host:
-        return 'NoTarget'
-    count_flag = '-n' if platform.system().lower().startswith('win') else '-c'
-    timeout_flag = '-w' if platform.system().lower().startswith('win') else '-W'
-    cmd = ['ping', count_flag, '1', timeout_flag, str(timeout), address_or_host]
-    try:
-        result = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout + 2)
-        return 'Reachable' if result.returncode == 0 else 'NoPing'
-    except Exception:
-        return 'PingFailed'
-
-def run_ssh(host):
-    if not allow_ssh or not host:
-        return '', '', 'SSHDisabled'
-    if not ssh_user:
-        return '', '', 'SSHUserMissing'
-    if not shutil_which('ssh'):
-        return '', '', 'SSHNotInstalled'
-    dest = f'{ssh_user}@{host}'
-    cmd = ['ssh', '-o', 'BatchMode=yes', '-o', f'ConnectTimeout={timeout}']
-    if ssh_key:
-        cmd.extend(['-i', ssh_key])
-    script = "hostname; (cat /sys/class/dmi/id/product_serial 2>/dev/null || dmidecode -s system-serial-number 2>/dev/null || true); (ip link 2>/dev/null | awk '/link\/ether/ {print $2}' | paste -sd ';' - || true)"
-    cmd.extend([dest, script])
-    try:
-        result = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout + 5)
-        if result.returncode != 0:
-            return '', '', 'SSHFailed:' + (result.stderr.strip()[:120] if result.stderr else str(result.returncode))
-        lines = [x.strip() for x in result.stdout.splitlines()]
-        observed_host = lines[0] if len(lines) > 0 else ''
-        observed_serial = lines[1] if len(lines) > 1 else ''
-        observed_macs = lines[2] if len(lines) > 2 else ''
-        return observed_host, observed_serial, observed_macs
-    except Exception as exc:
-        return '', '', 'SSHError:' + str(exc)[:120]
-
-def shutil_which(name):
-    from shutil import which
-    return which(name)
-
-def verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, notes):
-    evidence = []
-    if expected_serial and observed_serial:
-        evidence.append('SerialMatch' if expected_serial.upper() == observed_serial.strip().upper() else 'SerialConflict')
-    if expected_mac and observed_macs:
-        normalized = [norm_mac(x) for x in re.split(r'[;\s,]+', observed_macs) if x.strip()]
-        evidence.append('MACMatch' if norm_mac(expected_mac) in normalized else 'MACConflict')
-    if any(x.endswith('Conflict') for x in evidence):
-        return 'Conflict', 'Physical revisit or privileged remote review justified'
-    if evidence and all(x.endswith('Match') for x in evidence):
-        return 'Confirmed', 'No revisit needed based on collected evidence'
-    if ping_status == 'Reachable':
-        return 'ReachableNeedsPrivilegedSurvey', 'Try approved remote management path before revisit'
-    return 'Unreachable', 'Revisit justified only after network/remote-management path is exhausted'
-
-rows = []
+seen=[]
 with open(manifest, newline='', encoding='utf-8-sig') as f:
-    reader = csv.DictReader(f)
-    for row in reader:
-        now = dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        target = first(row, ['Target','HostName','Identifier','SurveyTargetHint'])
-        host = first(row, ['HostName'])
-        expected_serial = first(row, ['Serial','ExpectedSerial','Cybernet Serial'])
-        expected_mac = norm_mac(first(row, ['MACAddress','ExpectedMAC','Cybernet MAC']))
-        lookup = host or target
-        resolved, dns_name = resolve_host(lookup)
-        ping_status = ping(resolved or lookup)
-        observed_host, observed_serial, observed_macs_or_note = run_ssh(lookup)
-        notes = ''
-        observed_macs = observed_macs_or_note
-        if observed_macs_or_note.startswith('SSH'):
-            notes = observed_macs_or_note
-            observed_macs = ''
-        evidence_status, recommendation = verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, notes)
+    for row in csv.DictReader(f):
+        target=first(row, ['HostName','Target','Identifier','SurveyTargetHint'])
+        if target and target not in seen: seen.append(target)
+with open(out, 'w', encoding='utf-8') as f:
+    for target in seen: f.write(target+'\n')
+PY
+
+if [[ -n "$IDENTITY_ADAPTER" ]]; then
+  adapter_args=("$IDENTITY_ADAPTER" --targets-file "$TARGETS_FILE" --output "$IDENTITY_CSV" --timeout "$TIMEOUT_SEC")
+  if [[ "$ALLOW_SSH" -eq 1 ]]; then
+    adapter_args+=(--allow-ssh)
+    [[ -n "$SSH_USER" ]] && adapter_args+=(--ssh-user "$SSH_USER")
+    [[ -n "$SSH_KEY" ]] && adapter_args+=(--ssh-key "$SSH_KEY")
+  fi
+  bash "${adapter_args[@]}" >/dev/null
+else
+  printf 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes\n' > "$IDENTITY_CSV"
+fi
+
+python3 - "$MANIFEST" "$OUTPUT" "$IDENTITY_CSV" <<'PY'
+import csv, datetime as dt, re, sys
+manifest, output, identity_csv = sys.argv[1:4]
+fields = ['Timestamp','ExcelRow','ConflictField','ConflictValue','InputIdentifier','Target','HostName','ExpectedSerial','ExpectedMAC','ResolvedAddress','PingStatus','DnsName','ObservedHostName','ObservedSerial','ObservedMACs','TransportUsed','EvidenceStatus','RevisitRecommendation','Notes']
+def first(row, names):
+    lower={k.lower():v for k,v in row.items()}
+    for name in names:
+        v=lower.get(name.lower())
+        if v and str(v).strip(): return str(v).strip()
+    return ''
+def norm_mac(v):
+    hx=re.sub(r'[^0-9A-Fa-f]','',v or '').upper()
+    return ':'.join(hx[i:i+2] for i in range(0,12,2)) if len(hx)==12 else (v or '').strip().upper()
+def norm_serial(v): return re.sub(r'\s+','',(v or '').strip()).upper()
+def verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, identity_status):
+    evidence=[]
+    if expected_serial and observed_serial:
+        evidence.append('SerialMatch' if norm_serial(expected_serial)==norm_serial(observed_serial) else 'SerialConflict')
+    if expected_mac and observed_macs:
+        observed=[norm_mac(x) for x in re.split(r'[;\s,]+', observed_macs) if x.strip()]
+        evidence.append('MACMatch' if norm_mac(expected_mac) in observed else 'MACConflict')
+    if any(x.endswith('Conflict') for x in evidence): return 'Conflict','Physical revisit or privileged remote review justified'
+    if evidence and all(x.endswith('Match') for x in evidence): return 'Confirmed','No revisit needed based on collected evidence'
+    if identity_status == 'IdentityCollected': return 'IdentityCollectedNeedsComparisonData','Collected identity, but tracker lacks expected serial/MAC for hard comparison'
+    if ping_status == 'Reachable': return 'ReachableNeedsPrivilegedSurvey','Try approved identity transport before revisit'
+    return 'Unreachable','Revisit justified only after network/remote-management path is exhausted'
+identity={}
+with open(identity_csv, newline='', encoding='utf-8-sig') as f:
+    for row in csv.DictReader(f):
+        target=first(row, ['Target'])
+        if target: identity[target.upper()]=row
+rows=[]
+with open(manifest, newline='', encoding='utf-8-sig') as f:
+    for row in csv.DictReader(f):
+        target=first(row, ['HostName','Target','Identifier','SurveyTargetHint'])
+        host=first(row, ['HostName'])
+        expected_serial=first(row, ['Serial','ExpectedSerial','Cybernet Serial'])
+        expected_mac=norm_mac(first(row, ['MACAddress','ExpectedMAC','Cybernet MAC']))
+        ident=identity.get((host or target).upper(), identity.get(target.upper(), {}))
+        ping_status=first(ident, ['PingStatus'])
+        identity_status=first(ident, ['IdentityStatus'])
+        observed_serial=first(ident, ['ObservedSerial'])
+        observed_macs=first(ident, ['ObservedMACs'])
+        evidence_status,recommendation=verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, identity_status)
         rows.append({
-            'Timestamp': now,
+            'Timestamp': dt.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             'ExcelRow': first(row, ['ExcelRow']),
             'ConflictField': first(row, ['ConflictField']),
             'ConflictValue': first(row, ['ConflictValue']),
@@ -195,21 +163,20 @@ with open(manifest, newline='', encoding='utf-8-sig') as f:
             'HostName': host,
             'ExpectedSerial': expected_serial,
             'ExpectedMAC': expected_mac,
-            'ResolvedAddress': resolved,
-            'PingStatus': ping_status,
-            'DnsName': dns_name,
-            'ObservedHostName': observed_host,
+            'ResolvedAddress': first(ident, ['ResolvedAddress']),
+            'PingStatus': ping_status or 'NotChecked',
+            'DnsName': first(ident, ['DnsName']),
+            'ObservedHostName': first(ident, ['ObservedHostName']),
             'ObservedSerial': observed_serial,
             'ObservedMACs': observed_macs,
+            'TransportUsed': first(ident, ['TransportUsed']),
             'EvidenceStatus': evidence_status,
             'RevisitRecommendation': recommendation,
-            'Notes': notes,
+            'Notes': first(ident, ['Notes']),
         })
-
 with open(output, 'w', newline='', encoding='utf-8') as f:
-    writer = csv.DictWriter(f, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator='\n')
-    writer.writeheader()
-    writer.writerows(rows)
+    writer=csv.DictWriter(f, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator='\n')
+    writer.writeheader(); writer.writerows(rows)
 print(f'Wrote {len(rows)} evidence row(s) to {output}')
 PY
 


### PR DESCRIPTION
## **User description**
## Summary

- Adds Bash-first deployment audit tooling for deployed-only duplicate logic.
- Adds survey request, evidence collection, and final revisit verdict workflow.
- Adds Bash transport tools for network preflight, printer probe, workstation identity, optional WMI identity, and SMB read-only recon.
- Documents risks, known limitations, data hygiene, and PowerShell legacy policy.
- Adds contract tests for audit and transport scripts.

## Safety posture

- Read-only by default.
- No live tracker files committed.
- No SMB staging, no scheduled tasks, no remote mutation.
- SSH/WMI/SMB privileged paths require explicit opt-in.

## Branch

audit-deployment-2026-05-02


___

## **CodeAnt-AI Description**
**Add Bash-based deployment audit, evidence collection, and read-only transport tools**

### What Changed
- Added Bash tools to check host reachability, probe printer identity, collect workstation identity, run optional WMI and SMB read-only checks, and gather remote Cybernet evidence
- Added a survey manifest builder and final evidence reconciler so duplicate deployment cases can move from audit findings to a clear revisit decision
- Added contract tests and docs that define the expected CSV outputs, read-only limits, and when stronger remote access must be enabled explicitly
- Added clearer status results when identity cannot be collected, so missing access is reported as a blocked or incomplete check instead of a false match

### Impact
`✅ Fewer unnecessary onsite revisits`
`✅ Clearer remote evidence for duplicate deployments`
`✅ Safer read-only checks before physical follow-up`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=8rvTt-j9Mv53YNoUwbm2wDeP1PJ_tSv-oDf6Fs2Ibl8&org=EndeavorEverlasting)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
