### PR TITLE
Add read-only Test-TargetReadiness PowerShell checks for registry install diff

### DIFF
--- a/Tests/Pester/TargetReadiness.Tests.ps1
+++ b/Tests/Pester/TargetReadiness.Tests.ps1
@@ -1,0 +1,82 @@
+Set-StrictMode -Version Latest
+
+Describe 'Test-TargetReadiness script' {
+    $scriptPath = Join-Path $PSScriptRoot '..' '..' 'scripts' 'powershell' 'Test-TargetReadiness.ps1'
+    $scriptPath = (Resolve-Path $scriptPath).Path
+
+    It 'exists' {
+        Test-Path -LiteralPath $scriptPath | Should -BeTrue
+    }
+
+    It 'contains comment-based help sections' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        $content | Should -Match '\.SYNOPSIS'
+        $content | Should -Match '\.DESCRIPTION'
+        $content | Should -Match '\.PARAMETER\s+Target'
+        $content | Should -Match '\.EXAMPLE'
+        $content | Should -Match 'Safety'
+    }
+
+    It 'can run localhost mode without remote dependency' {
+        $outRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-readiness-' + [guid]::NewGuid().Guid)
+        $results = & $scriptPath -Target 'localhost' -OutputRoot $outRoot
+
+        $results | Should -Not -BeNullOrEmpty
+        $results[0].target | Should -Be 'localhost'
+        $results[0].checks | Should -Not -BeNullOrEmpty
+        ($results[0].checks | Select-Object -ExpandProperty status) | Should -Contain 'Pass'
+        Remove-Item -LiteralPath $outRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'parses CSV targets with common column names' {
+        $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-readiness-csv-' + [guid]::NewGuid().Guid)
+        New-Item -Path $tmpDir -ItemType Directory -Force | Out-Null
+        $csvPath = Join-Path $tmpDir 'targets.csv'
+        @(
+            [pscustomobject]@{ Target = 'localhost' },
+            [pscustomobject]@{ ComputerName = 'example.invalid' }
+        ) | Export-Csv -LiteralPath $csvPath -NoTypeInformation
+
+        $results = & $scriptPath -TargetsCsv $csvPath -OutputRoot $tmpDir
+
+        ($results | Measure-Object).Count | Should -Be 2
+        ($results.target) | Should -Contain 'localhost'
+        ($results.target) | Should -Contain 'example.invalid'
+        Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'returns structured statuses for unreachable targets without crashing batch' {
+        $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-readiness-unreach-' + [guid]::NewGuid().Guid)
+        New-Item -Path $tmpDir -ItemType Directory -Force | Out-Null
+        $csvPath = Join-Path $tmpDir 'targets.csv'
+        @([pscustomobject]@{ Target = 'example.invalid' }) | Export-Csv -LiteralPath $csvPath -NoTypeInformation
+
+        $results = & $scriptPath -TargetsCsv $csvPath -OutputRoot $tmpDir
+
+        $results | Should -Not -BeNullOrEmpty
+        $results[0].overall_status | Should -Match 'Ready|PartiallyReady|NotReady|Unknown'
+        foreach ($check in $results[0].checks) {
+            $check.status | Should -Match 'Pass|Fail|NotChecked|Error'
+            $check.PSObject.Properties.Name | Should -Contain 'details'
+            $check.PSObject.Properties.Name | Should -Contain 'error_message'
+        }
+        Remove-Item -LiteralPath $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'does not contain forbidden registry or remoting mutation commands' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        @(
+            'Set-ItemProperty',
+            'New-ItemProperty',
+            'Remove-ItemProperty',
+            'reg add',
+            'reg delete',
+            'Enable-PSRemoting',
+            'Set-Service\s+RemoteRegistry',
+            'Start-Service\s+RemoteRegistry',
+            'Stop-Service\s+RemoteRegistry'
+        ) | ForEach-Object {
+            $content | Should -Not -Match $_
+        }
+    }
+}

--- a/scripts/powershell/Test-TargetReadiness.ps1
+++ b/scripts/powershell/Test-TargetReadiness.ps1
@@ -1,0 +1,352 @@
+<#
+.SYNOPSIS
+Performs read-only target readiness checks for the Registry Install Diff Pipeline.
+
+.DESCRIPTION
+Runs Recon readiness checks for localhost, a single target, or a target list from CSV.
+The script is evidence-first and read-only: it does not install software and does not edit
+registry, service, or remoting settings.
+
+.PARAMETER Target
+Single target to check. Use localhost for local-only checks.
+
+.PARAMETER TargetsCsv
+CSV file containing targets. Expected column names include Target, ComputerName,
+Hostname, or Name. First non-empty value in those columns is used.
+
+.PARAMETER OutputRoot
+Directory for generated outputs. Defaults to exports/registry-install-diff/readiness.
+
+.PARAMETER OutputJson
+Optional JSON output file path. If omitted, a run-specific JSON file is created under OutputRoot.
+
+.PARAMETER OutputCsv
+Optional CSV output file path. If omitted, a run-specific CSV file is created under OutputRoot.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Test-TargetReadiness.ps1 -Target localhost
+Runs readiness checks for localhost.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Test-TargetReadiness.ps1 -TargetsCsv Config/target_batch.example.csv
+Runs readiness checks for targets listed in CSV.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Test-TargetReadiness.ps1 -Target HOST01 -OutputJson exports/registry-install-diff/readiness/readiness.json -OutputCsv exports/registry-install-diff/readiness/readiness.csv
+Runs readiness checks and exports to explicit JSON and CSV paths.
+
+.NOTES
+Safety:
+- Read-only by design.
+- No registry writes.
+- No service start/stop operations.
+- No WinRM enablement or remoting mutation.
+- No write attempts to admin shares.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(ParameterSetName = 'Single')]
+    [string]$Target = 'localhost',
+
+    [Parameter(ParameterSetName = 'Csv', Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$TargetsCsv,
+
+    [string]$OutputRoot = 'exports/registry-install-diff/readiness',
+    [string]$OutputJson,
+    [string]$OutputCsv
+)
+
+$ErrorActionPreference = 'Stop'
+
+function New-CheckResult {
+    param(
+        [string]$Name,
+        [string]$Status = 'NotChecked',
+        [hashtable]$Details = @{},
+        [string]$ErrorMessage
+    )
+
+    [pscustomobject]@{
+        name          = $Name
+        status        = $Status
+        details       = $Details
+        error_message = $ErrorMessage
+    }
+}
+
+function Get-TargetsFromCsv {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "TargetsCsv not found: $Path"
+    }
+
+    $rows = Import-Csv -LiteralPath $Path
+    $targets = New-Object System.Collections.Generic.List[string]
+
+    foreach ($row in $rows) {
+        $candidate = $null
+        foreach ($name in @('Target', 'ComputerName', 'Hostname', 'Name')) {
+            if ($row.PSObject.Properties.Name -contains $name) {
+                $value = [string]$row.$name
+                if (-not [string]::IsNullOrWhiteSpace($value)) {
+                    $candidate = $value.Trim()
+                    break
+                }
+            }
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+            $targets.Add($candidate)
+        }
+    }
+
+    return $targets | Select-Object -Unique
+}
+
+function Get-PendingRebootEvidence {
+    $signals = New-Object System.Collections.Generic.List[string]
+    $keyPaths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending',
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
+    )
+
+    foreach ($path in $keyPaths) {
+        if (Test-Path -LiteralPath $path) {
+            $signals.Add($path)
+        }
+    }
+
+    try {
+        $sessionMgr = Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Name 'PendingFileRenameOperations' -ErrorAction SilentlyContinue
+        if ($null -ne $sessionMgr.PendingFileRenameOperations) {
+            $signals.Add('HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations')
+        }
+    }
+    catch {
+        # ignore and rely on gathered signals
+    }
+
+    return $signals
+}
+
+function Get-OverallStatus {
+    param([object[]]$Checks)
+
+    if (-not $Checks -or $Checks.Count -eq 0) {
+        return 'Unknown'
+    }
+
+    $hasFail = $Checks.status -contains 'Fail'
+    $hasPass = $Checks.status -contains 'Pass'
+    $allNotChecked = ($Checks | Where-Object { $_.status -ne 'NotChecked' -and $_.status -ne 'Error' }).Count -eq 0
+
+    if ($hasFail -and -not $hasPass) { return 'NotReady' }
+    if ($hasFail -and $hasPass) { return 'PartiallyReady' }
+    if ($allNotChecked) { return 'Unknown' }
+    if ($hasPass) { return 'Ready' }
+    return 'Unknown'
+}
+
+function Test-TargetReadinessInternal {
+    param(
+        [string]$TargetName,
+        [string]$RunId,
+        [datetime]$CheckedAt,
+        [string]$JsonPath,
+        [string]$CsvPath
+    )
+
+    $checks = New-Object System.Collections.Generic.List[object]
+    $errors = New-Object System.Collections.Generic.List[string]
+    $scope = 'unresolved'
+
+    $identityDetails = @{ input_target = $TargetName }
+    $resolvedAddresses = @()
+
+    try {
+        if ($TargetName -in @('localhost', '.', $env:COMPUTERNAME)) {
+            $scope = 'localhost'
+            $identityDetails.resolved_hostname = $env:COMPUTERNAME
+        }
+        else {
+            $scope = 'remote'
+            $identityDetails.resolved_hostname = $TargetName
+        }
+        $checks.Add((New-CheckResult -Name 'TargetIdentity' -Status 'Pass' -Details $identityDetails))
+    }
+    catch {
+        $scope = 'unresolved'
+        $checks.Add((New-CheckResult -Name 'TargetIdentity' -Status 'Error' -Details $identityDetails -ErrorMessage $_.Exception.Message))
+        $errors.Add("TargetIdentity: $($_.Exception.Message)")
+    }
+
+    try {
+        if (Get-Command -Name Resolve-DnsName -ErrorAction SilentlyContinue) {
+            $dns = Resolve-DnsName -Name $TargetName -ErrorAction Stop
+            $resolvedAddresses = @($dns | Where-Object { $_.IPAddress } | Select-Object -ExpandProperty IPAddress -Unique)
+            $checks.Add((New-CheckResult -Name 'DnsResolution' -Status 'Pass' -Details @{ resolved_addresses = $resolvedAddresses }))
+        }
+        else {
+            $checks.Add((New-CheckResult -Name 'DnsResolution' -Status 'NotChecked' -Details @{ reason = 'Resolve-DnsName unavailable' }))
+        }
+    }
+    catch {
+        $checks.Add((New-CheckResult -Name 'DnsResolution' -Status 'Fail' -Details @{ resolved_addresses = @() } -ErrorMessage $_.Exception.Message))
+    }
+
+    try {
+        if (Get-Command -Name Test-Connection -ErrorAction SilentlyContinue) {
+            $reachable = Test-Connection -ComputerName $TargetName -Count 1 -Quiet -ErrorAction SilentlyContinue
+            if ($reachable) {
+                $checks.Add((New-CheckResult -Name 'Reachability' -Status 'Pass' -Details @{ reason = 'ICMP response received' }))
+            }
+            else {
+                $checks.Add((New-CheckResult -Name 'Reachability' -Status 'Fail' -Details @{ reason = 'No ICMP response; firewall or host policy may block ICMP' }))
+            }
+        }
+        else {
+            $checks.Add((New-CheckResult -Name 'Reachability' -Status 'NotChecked' -Details @{ reason = 'Test-Connection unavailable' }))
+        }
+    }
+    catch {
+        $checks.Add((New-CheckResult -Name 'Reachability' -Status 'Error' -Details @{} -ErrorMessage $_.Exception.Message))
+    }
+
+    try {
+        if ($scope -eq 'localhost') {
+            $checks.Add((New-CheckResult -Name 'AdminShareAccess' -Status 'NotChecked' -Details @{ reason = 'Admin share check is remote-focused' }))
+        }
+        else {
+            $adminPath = "\\$TargetName\C$"
+            $exists = Test-Path -LiteralPath $adminPath -ErrorAction SilentlyContinue
+            if ($exists) {
+                $checks.Add((New-CheckResult -Name 'AdminShareAccess' -Status 'Pass' -Details @{ path = $adminPath; access = 'Readable' }))
+            }
+            else {
+                $checks.Add((New-CheckResult -Name 'AdminShareAccess' -Status 'Fail' -Details @{ path = $adminPath; access = 'UnavailableOrUnauthorized' }))
+            }
+        }
+    }
+    catch {
+        $checks.Add((New-CheckResult -Name 'AdminShareAccess' -Status 'Error' -Details @{} -ErrorMessage $_.Exception.Message))
+    }
+
+    try {
+        if (Get-Command -Name Test-WSMan -ErrorAction SilentlyContinue) {
+            Test-WSMan -ComputerName $TargetName -ErrorAction Stop | Out-Null
+            $checks.Add((New-CheckResult -Name 'WinRMAvailability' -Status 'Pass' -Details @{ reason = 'Test-WSMan succeeded' }))
+        }
+        else {
+            $checks.Add((New-CheckResult -Name 'WinRMAvailability' -Status 'NotChecked' -Details @{ reason = 'Test-WSMan unavailable' }))
+        }
+    }
+    catch {
+        $checks.Add((New-CheckResult -Name 'WinRMAvailability' -Status 'Fail' -Details @{ reason = 'WinRM not available or inaccessible' } -ErrorMessage $_.Exception.Message))
+    }
+
+    try {
+        if ($scope -eq 'localhost') {
+            $svc = Get-Service -Name 'RemoteRegistry' -ErrorAction Stop
+        }
+        else {
+            $svc = Get-Service -Name 'RemoteRegistry' -ComputerName $TargetName -ErrorAction Stop
+        }
+        $svcStatus = if ($svc.Status -eq 'Running') { 'Pass' } else { 'Fail' }
+        $checks.Add((New-CheckResult -Name 'RemoteRegistryAvailability' -Status $svcStatus -Details @{ service_status = [string]$svc.Status; startup_type = [string]$svc.StartType }))
+    }
+    catch {
+        $checks.Add((New-CheckResult -Name 'RemoteRegistryAvailability' -Status 'NotChecked' -Details @{ reason = 'Service state unavailable without remote service access' } -ErrorMessage $_.Exception.Message))
+    }
+
+    try {
+        if ($scope -eq 'localhost') {
+            $signals = Get-PendingRebootEvidence
+            if ($signals.Count -gt 0) {
+                $checks.Add((New-CheckResult -Name 'PendingRebootSignal' -Status 'Fail' -Details @{ signal_count = $signals.Count; evidence_summary = $signals }))
+            }
+            else {
+                $checks.Add((New-CheckResult -Name 'PendingRebootSignal' -Status 'Pass' -Details @{ signal_count = 0; evidence_summary = @('No common pending reboot signals found') }))
+            }
+        }
+        else {
+            $checks.Add((New-CheckResult -Name 'PendingRebootSignal' -Status 'NotChecked' -Details @{ reason = 'Remote pending reboot check requires validated remote registry path' }))
+        }
+    }
+    catch {
+        $checks.Add((New-CheckResult -Name 'PendingRebootSignal' -Status 'Error' -Details @{} -ErrorMessage $_.Exception.Message))
+    }
+
+    $overall = Get-OverallStatus -Checks $checks
+
+    return [pscustomobject]@{
+        schema_version = '1.0.0'
+        run_id         = $RunId
+        checked_at     = $CheckedAt.ToString('o')
+        target         = $TargetName
+        scope          = $scope
+        overall_status = $overall
+        checks         = $checks
+        errors         = $errors
+        output_paths   = [pscustomobject]@{
+            json = $JsonPath
+            csv  = $CsvPath
+        }
+    }
+}
+
+$runId = [guid]::NewGuid().Guid
+$checkedAt = Get-Date
+
+if (-not (Test-Path -LiteralPath $OutputRoot)) {
+    New-Item -Path $OutputRoot -ItemType Directory -Force | Out-Null
+}
+
+if (-not $OutputJson) { $OutputJson = Join-Path $OutputRoot "readiness-$runId.json" }
+if (-not $OutputCsv) { $OutputCsv = Join-Path $OutputRoot "readiness-$runId.csv" }
+
+$targets = if ($PSCmdlet.ParameterSetName -eq 'Csv') { Get-TargetsFromCsv -Path $TargetsCsv } else { @($Target) }
+if (-not $targets -or $targets.Count -eq 0) {
+    throw 'No targets resolved for readiness checks.'
+}
+
+$results = foreach ($item in $targets) {
+    try {
+        Test-TargetReadinessInternal -TargetName $item -RunId $runId -CheckedAt $checkedAt -JsonPath $OutputJson -CsvPath $OutputCsv
+    }
+    catch {
+        [pscustomobject]@{
+            schema_version = '1.0.0'
+            run_id         = $runId
+            checked_at     = $checkedAt.ToString('o')
+            target         = $item
+            scope          = 'unresolved'
+            overall_status = 'Unknown'
+            checks         = @()
+            errors         = @($_.Exception.Message)
+            output_paths   = [pscustomobject]@{ json = $OutputJson; csv = $OutputCsv }
+        }
+    }
+}
+
+$results | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $OutputJson -Encoding UTF8
+
+$csvRows = foreach ($r in $results) {
+    foreach ($c in $r.checks) {
+        [pscustomobject]@{
+            run_id         = $r.run_id
+            checked_at     = $r.checked_at
+            target         = $r.target
+            scope          = $r.scope
+            overall_status = $r.overall_status
+            check_name     = $c.name
+            check_status   = $c.status
+            details        = ($c.details | ConvertTo-Json -Compress)
+            error_message  = $c.error_message
+        }
+    }
+}
+$csvRows | Export-Csv -LiteralPath $OutputCsv -NoTypeInformation -Encoding UTF8
+
+$results


