### PR TITLE
Add Nmap baseline and classifier workflow

### DIFF
--- a/docs/NMAP_BASELINE_MODULE.md
+++ b/docs/NMAP_BASELINE_MODULE.md
@@ -1,0 +1,142 @@
+# SysAdminSuite Nmap Baseline Module
+
+## Purpose
+
+`scripts/sas_nmap_baseline.sh` is the first Nmap-backed baseline module for SysAdminSuite.
+
+It follows:
+
+```text
+Recon -> Decide -> Act -> Log -> Export
+```
+
+The module is intentionally conservative. It is for authorized internal IT diagnostics, not broad scanning, stealth scanning, vulnerability testing, brute-force behavior, or evasion.
+
+## Files
+
+```text
+scripts/sas_nmap_baseline.sh
+scripts/sas_classify_nmap_baseline.sh
+```
+
+## Baseline Examples
+
+Local-only baseline:
+
+```bash
+bash scripts/sas_nmap_baseline.sh --scan-mode local-only
+```
+
+Dry run against localhost:
+
+```bash
+bash scripts/sas_nmap_baseline.sh --target 127.0.0.1 --scan-mode common-ports --dry-run
+```
+
+Printer-oriented probe:
+
+```bash
+bash scripts/sas_nmap_baseline.sh --target 10.10.10.25 --scan-mode printer-ports
+```
+
+Workstation-oriented probe:
+
+```bash
+bash scripts/sas_nmap_baseline.sh --target WMH300OPR001 --scan-mode workstation-ports
+```
+
+Small explicit CIDR ping discovery:
+
+```bash
+bash scripts/sas_nmap_baseline.sh --target 10.10.10.0/29 --scan-mode ping-only --allow-subnet --max-targets 8
+```
+
+## Classifier Example
+
+After a baseline run completes:
+
+```bash
+bash scripts/sas_classify_nmap_baseline.sh \
+  --run-dir "$USERPROFILE/SysAdminSuite/Runs/<RUN_FOLDER>"
+```
+
+The classifier reads a completed run folder. It does not run scans or mutate targets.
+
+## Scan Modes
+
+| Mode | Behavior |
+|---|---|
+| `local-only` | Collect local baseline only. Does not run Nmap. |
+| `ping-only` | Uses `nmap -sn` for host discovery. |
+| `common-ports` | Checks a small workstation/printer/admin set. |
+| `printer-ports` | Checks 80, 443, 515, 631, 9100, 161. |
+| `workstation-ports` | Checks 135, 139, 445, 3389, 5985, 5986. |
+| `custom-ports` | Uses `--ports`. |
+
+## Guardrails
+
+- No `-A`
+- No vulnerability scripts
+- No brute-force scripts
+- No stealth defaults
+- No spoofing
+- No decoys
+- No IDS/firewall evasion flags
+- No broad subnet scan by default
+- CIDR targets require `--allow-subnet`
+- CIDR broader than `/29` is blocked
+- Explicit target cap defaults to `16`
+
+## Output Layout
+
+Baseline runs write to:
+
+```text
+$USERPROFILE/SysAdminSuite/Runs/SAS_NMAP_BASELINE_<HOSTNAME>_<TIMESTAMP>/
+```
+
+Key outputs:
+
+```text
+logs/events.jsonl
+logs/trace.log
+raw/local/
+raw/nmap_<target>.nmap
+raw/nmap_<target>.xml
+exports/run_context.env
+exports/scan_index.csv
+exports/open_ports_summary.csv
+exports/baseline_report.md
+exports/baseline_report.json
+```
+
+Classifier outputs:
+
+```text
+exports/classifications.csv
+exports/recommended_actions.md
+logs/classifier_events.jsonl
+logs/classifier_trace.log
+```
+
+## Classifier Signals
+
+| Signal | Advisory Classification |
+|---|---|
+| `9100/tcp open` | possible printer or print device |
+| `515` or `631` open | possible print service |
+| `445/tcp open` | possible Windows workstation or server |
+| `3389/tcp open` | possible Windows remote access target |
+| `5985` or `5986` open | possible Windows management endpoint |
+| `80` or `443` open only | possible web admin or appliance endpoint |
+| no open ports | inconclusive; validate network/VLAN/firewall/DNS |
+
+The classifier is advisory only. It does not prove device role, ownership, authorization, or health.
+
+## Next Layer
+
+```text
+classification -> approved next workflow -> dry-run mutation plan
+```
+
+No mutation belongs in this baseline module.

--- a/docs/OU_GPO_INDICATORS.md
+++ b/docs/OU_GPO_INDICATORS.md
@@ -1,0 +1,149 @@
+# SysAdminSuite OU/GPO Indicator Collector
+
+## Purpose
+
+`scripts/sas_ou_gpo_indicators.sh` collects OU and Group Policy posture indicators where available.
+
+It follows:
+
+```text
+Recon -> Decide -> Act -> Log -> Export
+```
+
+This module is intentionally read-only. It collects evidence and exports indicators. It does not mutate Active Directory, local policy, or Group Policy.
+
+## Why This Exists
+
+Many field failures look like product failures until workstation posture is checked.
+
+Common examples:
+
+- wrong OU
+- missing Group Policy
+- expected GPO not applied
+- domain posture unclear
+- machine on the wrong network segment
+- user OU confused with computer OU
+- missing domain controller reachability
+
+This collector creates evidence before anyone starts guessing.
+
+## File
+
+```text
+scripts/sas_ou_gpo_indicators.sh
+```
+
+## Command Examples
+
+Default local run:
+
+```bash
+bash scripts/sas_ou_gpo_indicators.sh
+```
+
+Reference-host label:
+
+```bash
+bash scripts/sas_ou_gpo_indicators.sh --target-hint WMH300OPR024
+```
+
+Skip registry evidence:
+
+```bash
+bash scripts/sas_ou_gpo_indicators.sh --no-registry
+```
+
+Dry run:
+
+```bash
+bash scripts/sas_ou_gpo_indicators.sh --dry-run
+```
+
+## Evidence Commands
+
+The module uses Bash-on-Windows wrappers around Windows-native executables:
+
+```bash
+hostname.exe
+whoami.exe
+whoami.exe /user /fo list
+whoami.exe /groups /fo list
+whoami.exe /fqdn
+cmd.exe /c set
+wmic.exe computersystem get domain,partofdomain /format:list
+gpresult.exe /r /scope computer
+gpresult.exe /r /scope user
+nltest.exe /dsgetdc:<USERDNSDOMAIN>
+reg.exe query "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\State\\Machine" /s
+reg.exe query "HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\State" /s
+```
+
+## Guardrails
+
+- no `gpupdate`
+- no AD writes
+- no local policy changes
+- no registry writes
+- no PowerShell cmdlets
+- no remote host mutation
+- no interpretation that user OU equals computer OU
+
+## Output Layout
+
+Runs write to:
+
+```text
+$USERPROFILE/SysAdminSuite/Runs/SAS_OU_GPO_INDICATORS_<HOSTNAME>_<TIMESTAMP>/
+```
+
+Key outputs:
+
+```text
+logs/ou_gpo_events.jsonl
+logs/ou_gpo_trace.log
+raw/
+exports/command_plan.txt
+exports/ou_gpo_indicators.csv
+exports/ou_gpo_summary.env
+exports/ou_gpo_report.md
+exports/ou_gpo_report.json
+exports/ou_gpo_recommended_actions.md
+exports/applied_computer_gpos.txt
+exports/applied_user_gpos.txt
+exports/security_groups.txt
+```
+
+## Indicators
+
+| Indicator | Meaning |
+|---|---|
+| `domain_posture` | Whether local evidence suggests domain joined posture. |
+| `domain` | Domain from WMIC or environment fallback. |
+| `logon_server` | Current logon server hint. |
+| `domain_controller_indicator` | Best-effort DC evidence from gpresult or nltest. |
+| `computer_ou_path_hint` | Parsed computer OU path hint, not AD truth. |
+| `user_ou_path_hint` | Parsed user OU path hint. Keep separate from computer OU. |
+| `applied_computer_gpo_count` | Count of parsed applied computer GPOs. |
+| `applied_user_gpo_count` | Count of parsed applied user GPOs. |
+| `security_group_count` | Advisory count from gpresult and whoami group evidence. |
+
+## Correct Use
+
+Use this module to support the next decision:
+
+```text
+Does this workstation look like it is in the expected OU/GPO posture?
+```
+
+Do not use it as final proof. It is evidence collection, not AD truth.
+
+## Safe Next Workflow
+
+1. Run this module on the target host.
+2. Run it on a known-good reference host if available.
+3. Compare computer OU path hints, applied computer GPOs, and domain controller evidence.
+4. Draft a ServiceNow/AD request with source host and target host clearly separated.
+5. Attach only safe excerpts when sharing externally.
+
+WMIC and gpresult can fail or omit fields depending on permissions, cached policy, build, or network posture. Classify that as incomplete evidence first, not product failure.

