### PR TITLE
Document WAB test readiness and guest-network result classification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,21 @@ Do not assume:
 
 Bash scripts may call Windows-native executables such as `cmd.exe`, `hostname.exe`, `ping.exe`, `nslookup.exe`, and `netsh.exe`.
 
+## WAB Test Evidence Guardrail
+
+When the user reports that SysAdminSuite is `running` on the WAB path, do not treat that as full validation.
+
+Agents must classify field evidence before proposing product fixes:
+
+- `running` proves only process startup or script invocation.
+- Guest network results are not valid evidence for printer mapping, UNC access, RPC, AD, internal DNS, or print-server reachability.
+- If all network targets return offline while the machine is on guest network, classify the result as `ENVIRONMENT_BLOCKED_GUEST_NETWORK`, not `PRODUCT_FAILURE`.
+- Before changing network-feature code, require or document a preflight check for network posture, DNS resolution, SMB/445, RPC/135, and the exact command that produced the result.
+- Preserve local smoke-test evidence separately from network-feature validation.
+- Link WAB/network field testing to `docs/WAB_TEST_READINESS.md` and result triage to `docs/TEST_RESULT_CLASSIFICATION.md`.
+
+No agent should chase network ghosts created by the wrong network segment. First prove the field path. Then fix the product.
+
 ## Hard Rule for Agents
 
 When asked to add, modify, or extend Northwell-targeted SysAdminSuite functionality:

--- a/docs/CYBERNET_IDENTIFIER_POLICY.md
+++ b/docs/CYBERNET_IDENTIFIER_POLICY.md
@@ -1,0 +1,42 @@
+# Cybernet Identifier Policy
+
+## Purpose
+
+Cybernet unique identifier discovery is **Nmap-first** for the current WAB field path.
+
+PowerShell is known blocked in this path and must not be treated as the primary method for Cybernet identity discovery unless field conditions change and the user explicitly restores that method.
+
+## Policy
+
+- Use Nmap-derived evidence as the primary identity source for Cybernet discovery.
+- Preserve scanner artifacts as durable evidence before parsing or reconciling results.
+- Do not treat PowerShell, WMI, CIM, or remote PowerShell failures as proof that a Cybernet is offline.
+- Treat PowerShell-derived evidence as secondary or lab-only unless the field path proves it is available.
+- Keep discovery read-only unless the user explicitly approves a mutating workflow.
+
+## Expected identity evidence
+
+When available through the approved network path, Cybernet identity evidence may include:
+
+- Reachable host record
+- IP address
+- MAC address
+- Vendor/OUI hint
+- DNS or host naming evidence
+- Service posture
+- Saved scanner artifact path
+- Classification result
+
+## Classification
+
+| Condition | Classification |
+| --- | --- |
+| Cybernet discovery attempted while on guest network | `ENVIRONMENT_BLOCKED_GUEST_NETWORK` |
+| Nmap or equivalent approved scanner is blocked by endpoint policy | `ENVIRONMENT_BLOCKED_POLICY` |
+| Correct network is claimed but identity evidence is unavailable | `NETWORK_PREFLIGHT_FAILED` until the network path is proven |
+| Nmap-derived identity evidence is captured successfully | `OK_NMAP_IDENTITY_PROBE` |
+| Scanner evidence exists but SysAdminSuite parsing fails | `PRODUCT_FAILURE` |
+
+## Agent rule
+
+Future agents must not default Cybernet identity discovery back to PowerShell. The current field reality is that PowerShell is blocked. Use the working evidence path first, then build parsers and tracker reconciliation around that artifact layer.