### PR DESCRIPTION
## **User description**
### Motivation
- Provide an evidence-first readiness layer for the Registry Install Diff Pipeline that validates targets before snapshotting or installing software. 
- Support single-target and batch workflows and produce machine-readable artifacts to feed later registry snapshot/diff stages. 
- Preserve the PowerShell Windows lane and ensure no registry, service, remoting, or admin-share mutations are performed by default. 

### Description
- Add `scripts/powershell/Test-TargetReadiness.ps1`, a read-only PowerShell script supporting `-Target`, `-TargetsCsv`, `-OutputRoot`, `-OutputJson`, and `-OutputCsv` that emits per-target objects containing `schema_version`, `run_id`, `checked_at`, `target`, `scope`, `overall_status`, `checks`, `errors`, and `output_paths`. 
- Implement read-only checks for `TargetIdentity`, `DnsResolution`, `Reachability`, `AdminShareAccess` (read-only availability), `WinRMAvailability` (via `Test-WSMan`), `RemoteRegistryAvailability` (via `Get-Service`), and `PendingRebootSignal` (local read-only registry evidence). 
- Provide JSON and CSV export of results and ensure graceful per-target failure handling so a single target failure does not abort the batch. 
- Add `Tests/Pester/TargetReadiness.Tests.ps1` with tests for script existence, comment-based help, localhost invocation, CSV parsing, structured status outputs, and guardrails to assert the script does not contain forbidden mutation commands. 

