### PR TITLE
Add registry install-diff JSON schemas and example configs

### DIFF
--- a/config/registry_remediation.example.json
+++ b/config/registry_remediation.example.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "remediation_id": "REM-EXAMPLE-0001",
+  "software_id": "EXAMPLE-SOFTWARE-ID",
+  "target_scope": "localhost",
+  "target_key": "HKLM:\\Software\\ExampleVendor\\ExampleApp",
+  "value_name": "EnforceSetting",
+  "value_type": "dword",
+  "desired_value": 1,
+  "reason": "Example remediation for post-install drift verification only.",
+  "approved_by": "APPROVER-PLACEHOLDER",
+  "approved_at": "2026-01-15T12:00:00Z",
+  "rollback_required": true,
+  "rollback_plan": {
+    "steps": [
+      "Capture current value into evidence bundle.",
+      "Reapply prior known-good value from baseline manifest.",
+      "Capture post-rollback snapshot and attach to evidence bundle."
+    ],
+    "evidence_refs": [
+      "evidence://before-value.json",
+      "evidence://rollback-run.log",
+      "evidence://after-value.json"
+    ]
+  },
+  "risk_level": "Medium",
+  "evidence_required": true,
+  "mode": "ApprovedRemediation",
+  "before_value_evidence_ref": "evidence://before-value.json",
+  "after_value_evidence_ref": "evidence://after-value.json",
+  "review_after": "2026-02-01T00:00:00Z",
+  "expires_at": "2026-06-01T00:00:00Z"
+}

--- a/config/registry_watchlist.example.json
+++ b/config/registry_watchlist.example.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "1.0.0",
+  "description": "Example registry watchlist for install diff evidence collection and classification.",
+  "registry_paths": [
+    "HKLM:\\Software",
+    "HKLM:\\Software\\WOW6432Node",
+    "HKLM:\\System\\CurrentControlSet\\Services",
+    "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
+  ],
+  "exclude_patterns": [
+    "HKLM:\\Software\\Classes\\Installer\\Products\\*",
+    "HKLM:\\Software\\Microsoft\\Cryptography\\*"
+  ],
+  "noise_patterns": [
+    {
+      "id": "noise-lastwrite-time",
+      "pattern": "*LastWriteTime*",
+      "reason": "Timestamp churn not tied to meaningful install state"
+    }
+  ],
+  "expected_change_rules": [
+    {
+      "id": "expected-exampleapp-uninstall",
+      "software_id": "EXAMPLE-SOFTWARE-ID",
+      "path_pattern": "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ExampleApp",
+      "value_name": "DisplayVersion",
+      "classification": "ExpectedChange"
+    }
+  ],
+  "suspicious_change_rules": [
+    {
+      "id": "suspicious-run-key",
+      "path_pattern": "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run*",
+      "reason": "New autorun entries require operator review",
+      "default_classification": "SuspiciousChange"
+    }
+  ],
+  "remediation_candidate_rules": [
+    {
+      "id": "candidate-service-start",
+      "path_pattern": "HKLM:\\System\\CurrentControlSet\\Services\\ExampleAppService",
+      "value_name": "Start",
+      "reason": "Unexpected service start mode may need approved remediation",
+      "default_classification": "RemediationCandidate"
+    },
+    {
+      "id": "candidate-examplevendor-policy",
+      "path_pattern": "HKLM:\\Software\\ExampleVendor\\ExampleApp\\Policy",
+      "reason": "Policy drift from baseline",
+      "default_classification": "RemediationCandidate"
+    }
+  ]
+}

--- a/config/target_batch.example.csv
+++ b/config/target_batch.example.csv
@@ -1,0 +1,4 @@
+target,scope,software_id,mode,notes
+localhost,localhost,EXAMPLE-SOFTWARE-ID,DryRun,"Local validation before remote execution"
+LAB-PC-001,remote,EXAMPLE-SOFTWARE-ID,DryRun,"Lab target for readiness checks only"
+LAB-PC-002,remote,EXAMPLE-SOFTWARE-ID,Recon,"Inventory and snapshot-only run"