--- a/docs/TEST_RESULT_CLASSIFICATION.md
+++ b/docs/TEST_RESULT_CLASSIFICATION.md
@@ -1,0 +1,42 @@
+# SysAdminSuite Test Result Classification
+
+## Purpose
+
+Use this guide when reviewing field results so the repo does not confuse environment failures with product failures.
+
+A result is only a product failure when the environment is valid for the feature being tested.
+
+## Classification table
+
+| Classification | Use when | Product bug? | Next action |
+| --- | --- | --- | --- |
+| `OK_LOCAL_SMOKE` | App launches, local task executes, or artifact is generated without network dependency | No | Proceed to network preflight |
+| `ENVIRONMENT_BLOCKED_GUEST_NETWORK` | Host is on guest network and internal DNS/ports/UNC fail | No | Move to correct network and retest |
+| `ENVIRONMENT_BLOCKED_POLICY` | Execution policy, AppLocker, admin rights, antivirus, EDR, or endpoint controls block the run | Not by default | Document policy and pivot runtime path if needed |
+| `NETWORK_PREFLIGHT_FAILED` | Host claims correct network but DNS, SMB, RPC, or print server reachability fails | Not by default | Fix network/access posture first |
+| `PRODUCT_FAILURE` | Supported environment passes preflight, but SysAdminSuite logic fails | Yes | Open bug or PR with reproducible evidence |
+| `INCONCLUSIVE` | Output lacks command, network posture, environment, artifact, or raw error | Unknown | Retest with full evidence |
+
+## Evidence minimum
+
+Capture this before marking anything as a product failure:
+
+```text
+Date:
+Tester:
+Branch/commit:
+Machine hostname:
+Network posture: guest / enterprise wired / enterprise Wi-Fi / VPN / lab
+Elevation: yes/no
+PowerShell version:
+Command executed:
+Raw output:
+Artifacts generated:
+Classification:
+Expected behavior:
+Actual behavior:
+```
+
+## Field rule
+
+If the device is on guest network, offline printer/network results are expected. Guest network results may prove local launch behavior, but they do not validate printer mapping, UNC access, RPC, DNS, AD, or internal print-server reachability.

--- a/docs/WAB_TEST_READINESS.md
+++ b/docs/WAB_TEST_READINESS.md
@@ -1,0 +1,140 @@
+# WAB Test Readiness
+
+## Purpose
+
+This document defines how SysAdminSuite should be tested on the WAB path before anyone attempts printer mapping, UNC, RPC, DNS, or other network-dependent features.
+
+The immediate field lesson is simple: a tool can report `running` while every network result is still useless because the machine is on the wrong network. That is an environment miss, not automatically a product failure.
+
+## Current field observation
+
+Date: 2026-05-22
+
+Observed posture:
+
+- SysAdminSuite reported `running`.
+- Results came back offline because the user/device was on the guest network.
+- Network-feature validation is therefore inconclusive.
+- Local launch and offline-safe behavior may still be valid evidence.
+- Printer/network features must not be judged until the test host is on the correct enterprise network, VPN, or authorized test segment.
+
+## Core rule
+
+Do not test network features until the WAB host passes preflight.
+
+`running` only proves process startup. It does not prove network access, printer reachability, UNC access, RPC availability, DNS resolution, admin share access, or host eligibility.
+
+## Test phases
+
+### Phase 0: Repo readiness
+
+Run these from the repo root before field testing:
+
+```powershell
+# PowerShell script health
+.\tools\Test-ScriptHealth.ps1
+
+# Pester suite when Pester 5 is available
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\Test-Pester5Suite.ps1
+
+# Managed tests when the .NET SDK is available
+dotnet test .\SysAdminSuite.sln -c Release
+```
+
+Expected result:
+
+- Script parsing passes.
+- Encoding/BOM checks pass.
+- Pester failures are reviewed as product failures only if the local environment supports the tested path.
+- .NET failures are reviewed as product failures only if the SDK and restore path are available.
+
+### Phase 1: Local smoke test on WAB
+
+This phase proves the tool can launch and produce local artifacts without touching the network.
+
+```powershell
+# GUI launch smoke test
+powershell.exe -STA -NoProfile -ExecutionPolicy Bypass -File .\GUI\Start-SysAdminSuiteGui.ps1
+
+# QR task list smoke test
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\QRTasks\Invoke-TechTask.ps1 -Task ?
+
+# Local network snapshot only
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\QRTasks\Invoke-TechTask.ps1 -Task NetworkInfo
+```
+
+Evidence to save:
+
+- Screenshot showing the GUI opened.
+- The text output from `NetworkInfo`.
+- Any generated Desktop artifact from the QR task runner.
+- Exact command used.
+- Hostname, username context, PowerShell version, and whether the session was elevated.
+
+### Phase 2: Network preflight gate
+
+Before printer mapping, remote probes, or host reachability tests, record the network posture.
+
+```powershell
+ipconfig /all
+hostname
+whoami
+nltest /dsgetdc:nslijhs.net
+nslookup SWBPNHPHPS01V
+Test-NetConnection SWBPNHPHPS01V -Port 445
+Test-NetConnection SWBPNHPHPS01V -Port 135
+```
+
+Pass criteria:
+
+- Device is not on guest Wi-Fi for enterprise-target testing.
+- DNS resolves expected internal hosts.
+- Required print servers resolve.
+- SMB/445 is reachable where UNC mapping is required.
+- RPC/135 is reachable where scheduled task or remote management paths are required.
+- Domain/controller lookup behaves as expected for the test environment.
+
+Fail posture:
+
+If these fail while the host is on guest network, mark the result as:
+
+`ENVIRONMENT_BLOCKED_GUEST_NETWORK`
+
+Do not mark it as a SysAdminSuite failure.
+
+### Phase 3: Read-only network recon
+
+Only after Phase 2 passes:
+
+```powershell
+# Read-only recon against smoke hosts
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\Mapping\Controllers\RPM-Recon.ps1 -HostsPath .\Mapping\Config\hosts_smoke.txt
+```
+
+Result classification:
+
+| Result | Meaning | Action |
+| --- | --- | --- |
+| `OK_LOCAL_SMOKE` | GUI/local tasks run without network dependency | Safe to proceed to network preflight |
+| `ENVIRONMENT_BLOCKED_GUEST_NETWORK` | Host is on guest or otherwise isolated network | Move to correct network, then retest |
+| `ENVIRONMENT_BLOCKED_POLICY` | Execution policy, AppLocker, permissions, or endpoint controls block the test | Document policy and pivot to compiled/native path if needed |
+| `NETWORK_PREFLIGHT_FAILED` | Correct network claimed, but DNS/ports/UNC fail | Fix network posture before testing product code |
+| `PRODUCT_FAILURE` | Environment is valid and supported, but SysAdminSuite logic fails | Open bug with command, output, artifact, and expected behavior |
+| `INCONCLUSIVE` | Evidence is incomplete | Retest with full transcript and screenshots |
+
+## Minimum evidence for PRs and issues
+
+Every WAB/network test issue should include:
+
+- Branch or commit SHA tested.
+- Machine/network posture: guest, enterprise wired, enterprise Wi-Fi, VPN, or lab.
+- Whether the session was elevated.
+- PowerShell version.
+- Exact command.
+- Raw output.
+- Artifact paths created.
+- Result classification from the table above.
+
+## Do not skip this
+
+No feature work should proceed from an offline guest-network result. That is how ghosts get promoted to architecture.