### Testing
- Created the Pester test suite at `Tests/Pester/TargetReadiness.Tests.ps1` to validate behavior and safety checks, but the Pester suite was not executed in this environment due to missing PowerShell runtimes. 
- An attempt to run the readiness script here with `pwsh`/`powershell` reported `command not found`, so runtime validation is pending in an environment with PowerShell and Pester available. 
- Static/safety assertions are included in the tests to verify absence of forbidden mutation commands and should pass when run in a Windows/PowerShell environment with Pester installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12699ee47883228b65fc1e9ec4bd06)


___

## **CodeAnt-AI Description**
**Add read-only readiness checks for pipeline targets**

### What Changed
- Added a new PowerShell check that verifies whether a target is ready for the registry install diff pipeline without making changes
- Supports checking a single machine or a list of targets from CSV, and continues processing the rest if one target fails
- Produces JSON and CSV results for each target, including overall readiness, individual check results, and error details
- Checks target identity, name resolution, reachability, admin share access, WinRM availability, Remote Registry status, and local pending reboot signals
- Added tests that confirm the script exists, includes help text, handles localhost and CSV input, returns structured results, and avoids mutation commands

### Impact
`✅ Safer target validation before installs`
`✅ Fewer batch interruptions when one target fails`
`✅ Clearer readiness results for pipeline runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