--- a/schemas/install_run.schema.json
+++ b/schemas/install_run.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/install_run.schema.json",
+  "title": "Installer Run Metadata",
+  "description": "Execution metadata tied to tracked installer runs and evidence capture.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "software_id",
+    "target",
+    "mode",
+    "dry_run",
+    "installer",
+    "started_at",
+    "ended_at",
+    "duration_ms",
+    "exit_code",
+    "status",
+    "log_path",
+    "errors"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "run_id": { "type": "string" },
+    "software_id": { "type": "string" },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostname", "scope"],
+      "properties": {
+        "hostname": { "type": "string" },
+        "scope": { "type": "string", "enum": ["localhost", "remote", "unresolved"] }
+      }
+    },
+    "mode": { "type": "string", "enum": ["Recon", "Decide", "Act", "Log", "Export"] },
+    "dry_run": { "type": "boolean" },
+    "installer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "installer_path",
+        "installer_type",
+        "silent_args",
+        "source_config_path",
+        "source_config_key",
+        "resolved_from_sources_yaml",
+        "expected_registry_keys",
+        "expected_files",
+        "requires_reboot"
+      ],
+      "properties": {
+        "installer_path": { "type": "string" },
+        "installer_type": { "type": "string", "enum": ["exe", "msi", "msix", "batch", "powershell", "unknown"] },
+        "silent_args": { "type": "array", "items": { "type": "string" } },
+        "source_config_path": { "type": "string" },
+        "source_config_key": { "type": "string" },
+        "resolved_from_sources_yaml": { "type": "boolean" },
+        "expected_registry_keys": { "type": "array", "items": { "type": "string" } },
+        "expected_files": { "type": "array", "items": { "type": "string" } },
+        "requires_reboot": { "type": "boolean" }
+      }
+    },
+    "started_at": { "type": "string", "format": "date-time" },
+    "ended_at": { "type": "string", "format": "date-time" },
+    "duration_ms": { "type": "integer", "minimum": 0 },
+    "exit_code": { "type": ["integer", "null"] },
+    "status": {
+      "type": "string",
+      "enum": ["NotStarted", "DryRun", "Started", "Succeeded", "Failed", "Skipped", "Unknown"]
+    },
+    "log_path": { "type": "string" },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/registry_diff.schema.json
+++ b/schemas/registry_diff.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/registry_diff.schema.json",
+  "title": "Registry Diff",
+  "description": "Comparison evidence between before/after registry snapshots.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "target",
+    "software_id",
+    "compared_at",
+    "before_snapshot",
+    "after_snapshot",
+    "summary",
+    "changes",
+    "errors"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "run_id": { "type": "string" },
+    "target": { "type": "string" },
+    "software_id": { "type": "string" },
+    "compared_at": { "type": "string", "format": "date-time" },
+    "before_snapshot": { "type": "string" },
+    "after_snapshot": { "type": "string" },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total_changes", "by_classification"],
+      "properties": {
+        "total_changes": { "type": "integer", "minimum": 0 },
+        "by_classification": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "CreatedKey",
+            "DeletedKey",
+            "CreatedValue",
+            "DeletedValue",
+            "ModifiedValue",
+            "ExpectedChange",
+            "Noise",
+            "SuspiciousChange",
+            "RemediationCandidate"
+          ],
+          "properties": {
+            "CreatedKey": { "type": "integer", "minimum": 0 },
+            "DeletedKey": { "type": "integer", "minimum": 0 },
+            "CreatedValue": { "type": "integer", "minimum": 0 },
+            "DeletedValue": { "type": "integer", "minimum": 0 },
+            "ModifiedValue": { "type": "integer", "minimum": 0 },
+            "ExpectedChange": { "type": "integer", "minimum": 0 },
+            "Noise": { "type": "integer", "minimum": 0 },
+            "SuspiciousChange": { "type": "integer", "minimum": 0 },
+            "RemediationCandidate": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "changes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["classification", "key_path", "requires_review"],
+        "properties": {
+          "classification": {
+            "type": "string",
+            "enum": [
+              "CreatedKey",
+              "DeletedKey",
+              "CreatedValue",
+              "DeletedValue",
+              "ModifiedValue",
+              "ExpectedChange",
+              "Noise",
+              "SuspiciousChange",
+              "RemediationCandidate"
+            ]
+          },
+          "key_path": { "type": "string" },
+          "value_name": { "type": ["string", "null"] },
+          "before": { "type": ["object", "string", "number", "boolean", "array", "null"] },
+          "after": { "type": ["object", "string", "number", "boolean", "array", "null"] },
+          "reason": { "type": "string" },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "matched_rule_id": { "type": ["string", "null"] },
+          "requires_review": { "type": "boolean" }
+        }
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/registry_remediation.schema.json
+++ b/schemas/registry_remediation.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/registry_remediation.schema.json",
+  "title": "Approved Registry Remediation Manifest",
+  "description": "Explicit non-default remediation lane. Registry edits are only allowed with ApprovedRemediation mode and rollback evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "remediation_id",
+    "software_id",
+    "target_scope",
+    "target_key",
+    "value_name",
+    "value_type",
+    "desired_value",
+    "reason",
+    "approved_by",
+    "approved_at",
+    "rollback_required",
+    "risk_level",
+    "evidence_required",
+    "mode"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "remediation_id": { "type": "string" },
+    "software_id": { "type": "string" },
+    "target_scope": { "type": "string", "enum": ["localhost", "remote", "batch"] },
+    "target_key": { "type": "string" },
+    "value_name": { "type": ["string", "null"] },
+    "value_type": { "type": "string" },
+    "desired_value": { "type": ["string", "number", "boolean", "array", "object", "null"] },
+    "reason": { "type": "string" },
+    "approved_by": { "type": "string" },
+    "approved_at": { "type": "string", "format": "date-time" },
+    "rollback_required": { "type": "boolean" },
+    "rollback_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["steps", "evidence_refs"],
+      "properties": {
+        "steps": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "evidence_refs": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      }
+    },
+    "risk_level": { "type": "string", "enum": ["Low", "Medium", "High", "Critical"] },
+    "evidence_required": { "type": "boolean" },
+    "mode": { "type": "string", "const": "ApprovedRemediation" },
+    "before_value_evidence_ref": { "type": "string" },
+    "after_value_evidence_ref": { "type": "string" },
+    "expires_at": { "type": "string", "format": "date-time" },
+    "review_after": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "rollback_required": { "const": true } },
+        "required": ["rollback_required"]
+      },
+      "then": { "required": ["rollback_plan", "before_value_evidence_ref", "after_value_evidence_ref"] }
+    }
+  ]
+}