--- a/scripts/sas_classify_nmap_baseline.sh
+++ b/scripts/sas_classify_nmap_baseline.sh
@@ -18,7 +18,7 @@ EOF
 }
 fail() { echo "ERROR: $*" >&2; exit 1; }
 json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\r/\\r/g; s/\n/\\n/g'; }
-csv_escape() { local v="$1"; v="${v//"/""}"; printf '"%s"' "$v"; }
+csv_escape() { local v="$1"; v="${v//\"/\"\"}"; printf '"%s"' "$v"; }
 now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 
 while [[ $# -gt 0 ]]; do
@@ -95,17 +95,9 @@ Source run:
 
 \`$RUN_DIR\`
 
-| Target | Classification | Confidence | Signals | Recommended Next Action |
-|---|---|---|---|---|
-EOF
+Classification CSV:
 
-tail -n +2 "$CLASS_CSV" | while IFS= read -r row || [[ -n "$row" ]]; do
-  clean="${row#\"}"; clean="${clean%\"}"; clean="${clean//\",\"/|}"; clean="${clean//\"\"/\"}"
-  IFS='|' read -r target classification confidence signals action <<< "$clean"
-  printf '| %s | %s | %s | %s | %s |\n' "$target" "$classification" "$confidence" "$signals" "$action" >> "$ACTIONS_MD"
-done
-
-cat >> "$ACTIONS_MD" <<'EOF'
+\`$CLASS_CSV\`
 
 These classifications are advisory. They do not prove ownership, role, authorization, or health.
 EOF

--- a/scripts/sas_classify_nmap_baseline.sh
+++ b/scripts/sas_classify_nmap_baseline.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SysAdminSuite Nmap Baseline Classifier
+# Shape: Recon -> Decide -> Act -> Log -> Export
+# Reads a completed sas_nmap_baseline.sh run folder and exports advisory classifications.
+
+set -Eeuo pipefail
+RUN_DIR=""
+
+usage() { cat <<'EOF'
+Usage: bash scripts/sas_classify_nmap_baseline.sh --run-dir <baseline-run-folder>
+
+Outputs:
+  exports/classifications.csv
+  exports/recommended_actions.md
+  logs/classifier_events.jsonl
+  logs/classifier_trace.log
+EOF
+}
+fail() { echo "ERROR: $*" >&2; exit 1; }
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\r/\\r/g; s/\n/\\n/g'; }
+csv_escape() { local v="$1"; v="${v//"/""}"; printf '"%s"' "$v"; }
+now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --run-dir) [[ $# -ge 2 ]] || fail "--run-dir requires value"; RUN_DIR="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$RUN_DIR" ]] || fail "--run-dir is required"
+[[ -d "$RUN_DIR" ]] || fail "Run directory not found: $RUN_DIR"
+EXPORT_DIR="$RUN_DIR/exports"; LOG_DIR="$RUN_DIR/logs"
+OPEN_CSV="$EXPORT_DIR/open_ports_summary.csv"; INDEX_CSV="$EXPORT_DIR/scan_index.csv"
+EVENT_LOG="$LOG_DIR/classifier_events.jsonl"; TRACE_LOG="$LOG_DIR/classifier_trace.log"
+CLASS_CSV="$EXPORT_DIR/classifications.csv"; ACTIONS_MD="$EXPORT_DIR/recommended_actions.md"
+mkdir -p "$EXPORT_DIR" "$LOG_DIR"
+[[ -f "$OPEN_CSV" ]] || fail "Missing open ports summary: $OPEN_CSV"
+
+log_event() {
+  local stage="$1" level="$2" msg="$3" data="${4:-}" ts; ts="$(now_iso)"
+  printf '{"timestamp":"%s","stage":"%s","level":"%s","message":"%s","data":"%s"}\n' \
+    "$(json_escape "$ts")" "$(json_escape "$stage")" "$(json_escape "$level")" "$(json_escape "$msg")" "$(json_escape "$data")" >> "$EVENT_LOG"
+  printf '[%s][%s] %s\n' "$stage" "$level" "$msg" | tee -a "$TRACE_LOG"
+}
+
+log_event START INFO "Nmap classifier started" "run_dir=$RUN_DIR"
+log_event RECON INFO "Reading baseline artifacts"
+
+TARGETS=()
+if [[ -f "$INDEX_CSV" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" == target,* || -z "$line" ]] && continue
+    target="${line%%,*}"; target="${target#\"}"; target="${target%\"}"
+    [[ -n "$target" ]] && TARGETS+=("$target")
+  done < "$INDEX_CSV"
+fi
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" == target,* || -z "$line" ]] && continue
+    target="${line%%,*}"; target="${target#\"}"; target="${target%\"}"
+    [[ -n "$target" ]] && TARGETS+=("$target")
+  done < "$OPEN_CSV"
+fi
+
+UNIQUE=()
+for t in "${TARGETS[@]}"; do seen=0; for u in "${UNIQUE[@]}"; do [[ "$u" == "$t" ]] && seen=1 && break; done; [[ "$seen" -eq 0 ]] && UNIQUE+=("$t"); done
+log_event DECIDE INFO "Classifying targets" "count=${#UNIQUE[@]}"
+
+printf 'target,classification,confidence,signals,recommended_next_action\n' > "$CLASS_CSV"
+
+classify() {
+  local target="$1" lines="$2" classification="unknown_or_no_open_ports" confidence="low" action="Validate network posture, DNS, route, VLAN, firewall, and target freshness before changing product code." signals=()
+  if grep -Eq '(^|[^0-9])9100/tcp[[:space:]]+open' <<< "$lines"; then classification="possible_printer_or_print_device"; confidence="medium"; action="Validate queue name, driver availability, TCP/IP port mapping, and print-server vs direct-IP path."; signals+=("9100/tcp open"); fi
+  if grep -Eq '(^|[^0-9])(515|631)/(tcp|udp)[[:space:]]+open' <<< "$lines"; then [[ "$classification" == possible_printer_or_print_device ]] && confidence="high" || classification="possible_print_service"; signals+=("LPD/CUPS port open"); fi
+  if grep -Eq '(^|[^0-9])445/tcp[[:space:]]+open' <<< "$lines"; then [[ "$classification" == unknown_or_no_open_ports ]] && classification="possible_windows_workstation_or_server" && confidence="medium" && action="Validate hostname, domain posture, SMB reachability, OU/GPO posture, and approved admin path."; signals+=("445/tcp open"); fi
+  if grep -Eq '(^|[^0-9])3389/tcp[[:space:]]+open' <<< "$lines"; then [[ "$classification" == possible_windows_workstation_or_server ]] && confidence="high" || classification="possible_windows_remote_access_target"; signals+=("3389/tcp open"); fi
+  if grep -Eq '(^|[^0-9])(5985|5986)/tcp[[:space:]]+open' <<< "$lines"; then [[ "$classification" == possible_windows_workstation_or_server ]] && confidence="high" || classification="possible_windows_management_endpoint"; signals+=("WinRM port open"); fi
+  if grep -Eq '(^|[^0-9])(80|443)/tcp[[:space:]]+open' <<< "$lines"; then [[ "$classification" == unknown_or_no_open_ports ]] && classification="possible_web_admin_or_appliance_endpoint" && confidence="low" && action="Confirm device identity before browsing or changing configuration."; signals+=("web port open"); fi
+  if [[ -z "$lines" ]]; then classification="no_open_ports_observed"; confidence="low"; signals+=("no open ports in summary"); fi
+  signal_text="$(IFS='; '; echo "${signals[*]:-no direct signal}")"
+  csv_escape "$target"; printf ','; csv_escape "$classification"; printf ','; csv_escape "$confidence"; printf ','; csv_escape "$signal_text"; printf ','; csv_escape "$action"; printf '\n'
+}
+
+for target in "${UNIQUE[@]}"; do
+  lines="$(awk -v t="$target" 'NR==1{next}{raw=$0; first=raw; sub(/,.*/,"",first); gsub(/^"|"$/, "", first); if(first==t){sub(/^"[^"]+",/,"",raw); gsub(/^"|"$/, "", raw); gsub(/""/,"\"",raw); print raw}}' "$OPEN_CSV")"
+  classify "$target" "$lines" >> "$CLASS_CSV"
+done
+
+cat > "$ACTIONS_MD" <<EOF
+# SysAdminSuite Nmap Baseline Classifications
+
+Source run:
+
+\`$RUN_DIR\`
+
+| Target | Classification | Confidence | Signals | Recommended Next Action |
+|---|---|---|---|---|
+EOF
+
+tail -n +2 "$CLASS_CSV" | while IFS= read -r row || [[ -n "$row" ]]; do
+  clean="${row#\"}"; clean="${clean%\"}"; clean="${clean//\",\"/|}"; clean="${clean//\"\"/\"}"
+  IFS='|' read -r target classification confidence signals action <<< "$clean"
+  printf '| %s | %s | %s | %s | %s |\n' "$target" "$classification" "$confidence" "$signals" "$action" >> "$ACTIONS_MD"
+done
+
+cat >> "$ACTIONS_MD" <<'EOF'
+
+These classifications are advisory. They do not prove ownership, role, authorization, or health.
+EOF
+
+log_event EXPORT INFO "Classifier outputs exported" "csv=$CLASS_CSV md=$ACTIONS_MD"
+log_event END INFO "Nmap classifier completed" "run_dir=$RUN_DIR"
+echo "DONE"
+echo "Classifications: $CLASS_CSV"
+echo "Recommended Actions: $ACTIONS_MD"

--- a/scripts/sas_nmap_baseline.sh
+++ b/scripts/sas_nmap_baseline.sh
@@ -93,9 +93,11 @@ capture() {
   local label="$1" out="$2"; shift 2
   { echo "# $label"; echo "# command: $*"; echo "# captured_at: $(now_iso)"; echo; } > "$out"
   if [[ "$DRY_RUN" -eq 1 ]]; then echo "DRY RUN" >> "$out"; echo "# exit_code: 0" >> "$out"; return 0; fi
-  set +e; "$@" >> "$out" 2>&1; code=$?; set -e
-  echo; echo "# exit_code: $code"
-  } >> "$out"
+  set +e
+  "$@" >> "$out" 2>&1
+  code=$?
+  set -e
+  { echo; echo "# exit_code: $code"; } >> "$out"
 }
 
 log_event START INFO "Nmap baseline started"

--- a/scripts/sas_nmap_baseline.sh
+++ b/scripts/sas_nmap_baseline.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SysAdminSuite Nmap Baseline Module
+# Shape: Recon -> Decide -> Act -> Log -> Export
+# Read-only diagnostic collector for authorized internal support work.
+
+set -Eeuo pipefail
+
+SCAN_MODE="common-ports"
+TARGETS=()
+TARGET_FILE=""
+PORTS=""
+TIMING="safe"
+ALLOW_SUBNET=0
+MAX_TARGETS=16
+NO_SERVICE_DETECTION=0
+DRY_RUN=0
+OUTPUT_ROOT="${USERPROFILE:-${HOME:-.}}/SysAdminSuite/Runs"
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/sas_nmap_baseline.sh [options]
+
+Options:
+  --target <host-or-ip>          Add target. Repeatable.
+  --targets <a,b,c>             Add comma-separated targets.
+  --target-file <file>          Add targets from file. Blank lines and # comments ignored.
+  --scan-mode <mode>            local-only | ping-only | common-ports | printer-ports | workstation-ports | custom-ports
+  --ports <ports>               Required with custom-ports. Example: 80,443,9100
+  --timing <safe|normal>        Default: safe.
+  --allow-subnet                Permit CIDR targets. CIDR broader than /29 is blocked.
+  --max-targets <n>             Default: 16.
+  --no-service-detection        Skip -sV --version-light.
+  --output-root <path>          Default: $USERPROFILE/SysAdminSuite/Runs.
+  --dry-run                     Build reports without executing nmap.
+  -h, --help                    Show help.
+EOF
+}
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+trim() { local v="$*"; v="${v#"${v%%[![:space:]]*}"}"; v="${v%"${v##*[![:space:]]}"}"; printf '%s' "$v"; }
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\r/\\r/g; s/\n/\\n/g'; }
+safe_token() { printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '_'; }
+now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+portable_hostname() { hostname.exe 2>/dev/null || hostname 2>/dev/null || echo unknown-host; }
+portable_whoami() { whoami.exe 2>/dev/null || whoami 2>/dev/null || echo unknown-user; }
+command_path() { command -v "$1" 2>/dev/null || true; }
+
+add_target() { local t; t="$(trim "$1")"; [[ -n "$t" ]] && TARGETS+=("$t"); }
+add_csv_targets() { local old="$IFS"; IFS=',' read -r -a parts <<< "$1"; IFS="$old"; for p in "${parts[@]}"; do add_target "$p"; done; }
+load_targets() { local line; [[ -f "$1" ]] || fail "Target file not found: $1"; while IFS= read -r line || [[ -n "$line" ]]; do line="$(trim "$line")"; [[ -z "$line" || "$line" == \#* ]] && continue; add_target "$line"; done < "$1"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) [[ $# -ge 2 ]] || fail "--target requires value"; add_target "$2"; shift 2 ;;
+    --targets) [[ $# -ge 2 ]] || fail "--targets requires value"; add_csv_targets "$2"; shift 2 ;;
+    --target-file) [[ $# -ge 2 ]] || fail "--target-file requires value"; TARGET_FILE="$2"; shift 2 ;;
+    --scan-mode) [[ $# -ge 2 ]] || fail "--scan-mode requires value"; SCAN_MODE="$2"; shift 2 ;;
+    --ports) [[ $# -ge 2 ]] || fail "--ports requires value"; PORTS="$2"; shift 2 ;;
+    --timing) [[ $# -ge 2 ]] || fail "--timing requires value"; TIMING="$2"; shift 2 ;;
+    --allow-subnet) ALLOW_SUBNET=1; shift ;;
+    --max-targets) [[ $# -ge 2 ]] || fail "--max-targets requires value"; MAX_TARGETS="$2"; shift 2 ;;
+    --no-service-detection) NO_SERVICE_DETECTION=1; shift ;;
+    --output-root) [[ $# -ge 2 ]] || fail "--output-root requires value"; OUTPUT_ROOT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$TARGET_FILE" ]] && load_targets "$TARGET_FILE"
+[[ ${#TARGETS[@]} -eq 0 ]] && TARGETS=("127.0.0.1")
+[[ "$MAX_TARGETS" =~ ^[0-9]+$ ]] || fail "--max-targets must be numeric"
+[[ ${#TARGETS[@]} -le "$MAX_TARGETS" ]] || fail "Target count ${#TARGETS[@]} exceeds cap $MAX_TARGETS"
+case "$SCAN_MODE" in local-only|ping-only|common-ports|printer-ports|workstation-ports|custom-ports) ;; *) fail "Unsupported scan mode: $SCAN_MODE" ;; esac
+case "$TIMING" in safe|normal) ;; *) fail "Unsupported timing: $TIMING" ;; esac
+
+HOST="$(portable_hostname)"
+STAMP="$(date +"%Y%m%d_%H%M%S")"
+RUN_ID="SAS_NMAP_BASELINE_${HOST}_${STAMP}"
+RUN_DIR="$OUTPUT_ROOT/$RUN_ID"
+LOG_DIR="$RUN_DIR/logs"; RAW_DIR="$RUN_DIR/raw"; LOCAL_DIR="$RAW_DIR/local"; EXPORT_DIR="$RUN_DIR/exports"
+mkdir -p "$LOG_DIR" "$LOCAL_DIR" "$EXPORT_DIR"
+EVENT_LOG="$LOG_DIR/events.jsonl"; TRACE_LOG="$LOG_DIR/trace.log"
+
+log_event() {
+  local stage="$1" level="$2" msg="$3" data="${4:-}" ts; ts="$(now_iso)"
+  printf '{"timestamp":"%s","run_id":"%s","stage":"%s","level":"%s","message":"%s","data":"%s"}\n' \
+    "$(json_escape "$ts")" "$(json_escape "$RUN_ID")" "$(json_escape "$stage")" "$(json_escape "$level")" "$(json_escape "$msg")" "$(json_escape "$data")" >> "$EVENT_LOG"
+  printf '[%s][%s] %s\n' "$stage" "$level" "$msg" | tee -a "$TRACE_LOG"
+}
+
+capture() {
+  local label="$1" out="$2"; shift 2
+  { echo "# $label"; echo "# command: $*"; echo "# captured_at: $(now_iso)"; echo; } > "$out"
+  if [[ "$DRY_RUN" -eq 1 ]]; then echo "DRY RUN" >> "$out"; echo "# exit_code: 0" >> "$out"; return 0; fi
+  set +e; "$@" >> "$out" 2>&1; code=$?; set -e
+  echo; echo "# exit_code: $code"
+  } >> "$out"
+}
+
+log_event START INFO "Nmap baseline started"
+log_event RECON INFO "Collecting local baseline"
+
+NMAP_BIN="$(command_path nmap.exe)"; [[ -z "$NMAP_BIN" ]] && NMAP_BIN="$(command_path nmap)"
+capture hostname "$LOCAL_DIR/hostname.txt" hostname.exe
+capture whoami "$LOCAL_DIR/whoami.txt" whoami.exe
+capture windows-version "$LOCAL_DIR/windows_version.txt" cmd.exe /c ver
+capture ipconfig "$LOCAL_DIR/ipconfig_all.txt" cmd.exe /c ipconfig /all
+capture getmac "$LOCAL_DIR/getmac.txt" cmd.exe /c getmac /v /fo list
+capture arp "$LOCAL_DIR/arp_a.txt" cmd.exe /c arp -a
+capture route "$LOCAL_DIR/route_print.txt" cmd.exe /c route print
+capture netsh-interface "$LOCAL_DIR/netsh_interface.txt" cmd.exe /c netsh interface show interface
+if [[ -n "$NMAP_BIN" ]]; then capture nmap-version "$LOCAL_DIR/nmap_version.txt" "$NMAP_BIN" --version; else echo "nmap not found" > "$LOCAL_DIR/nmap_version.txt"; fi
+
+log_event DECIDE INFO "Evaluating guardrails"
+case "$SCAN_MODE" in
+  local-only|ping-only) : ;;
+  common-ports) PORTS="22,80,135,139,443,445,3389,5985,5986,9100" ;;
+  printer-ports) PORTS="80,443,515,631,9100,161" ;;
+  workstation-ports) PORTS="135,139,445,3389,5985,5986" ;;
+  custom-ports) [[ -n "$PORTS" ]] || fail "--ports required for custom-ports" ;;
+esac
+
+for target in "${TARGETS[@]}"; do
+  if [[ "$target" =~ /([0-9]{1,2})$ ]]; then
+    [[ "$ALLOW_SUBNET" -eq 1 ]] || fail "CIDR target requires --allow-subnet: $target"
+    [[ "${BASH_REMATCH[1]}" -ge 29 ]] || fail "CIDR broader than /29 blocked: $target"
+  fi
+done
+
+TIMING_ARGS=("-T2" "--max-retries" "2" "--host-timeout" "90s")
+[[ "$TIMING" == "normal" ]] && TIMING_ARGS=("-T3" "--max-retries" "3" "--host-timeout" "120s")
+SCAN_ARGS=(); WILL_RUN=0; BLOCKED=""
+if [[ "$SCAN_MODE" == "local-only" ]]; then BLOCKED="local-only mode";
+elif [[ -z "$NMAP_BIN" ]]; then BLOCKED="nmap not found";
+else
+  WILL_RUN=1
+  if [[ "$SCAN_MODE" == "ping-only" ]]; then SCAN_ARGS=("-sn" "${TIMING_ARGS[@]}");
+  else
+    SCAN_ARGS=("-Pn" "-p" "$PORTS")
+    [[ "$NO_SERVICE_DETECTION" -eq 1 ]] || SCAN_ARGS+=("-sV" "--version-light")
+    SCAN_ARGS+=("${TIMING_ARGS[@]}")
+  fi
+fi
+
+cat > "$EXPORT_DIR/run_context.env" <<EOF
+run_id=$RUN_ID
+hostname=$HOST
+user=$(portable_whoami)
+scan_mode=$SCAN_MODE
+targets=${TARGETS[*]}
+nmap_bin=${NMAP_BIN:-NOT_FOUND}
+will_run_nmap=$WILL_RUN
+blocked_reason=$BLOCKED
+EOF
+
+OPEN_CSV="$EXPORT_DIR/open_ports_summary.csv"; INDEX_CSV="$EXPORT_DIR/scan_index.csv"
+printf 'target,port_state_line\n' > "$OPEN_CSV"
+printf 'target,exit_code,duration_seconds,normal_output,xml_output,stdout_output\n' > "$INDEX_CSV"
+
+if [[ "$WILL_RUN" -eq 1 ]]; then
+  for target in "${TARGETS[@]}"; do
+    token="$(safe_token "$target")"; normal="$RAW_DIR/nmap_${token}.nmap"; xml="$RAW_DIR/nmap_${token}.xml"; stdout="$RAW_DIR/nmap_${token}.stdout.txt"
+    args=("${SCAN_ARGS[@]}" "-oN" "$normal" "-oX" "$xml" "$target")
+    log_event ACT INFO "Running Nmap" "target=$target args=${args[*]}"
+    start=$(date +%s)
+    if [[ "$DRY_RUN" -eq 1 ]]; then echo "DRY RUN: $NMAP_BIN ${args[*]}" > "$stdout"; touch "$normal" "$xml"; code=0; else set +e; "$NMAP_BIN" "${args[@]}" > "$stdout" 2>&1; code=$?; set -e; fi
+    dur=$(( $(date +%s) - start ))
+    printf '"%s",%s,%s,"%s","%s","%s"\n' "$target" "$code" "$dur" "$normal" "$xml" "$stdout" >> "$INDEX_CSV"
+    [[ -s "$normal" ]] && awk -v target="$target" '/^[0-9]+\/(tcp|udp)[[:space:]]+open/ {gsub(/"/,"\"\""); printf "\"%s\",\"%s\"\n", target, $0}' "$normal" >> "$OPEN_CSV"
+  done
+else
+  log_event ACT WARN "Nmap scan skipped" "$BLOCKED"
+fi
+
+REPORT="$EXPORT_DIR/baseline_report.md"; JSON="$EXPORT_DIR/baseline_report.json"
+cat > "$REPORT" <<EOF
+# SysAdminSuite Nmap Baseline Report
+
+| Field | Value |
+|---|---|
+| Run ID | $RUN_ID |
+| Hostname | $HOST |
+| User | $(portable_whoami) |
+| Scan Mode | $SCAN_MODE |
+| Targets | ${TARGETS[*]} |
+| Nmap Available | $([[ -n "$NMAP_BIN" ]] && echo true || echo false) |
+| Nmap Path | ${NMAP_BIN:-NOT_FOUND} |
+| Will Run Nmap | $WILL_RUN |
+| Blocked Reason | ${BLOCKED:-none} |
+
+## Artifacts
+
+- Local baseline: \`$LOCAL_DIR\`
+- Scan index: \`$INDEX_CSV\`
+- Open ports summary: \`$OPEN_CSV\`
+- Raw output: \`$RAW_DIR\`
+- Event log: \`$EVENT_LOG\`
+EOF
+cat > "$JSON" <<EOF
+{"run_id":"$(json_escape "$RUN_ID")","hostname":"$(json_escape "$HOST")","scan_mode":"$(json_escape "$SCAN_MODE")","targets":"$(json_escape "${TARGETS[*]}")","will_run_nmap":$([[ "$WILL_RUN" -eq 1 ]] && echo true || echo false),"run_dir":"$(json_escape "$RUN_DIR")"}
+EOF
+log_event EXPORT INFO "Reports exported" "report=$REPORT"
+log_event END INFO "Nmap baseline completed" "run_dir=$RUN_DIR"
+
+echo "DONE"
+echo "Run Directory: $RUN_DIR"
+echo "Report: $REPORT"

--- a/scripts/sas_ou_gpo_indicators.sh
+++ b/scripts/sas_ou_gpo_indicators.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# SysAdminSuite OU/GPO Indicator Collector
+# Shape: Recon -> Decide -> Act -> Log -> Export
+# Read-only evidence collector. No gpupdate, no AD writes, no registry writes.
+
+set -Eeuo pipefail
+OUTPUT_ROOT="${USERPROFILE:-${HOME:-.}}/SysAdminSuite/Runs"
+TARGET_HINT="local"
+INCLUDE_REGISTRY=1
+DRY_RUN=0
+
+usage() { cat <<'EOF'
+Usage: bash scripts/sas_ou_gpo_indicators.sh [options]
+
+Options:
+  --target-hint <label>     Optional run label/reference host context.
+  --output-root <path>      Default: $USERPROFILE/SysAdminSuite/Runs.
+  --no-registry             Skip read-only Group Policy registry-state capture.
+  --dry-run                 Build command plan without executing evidence commands.
+  -h, --help                Show help.
+EOF
+}
+fail() { echo "ERROR: $*" >&2; exit 1; }
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\r/\\r/g; s/\n/\\n/g'; }
+csv_escape() { local v="$1"; v="${v//"/""}"; printf '"%s"' "$v"; }
+now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+portable_hostname() { hostname.exe 2>/dev/null || hostname 2>/dev/null || echo unknown-host; }
+portable_whoami() { whoami.exe 2>/dev/null || whoami 2>/dev/null || echo unknown-user; }
+normalize_file() { [[ -f "$1" ]] && tr -d '\r' < "$1" || true; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target-hint) [[ $# -ge 2 ]] || fail "--target-hint requires value"; TARGET_HINT="$2"; shift 2 ;;
+    --output-root) [[ $# -ge 2 ]] || fail "--output-root requires value"; OUTPUT_ROOT="$2"; shift 2 ;;
+    --no-registry) INCLUDE_REGISTRY=0; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+HOST="$(portable_hostname)"; STAMP="$(date +"%Y%m%d_%H%M%S")"
+RUN_ID="SAS_OU_GPO_INDICATORS_${HOST}_${STAMP}"
+RUN_DIR="$OUTPUT_ROOT/$RUN_ID"; LOG_DIR="$RUN_DIR/logs"; RAW_DIR="$RUN_DIR/raw"; EXPORT_DIR="$RUN_DIR/exports"
+mkdir -p "$LOG_DIR" "$RAW_DIR" "$EXPORT_DIR"
+EVENT_LOG="$LOG_DIR/ou_gpo_events.jsonl"; TRACE_LOG="$LOG_DIR/ou_gpo_trace.log"; PLAN="$EXPORT_DIR/command_plan.txt"
+INDICATORS="$EXPORT_DIR/ou_gpo_indicators.csv"; SUMMARY="$EXPORT_DIR/ou_gpo_summary.env"; REPORT="$EXPORT_DIR/ou_gpo_report.md"; ACTIONS="$EXPORT_DIR/ou_gpo_recommended_actions.md"; JSON="$EXPORT_DIR/ou_gpo_report.json"
+: > "$PLAN"
+
+log_event() {
+  local stage="$1" level="$2" msg="$3" data="${4:-}" ts; ts="$(now_iso)"
+  printf '{"timestamp":"%s","run_id":"%s","stage":"%s","level":"%s","message":"%s","data":"%s"}\n' \
+    "$(json_escape "$ts")" "$(json_escape "$RUN_ID")" "$(json_escape "$stage")" "$(json_escape "$level")" "$(json_escape "$msg")" "$(json_escape "$data")" >> "$EVENT_LOG"
+  printf '[%s][%s] %s\n' "$stage" "$level" "$msg" | tee -a "$TRACE_LOG"
+}
+
+capture() {
+  local label="$1" out="$2"; shift 2
+  { echo "# $label"; echo "# command: $*"; echo "# captured_at: $(now_iso)"; echo; } > "$out"
+  printf '%s\n' "$*" >> "$PLAN"
+  if [[ "$DRY_RUN" -eq 1 ]]; then echo "DRY RUN" >> "$out"; echo "# exit_code: 0" >> "$out"; return 0; fi
+  set +e; "$@" >> "$out" 2>&1; code=$?; set -e
+  echo; echo "# exit_code: $code"
+  } >> "$out"
+}
+
+extract_env() { normalize_file "$1" | awk -F '=' -v k="$2" 'tolower($1)==tolower(k){print $2; exit}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' || true; }
+extract_wmic() { normalize_file "$1" | awk -F '=' -v k="$2" 'tolower($1)==tolower(k){print $2; exit}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' || true; }
+extract_dn() { normalize_file "$1" | grep -E '^[[:space:]]*(CN|OU)=[^,]+,.*DC=' | head -n 1 | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' || true; }
+ou_from_dn() { printf '%s' "$1" | awk -F ',' '{c=0; for(i=1;i<=NF;i++){x=$i; gsub(/^[[:space:]]+|[[:space:]]+$/, "", x); if(x ~ /^OU=/){sub(/^OU=/,"",x); ou[++c]=x}} for(i=c;i>=1;i--) printf "%s%s", ou[i], (i==1?"":"/") }'; }
+first_match() { normalize_file "$1" | grep -E "$2" | head -n 1 | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' || true; }
+
+extract_gpos() {
+  normalize_file "$1" | awk '
+    /Applied Group Policy Objects/ {cap=1; next}
+    /The following GPOs were not applied|The computer is a part of|The user is a part of|Resultant Set Of Policies/ {cap=0}
+    cap==1 {line=$0; gsub(/^[[:space:]]+|[[:space:]]+$/, "", line); if(line!="" && line!~ /^[-]+$/ && line!~ /^N\/A$/) print line}' | sort -u || true
+}
+extract_groups() {
+  { normalize_file "$1"; normalize_file "$2"; normalize_file "$3" | awk -F ':' '/Group Name/ {print $2}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'; } \
+    | awk 'NF' | sort -u || true
+}
+write_indicator() { csv_escape "$1" >> "$INDICATORS"; printf ',' >> "$INDICATORS"; csv_escape "$2" >> "$INDICATORS"; printf ',' >> "$INDICATORS"; csv_escape "$3" >> "$INDICATORS"; printf ',' >> "$INDICATORS"; csv_escape "$4" >> "$INDICATORS"; printf ',' >> "$INDICATORS"; csv_escape "$5" >> "$INDICATORS"; printf '\n' >> "$INDICATORS"; }
+
+log_event START INFO "OU/GPO indicator collector started" "target_hint=$TARGET_HINT"
+log_event RECON INFO "Collecting raw evidence"
+
+capture hostname "$RAW_DIR/hostname.txt" hostname.exe
+capture whoami "$RAW_DIR/whoami.txt" whoami.exe
+capture whoami-user "$RAW_DIR/whoami_user.txt" whoami.exe /user /fo list
+capture whoami-groups "$RAW_DIR/whoami_groups.txt" whoami.exe /groups /fo list
+capture whoami-fqdn "$RAW_DIR/whoami_fqdn.txt" whoami.exe /fqdn
+capture environment "$RAW_DIR/environment_set.txt" cmd.exe /c set
+capture computer-domain "$RAW_DIR/wmic_computersystem_domain.txt" wmic.exe computersystem get domain,partofdomain /format:list
+capture gpresult-computer "$RAW_DIR/gpresult_computer.txt" gpresult.exe /r /scope computer
+capture gpresult-user "$RAW_DIR/gpresult_user.txt" gpresult.exe /r /scope user
+USERDNSDOMAIN="$(extract_env "$RAW_DIR/environment_set.txt" USERDNSDOMAIN)"
+if [[ -n "$USERDNSDOMAIN" ]]; then capture nltest "$RAW_DIR/nltest_dsgetdc.txt" nltest.exe "/dsgetdc:$USERDNSDOMAIN"; else echo "USERDNSDOMAIN unavailable" > "$RAW_DIR/nltest_dsgetdc.txt"; fi
+if [[ "$INCLUDE_REGISTRY" -eq 1 ]]; then
+  capture gp-reg-machine "$RAW_DIR/reg_gp_state_machine.txt" reg.exe query "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\State\\Machine" /s
+  capture gp-reg-user "$RAW_DIR/reg_gp_state_user.txt" reg.exe query "HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Group Policy\\State" /s
+else
+  echo "Registry capture skipped" > "$RAW_DIR/reg_gp_state_machine.txt"; echo "Registry capture skipped" > "$RAW_DIR/reg_gp_state_user.txt"
+fi
+
+log_event DECIDE INFO "Parsing indicators"
+DOMAIN="$(extract_wmic "$RAW_DIR/wmic_computersystem_domain.txt" Domain)"
+PART="$(extract_wmic "$RAW_DIR/wmic_computersystem_domain.txt" PartOfDomain)"
+USERDOMAIN="$(extract_env "$RAW_DIR/environment_set.txt" USERDOMAIN)"
+LOGONSERVER="$(extract_env "$RAW_DIR/environment_set.txt" LOGONSERVER)"
+COMP_DN="$(extract_dn "$RAW_DIR/gpresult_computer.txt")"
+USER_DN="$(extract_dn "$RAW_DIR/whoami_fqdn.txt")"
+COMP_OU="$(ou_from_dn "$COMP_DN")"; USER_OU="$(ou_from_dn "$USER_DN")"
+DC_HINT="$(first_match "$RAW_DIR/gpresult_computer.txt" 'Group Policy was applied from|Group Policy was applied from:')"
+[[ -z "$DC_HINT" ]] && DC_HINT="$(first_match "$RAW_DIR/nltest_dsgetdc.txt" 'DC:|Address:|Dom Name:')"
+POSTURE="unknown"; [[ "${PART,,}" == true ]] && POSTURE="domain_joined"; [[ "${PART,,}" == false ]] && POSTURE="not_domain_joined_or_unavailable"
+
+COMP_GPOS="$EXPORT_DIR/applied_computer_gpos.txt"; USER_GPOS="$EXPORT_DIR/applied_user_gpos.txt"; GROUPS="$EXPORT_DIR/security_groups.txt"
+extract_gpos "$RAW_DIR/gpresult_computer.txt" > "$COMP_GPOS"
+extract_gpos "$RAW_DIR/gpresult_user.txt" > "$USER_GPOS"
+extract_groups "$RAW_DIR/gpresult_computer.txt" "$RAW_DIR/gpresult_user.txt" "$RAW_DIR/whoami_groups.txt" > "$GROUPS"
+COMP_GPO_COUNT=$(grep -cve '^$' "$COMP_GPOS" || true); USER_GPO_COUNT=$(grep -cve '^$' "$USER_GPOS" || true); GROUP_COUNT=$(grep -cve '^$' "$GROUPS" || true)
+
+log_event ACT INFO "Writing indicators"
+printf 'indicator,value,confidence,source,note\n' > "$INDICATORS"
+write_indicator hostname "$HOST" high hostname.exe "Local computer name."
+write_indicator target_hint "$TARGET_HINT" medium operator "Run label, not authoritative."
+write_indicator current_user "$(portable_whoami)" high whoami.exe "Current security context."
+write_indicator domain_posture "$POSTURE" medium "wmic computersystem" "Best-effort local posture."
+write_indicator domain "${DOMAIN:-${USERDNSDOMAIN:-unknown}}" medium "wmic/environment" "WMIC first, environment fallback."
+write_indicator user_domain "${USERDOMAIN:-unknown}" medium environment "USERDOMAIN value."
+write_indicator user_dns_domain "${USERDNSDOMAIN:-unknown}" medium environment "USERDNSDOMAIN value."
+write_indicator logon_server "${LOGONSERVER:-unknown}" medium environment "Logon server hint."
+write_indicator domain_controller_indicator "${DC_HINT:-unknown}" medium "gpresult/nltest" "Best-effort DC source hint."
+write_indicator computer_distinguished_name "${COMP_DN:-unknown}" medium gpresult "Computer DN if exposed."
+write_indicator computer_ou_path_hint "${COMP_OU:-unknown}" medium parsed_dn "Computer OU hint, not AD truth."
+write_indicator user_distinguished_name "${USER_DN:-unknown}" medium "whoami /fqdn" "User DN, not computer OU."
+write_indicator user_ou_path_hint "${USER_OU:-unknown}" medium parsed_dn "Keep separate from computer OU."
+write_indicator applied_computer_gpo_count "$COMP_GPO_COUNT" medium gpresult "Parsed applied computer GPO count."
+write_indicator applied_user_gpo_count "$USER_GPO_COUNT" medium gpresult "Parsed applied user GPO count."
+write_indicator security_group_count "$GROUP_COUNT" low "gpresult/whoami" "Noisy, advisory only."
+
+cat > "$SUMMARY" <<EOF
+run_id=$RUN_ID
+hostname=$HOST
+target_hint=$TARGET_HINT
+current_user=$(portable_whoami)
+domain_posture=$POSTURE
+domain=${DOMAIN:-${USERDNSDOMAIN:-unknown}}
+user_domain=${USERDOMAIN:-unknown}
+user_dns_domain=${USERDNSDOMAIN:-unknown}
+logon_server=${LOGONSERVER:-unknown}
+domain_controller_indicator=${DC_HINT:-unknown}
+computer_distinguished_name=${COMP_DN:-unknown}
+computer_ou_path_hint=${COMP_OU:-unknown}
+user_distinguished_name=${USER_DN:-unknown}
+user_ou_path_hint=${USER_OU:-unknown}
+applied_computer_gpo_count=$COMP_GPO_COUNT
+applied_user_gpo_count=$USER_GPO_COUNT
+security_group_count=$GROUP_COUNT
+EOF
+
+log_event EXPORT INFO "Writing reports"
+cat > "$REPORT" <<EOF
+# SysAdminSuite OU/GPO Indicator Report
+
+| Field | Value |
+|---|---|
+| Run ID | $RUN_ID |
+| Hostname | $HOST |
+| Current User | $(portable_whoami) |
+| Target Hint | $TARGET_HINT |
+| Domain Posture | $POSTURE |
+| Domain | ${DOMAIN:-${USERDNSDOMAIN:-unknown}} |
+| Logon Server | ${LOGONSERVER:-unknown} |
+| Computer OU Path Hint | ${COMP_OU:-unknown} |
+| User OU Path Hint | ${USER_OU:-unknown} |
+| Applied Computer GPO Count | $COMP_GPO_COUNT |
+| Applied User GPO Count | $USER_GPO_COUNT |
+
+## Artifacts
+
+- Indicators: \`$INDICATORS\`
+- Summary: \`$SUMMARY\`
+- Applied computer GPOs: \`$COMP_GPOS\`
+- Applied user GPOs: \`$USER_GPOS\`
+- Security groups: \`$GROUPS\`
+- Raw evidence: \`$RAW_DIR\`
+EOF
+cat > "$ACTIONS" <<EOF
+# OU/GPO Recommended Actions
+
+- Compare target evidence against a known-good reference host.
+- Keep computer OU and user OU separate.
+- If computer OU path is missing, review raw gpresult and authorized AD/ServiceNow tooling.
+- Do not run gpupdate or mutate policy from this collector.
+- Treat incomplete evidence as incomplete evidence, not product failure.
+EOF
+cat > "$JSON" <<EOF
+{"run_id":"$(json_escape "$RUN_ID")","hostname":"$(json_escape "$HOST")","domain_posture":"$(json_escape "$POSTURE")","computer_ou_path_hint":"$(json_escape "${COMP_OU:-unknown}")","user_ou_path_hint":"$(json_escape "${USER_OU:-unknown}")","run_dir":"$(json_escape "$RUN_DIR")"}
+EOF
+log_event END INFO "OU/GPO indicator collector completed" "run_dir=$RUN_DIR"
+echo "DONE"
+echo "Run Directory: $RUN_DIR"
+echo "Report: $REPORT"

--- a/scripts/sas_ou_gpo_indicators.sh
+++ b/scripts/sas_ou_gpo_indicators.sh
@@ -22,7 +22,7 @@ EOF
 }
 fail() { echo "ERROR: $*" >&2; exit 1; }
 json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g; s/\r/\\r/g; s/\n/\\n/g'; }
-csv_escape() { local v="$1"; v="${v//"/""}"; printf '"%s"' "$v"; }
+csv_escape() { local v="$1"; v="${v//\"/\"\"}"; printf '"%s"' "$v"; }
 now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 portable_hostname() { hostname.exe 2>/dev/null || hostname 2>/dev/null || echo unknown-host; }
 portable_whoami() { whoami.exe 2>/dev/null || whoami 2>/dev/null || echo unknown-user; }
@@ -59,9 +59,11 @@ capture() {
   { echo "# $label"; echo "# command: $*"; echo "# captured_at: $(now_iso)"; echo; } > "$out"
   printf '%s\n' "$*" >> "$PLAN"
   if [[ "$DRY_RUN" -eq 1 ]]; then echo "DRY RUN" >> "$out"; echo "# exit_code: 0" >> "$out"; return 0; fi
-  set +e; "$@" >> "$out" 2>&1; code=$?; set -e
-  echo; echo "# exit_code: $code"
-  } >> "$out"
+  set +e
+  "$@" >> "$out" 2>&1
+  code=$?
+  set -e
+  { echo; echo "# exit_code: $code"; } >> "$out"
 }
 
 extract_env() { normalize_file "$1" | awk -F '=' -v k="$2" 'tolower($1)==tolower(k){print $2; exit}' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' || true; }


### PR DESCRIPTION
## **User description**
## Summary

Adds the first Bash-first Nmap baseline workflow for SysAdminSuite, following:

```text
Recon -> Decide -> Act -> Log -> Export
```

## Added

- `scripts/sas_nmap_baseline.sh`
  - Collects local Bash-on-Windows workstation/network baseline artifacts.
  - Runs conservative Nmap scans only after a decision gate.
  - Exports raw Nmap output, XML, CSV summaries, Markdown, JSON, and JSONL logs.

- `scripts/sas_classify_nmap_baseline.sh`
  - Reads a completed baseline run folder.
  - Classifies advisory device roles from open port evidence.
  - Exports `classifications.csv` and `recommended_actions.md`.

- `docs/NMAP_BASELINE_MODULE.md`
  - Documents usage, guardrails, examples, output layout, and classifier behavior.

## Guardrails

The baseline module intentionally avoids risky scanning defaults:

- No `-A`
- No vuln scripts
- No brute-force scripts
- No stealth/evasion/spoofing
- No broad subnet scan by default
- CIDR requires `--allow-subnet`
- CIDR broader than `/29` is blocked
- Default target cap is `16`

## Notes

This follows the repo's Bash-first Northwell field-work posture from `AGENTS.md`. PowerShell remains protected and production-relevant, but this feature does not add new PowerShell surface area.

## Suggested Smoke Test

```bash
bash scripts/sas_nmap_baseline.sh --scan-mode local-only
bash scripts/sas_nmap_baseline.sh --target 127.0.0.1 --scan-mode common-ports --dry-run
bash scripts/sas_classify_nmap_baseline.sh --run-dir "$USERPROFILE/SysAdminSuite/Runs/<RUN_FOLDER>"
```

## Follow-up

Next layer should map advisory classifications into approved workflows:

```text
classification -> approved next workflow -> dry-run mutation plan
```

No mutation is included in this PR.


___

## **CodeAnt-AI Description**
**Add a safe Nmap baseline workflow and advisory classification output**

### What Changed
- Adds a new baseline scan flow that collects local device/network details, then runs only small, explicit Nmap checks when allowed
- Limits scanning by default with conservative target caps, subnet approval, and a dry-run mode; local-only runs skip Nmap entirely
- Saves each run in a structured folder with raw scan output, XML, CSV summaries, logs, and a Markdown/JSON report
- Adds a follow-up classifier that reads an existing run and labels likely device roles such as printer, Windows workstation, management endpoint, or web appliance, with suggested next support steps
- Documents the scan modes, guardrails, output layout, and classifier results

### Impact
`✅ Safer baseline network checks`
`✅ Clearer scan output for support follow-up`
`✅ Faster triage of likely device roles`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