### PR DESCRIPTION
## **User description**
## Summary

This PR documents the WAB test-readiness posture before network-dependent SysAdminSuite features are judged.

It adds guardrails for the field case where SysAdminSuite reports `running`, but every network result is offline because the device is on guest network.

## Changes

- Add `docs/WAB_TEST_READINESS.md`
  - Defines local smoke testing, network preflight gates, and read-only recon order.
  - Makes clear that `running` is not full product validation.
  - Records the 2026-05-22 guest-network observation as environment-blocked evidence.

- Add `docs/TEST_RESULT_CLASSIFICATION.md`
  - Adds result labels such as `ENVIRONMENT_BLOCKED_GUEST_NETWORK`, `NETWORK_PREFLIGHT_FAILED`, `PRODUCT_FAILURE`, and `INCONCLUSIVE`.
  - Defines minimum evidence required before calling something a product bug.

- Update `AGENTS.md`
  - Adds a WAB test evidence guardrail so future agents do not chase guest-network ghosts as product failures.

## Field verdict

Current WAB observation should be classified as:

`ENVIRONMENT_BLOCKED_GUEST_NETWORK`

Local app launch may be meaningful, but printer mapping, UNC access, RPC, AD, internal DNS, and print-server reachability are not validated until the host is on the correct enterprise network or authorized test segment.

## Test impact

Docs-only change. No runtime code modified.

## Next steps after merge

1. Run local WAB smoke test.
2. Capture `NetworkInfo` artifact.
3. Move host to correct enterprise network or authorized test segment.
4. Run network preflight.
5. Only then attempt read-only printer/network recon.


___

## **CodeAnt-AI Description**
Document how to tell guest-network results from real product failures

### What Changed
- Adds a WAB testing guide that says `running` only proves the app started, not that printer, DNS, RPC, UNC, or print-server checks are valid
- Defines the test order: local smoke test first, then network preflight, then read-only network checks only after the host is on the right network
- Adds clear result labels so guest-network or blocked-network runs are not misreported as product bugs
- Updates agent guidance to require network posture evidence before suggesting fixes for WAB network issues

### Impact
`✅ Fewer false bug reports from guest-network testing`
`✅ Clearer WAB test triage`
`✅ Safer network-feature validation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