--- a/schemas/registry_snapshot.schema.json
+++ b/schemas/registry_snapshot.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.invalid/schemas/registry_snapshot.schema.json",
+  "title": "Registry Snapshot",
+  "description": "Read-only registry snapshot evidence captured before or after install activity.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "run_id",
+    "target",
+    "captured_at",
+    "source",
+    "registry_paths",
+    "entries",
+    "errors"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "minLength": 1 },
+    "run_id": { "type": "string", "minLength": 1 },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostname", "scope"],
+      "properties": {
+        "hostname": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "enum": ["localhost", "remote", "unresolved"] },
+        "notes": { "type": "string" }
+      }
+    },
+    "captured_at": { "type": "string", "format": "date-time" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tool", "mode"],
+      "properties": {
+        "tool": { "type": "string" },
+        "mode": { "type": "string", "enum": ["Recon", "Act", "Log", "Export", "Unknown"] },
+        "operator": { "type": "string" }
+      }
+    },
+    "registry_paths": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key_path",
+          "value_name",
+          "value_type",
+          "value_data_kind",
+          "captured_at",
+          "access_status"
+        ],
+        "properties": {
+          "key_path": { "type": "string", "minLength": 1 },
+          "value_name": {
+            "description": "Use empty string for default value; use null when key has no values.",
+            "type": ["string", "null"]
+          },
+          "value_type": { "type": ["string", "null"] },
+          "value_data": {
+            "description": "Can be null for key-only placeholder entries.",
+            "type": ["string", "number", "integer", "boolean", "array", "object", "null"]
+          },
+          "value_data_kind": {
+            "type": "string",
+            "enum": [
+              "string",
+              "dword",
+              "qword",
+              "binary",
+              "multi_string",
+              "expandable_string",
+              "unknown"
+            ]
+          },
+          "captured_at": { "type": "string", "format": "date-time" },
+          "access_status": {
+            "type": "string",
+            "enum": ["Captured", "AccessDenied", "NotFound", "Error"]
+          },
+          "error_message": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["message"],
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" },
+          "key_path": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## **User description**
### Motivation
- Provide a formal, evidence-first contract for registry snapshotting, before/after diffs, tracked installer runs, and explicit remediation manifests to support the Registry Install Diff Pipeline.
- Ensure remediation remains an explicit, non-default lane by encoding `ApprovedRemediation` mode and rollback/evidence gating in the schema.
- Supply example watchlist and batch target artifacts so pipeline implementers have concrete, non-production examples that reference existing `Config/sources.yaml` IDs (placeholder `EXAMPLE-SOFTWARE-ID`).

### Description
- Added JSON schemas: `schemas/registry_snapshot.schema.json`, `schemas/registry_diff.schema.json`, `schemas/install_run.schema.json`, and `schemas/registry_remediation.schema.json` with required top-level fields and typed properties (status enums, classification enums, rollback gating with `allOf` enforcement, and key-only placeholder support via `value_name: null`).
- Added example configs: `config/registry_watchlist.example.json` (watch roots, exclude/noise patterns, expected/suspicious/remediation rules), `config/registry_remediation.example.json` (ApprovedRemediation example with `rollback_required: true` and evidence refs), and `config/target_batch.example.csv` (generic batch targets: `localhost`, `LAB-PC-001`, `LAB-PC-002`).
- Schema highlights: snapshots allow key-only entries to detect key creation/deletion, diffs include per-classification summary counts and normalized change objects with `confidence`, `evidence`, `matched_rule_id`, and `requires_review`, and `install_run` records installer resolution from `sources.yaml` fields such as `source_config_path` / `source_config_key` and `resolved_from_sources_yaml`.
- Operational notes: examples use placeholder vendor/app IDs only and avoid real hostnames or credentials; `config/target_batch.example.csv` had to be added with force because it is ignored by repo `.gitignore` by default.

### Testing
- Parsed all JSON schema and example files with `jq empty` successfully for: `schemas/registry_snapshot.schema.json`, `schemas/registry_diff.schema.json`, `schemas/install_run.schema.json`, `schemas/registry_remediation.schema.json`, `config/registry_watchlist.example.json`, and `config/registry_remediation.example.json` (all parse OK).
- Verified JSON parsing fallback with Node: `node -e "JSON.parse(require('fs').readFileSync(f,'utf8'))"` for the same files (all returned OK).
- Parsed `config/target_batch.example.csv` with Python `csv.DictReader` and confirmed 3 example rows.
- Looked for an in-repo schema validator (`rg -n 'ajv|jsonschema|spectral|schema validate|SCHEMA_VALIDATOR' README* docs pyproject.toml`) and found none, so full schema <-> instance validation with a documented validator is `SCHEMA_VALIDATOR_UNDOCUMENTED` and remains TODO.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12695cce8883228bc608b08c4cc25d)


___

## **CodeAnt-AI Description**
**Add registry install diff schemas and example configs**

### What Changed
- Added schemas for capturing registry snapshots, comparing before/after snapshots, recording installer runs, and approving explicit remediation changes
- Snapshot records now support key-only entries and can store missing or blocked access as part of the evidence
- Diff records now include change counts, per-change review status, confidence, evidence links, and matched rule references
- Added example watchlist and remediation files so teams can start with realistic, non-production registry paths and approval data

### Impact
`✅ Clearer install-diff evidence`
`✅ Safer approved registry changes`
`✅ Easier pipeline setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
