### PR TITLE
Add read-only PowerShell registry snapshot script and Pester tests

### DIFF
--- a/Tests/Pester/RegistrySnapshot.Tests.ps1
+++ b/Tests/Pester/RegistrySnapshot.Tests.ps1
@@ -1,0 +1,60 @@
+Describe 'Get-RegistrySnapshot Script' {
+    $scriptPath = Join-Path $PSScriptRoot '..\..\scripts\powershell\Get-RegistrySnapshot.ps1'
+
+    It 'script exists' {
+        Test-Path -LiteralPath $scriptPath | Should -BeTrue
+    }
+
+    It 'has comment-based help synopsis' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        $content | Should -Match '\.SYNOPSIS'
+        $content | Should -Match '\.DESCRIPTION'
+        $content | Should -Match 'Safety notes'
+    }
+
+    It 'accepts localhost invocation with narrow key and parses output' {
+        $result = & $scriptPath -Target localhost -RegistryPath 'HKLM:\SOFTWARE\Microsoft' -ExcludePattern '*\DoesNotMatch*'
+        $result | Should -Not -BeNullOrEmpty
+        $result.target.scope | Should -Be 'localhost'
+        $result.entries.Count | Should -BeGreaterOrEqual 1
+        $result.entries[0].PSObject.Properties.Name | Should -Contain 'key_path'
+        $result.entries[0].PSObject.Properties.Name | Should -Contain 'access_status'
+    }
+
+    It 'creates output JSON when OutputPath is supplied' {
+        $tempPath = Join-Path $env:TEMP "registry-snapshot-test-$([guid]::NewGuid().ToString()).json"
+        $null = & $scriptPath -Target localhost -RegistryPath 'HKLM:\SOFTWARE\Microsoft' -OutputPath $tempPath
+
+        Test-Path -LiteralPath $tempPath | Should -BeTrue
+        $parsed = Get-Content -LiteralPath $tempPath -Raw | ConvertFrom-Json
+        $parsed.schema_version | Should -Not -BeNullOrEmpty
+        $parsed.entries | Should -Not -BeNullOrEmpty
+
+        Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'handles missing paths without fatal crash' {
+        $result = & $scriptPath -Target localhost -RegistryPath 'HKLM:\SOFTWARE\DefinitelyMissingPath_ForRegistrySnapshotTests'
+        $result | Should -Not -BeNullOrEmpty
+        ($result.entries | Where-Object { $_.access_status -eq 'NotFound' }).Count | Should -BeGreaterThan 0
+    }
+
+    It 'accepts exclude patterns array' {
+        $result = & $scriptPath -Target localhost -RegistryPaths 'HKLM:\SOFTWARE\Microsoft' -ExcludePatterns '*\Volatile*','*\RecentDocs*'
+        $result.summary.PSObject.Properties.Name | Should -Contain 'excluded'
+    }
+
+    It 'does not include forbidden write or remoting commands' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        $forbidden = @(
+            'Set-ItemProperty','New-ItemProperty','Remove-ItemProperty',
+            'reg add','reg delete','reg import','reg restore',
+            'Start-Service RemoteRegistry','Stop-Service RemoteRegistry','Set-Service RemoteRegistry',
+            'Enable-PSRemoting','Start-Process .*msi','msiexec'
+        )
+
+        foreach ($term in $forbidden) {
+            $content | Should -Not -Match [regex]::Escape($term)
+        }
+    }
+}

--- a/scripts/powershell/Get-RegistrySnapshot.ps1
+++ b/scripts/powershell/Get-RegistrySnapshot.ps1
@@ -1,0 +1,324 @@
+<#
+.SYNOPSIS
+Captures a read-only registry snapshot for install-diff evidence collection.
+
+.DESCRIPTION
+Get-RegistrySnapshot.ps1 captures selected registry keys and values into a structured object
+and optional JSON export. It is designed for the Registry Install Diff Pipeline evidence flow
+(Recon -> Decide -> Act -> Log -> Export).
+
+By default, the script inspects:
+- HKLM:\Software
+- HKLM:\Software\WOW6432Node
+- HKLM:\System\CurrentControlSet\Services
+- HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall
+
+If -Target is not localhost (or local machine aliases), remote capture is not implemented in this
+sprint. The script returns a structured result with an error reason of
+RemoteRegistrySnapshotNotImplemented and does not modify remoting, services, or credentials.
+
+.PARAMETER Target
+Capture target. Defaults to localhost.
+
+.PARAMETER RegistryPath
+Single registry root path to snapshot.
+
+.PARAMETER RegistryPaths
+Multiple registry root paths to snapshot.
+
+.PARAMETER ExcludePattern
+Single wildcard exclusion pattern applied to registry key paths.
+
+.PARAMETER ExcludePatterns
+Multiple wildcard exclusion patterns applied to registry key paths.
+
+.PARAMETER OutputPath
+Optional JSON output path for persisted snapshot evidence.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Get-RegistrySnapshot.ps1 -Target localhost
+Captures default watch areas on localhost and returns structured output.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Get-RegistrySnapshot.ps1 -Target localhost -RegistryPath "HKLM:\Software\ExampleVendor"
+Captures a single explicit key path.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Get-RegistrySnapshot.ps1 -Target localhost -RegistryPaths "HKLM:\Software","HKLM:\Software\WOW6432Node" -ExcludePatterns "*\RecentDocs*","*\SessionInformation*"
+Captures selected paths while skipping excluded patterns.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Get-RegistrySnapshot.ps1 -Target localhost -RegistryPath "HKLM:\Software" -OutputPath "exports/registry-install-diff/test/registry_before.json"
+Captures snapshot and writes structured JSON to the requested file.
+
+.NOTES
+Safety notes:
+- Read-only evidence capture only.
+- No registry writes, installer execution, remoting changes, or service changes are performed.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Target = 'localhost',
+
+    [Parameter()]
+    [string]$RegistryPath,
+
+    [Parameter()]
+    [string[]]$RegistryPaths,
+
+    [Parameter()]
+    [string]$ExcludePattern,
+
+    [Parameter()]
+    [string[]]$ExcludePatterns,
+
+    [Parameter()]
+    [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$defaultRegistryPaths = @(
+    'HKLM:\Software',
+    'HKLM:\Software\WOW6432Node',
+    'HKLM:\System\CurrentControlSet\Services',
+    'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$effectiveRegistryPaths = @()
+if ($RegistryPath) { $effectiveRegistryPaths += $RegistryPath }
+if ($RegistryPaths) { $effectiveRegistryPaths += $RegistryPaths }
+if (-not $effectiveRegistryPaths -or $effectiveRegistryPaths.Count -eq 0) {
+    $effectiveRegistryPaths = $defaultRegistryPaths
+}
+$effectiveRegistryPaths = $effectiveRegistryPaths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+$effectiveExcludePatterns = @()
+if ($ExcludePattern) { $effectiveExcludePatterns += $ExcludePattern }
+if ($ExcludePatterns) { $effectiveExcludePatterns += $ExcludePatterns }
+$effectiveExcludePatterns = $effectiveExcludePatterns | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+function Get-ValueDataKind {
+    param([object]$Value)
+
+    if ($null -eq $Value) { return 'unknown' }
+    if ($Value -is [string]) {
+        if ($Value -match '%[^%]+%') { return 'expandable_string' }
+        return 'string'
+    }
+    if ($Value -is [int]) { return 'dword' }
+    if ($Value -is [long]) { return 'qword' }
+    if ($Value -is [byte[]]) { return 'binary' }
+    if ($Value -is [string[]]) { return 'multi_string' }
+    return 'unknown'
+}
+
+function Convert-ValueData {
+    param([object]$Value)
+
+    if ($Value -is [byte[]]) {
+        return [Convert]::ToBase64String($Value)
+    }
+    return $Value
+}
+
+function Test-IsExcluded {
+    param(
+        [string]$Path,
+        [string[]]$Patterns
+    )
+
+    foreach ($pattern in $Patterns) {
+        if ($Path -like $pattern) {
+            return $true
+        }
+    }
+    return $false
+}
+
+$capturedAt = (Get-Date).ToString('o')
+$runId = [guid]::NewGuid().ToString()
+$hostName = $env:COMPUTERNAME
+$scope = 'localhost'
+$targetNotes = 'Read-only local capture completed.'
+
+$localAliases = @('localhost', '.', $env:COMPUTERNAME)
+if ($localAliases -notcontains $Target) {
+    $scope = 'remote'
+    $targetNotes = 'Remote registry snapshot is not implemented in this sprint.'
+}
+
+$result = [ordered]@{
+    schema_version = '1.0.0'
+    run_id         = $runId
+    target         = [ordered]@{
+        hostname = if ($Target) { $Target } else { $hostName }
+        scope    = $scope
+        notes    = $targetNotes
+    }
+    captured_at    = $capturedAt
+    source         = [ordered]@{
+        script = 'scripts/powershell/Get-RegistrySnapshot.ps1'
+        mode   = 'read_only'
+    }
+    registry_paths = $effectiveRegistryPaths
+    entries        = @()
+    errors         = @()
+    summary        = [ordered]@{
+        roots_requested = $effectiveRegistryPaths.Count
+        keys_scanned    = 0
+        entries_total   = 0
+        captured        = 0
+        access_denied   = 0
+        not_found       = 0
+        errors          = 0
+        excluded        = 0
+    }
+    output_path    = $OutputPath
+}
+
+if ($scope -ne 'localhost') {
+    $result.target.scope = 'remote'
+    $result.target.notes = 'RemoteRegistrySnapshotNotImplemented'
+    $result.errors += [ordered]@{
+        key_path      = $null
+        access_status = 'Error'
+        error_message = 'RemoteRegistrySnapshotNotImplemented'
+        captured_at   = (Get-Date).ToString('o')
+    }
+    $result.summary.errors = 1
+}
+else {
+    foreach ($rootPath in $effectiveRegistryPaths) {
+        if (Test-IsExcluded -Path $rootPath -Patterns $effectiveExcludePatterns) {
+            $result.summary.excluded++
+            continue
+        }
+
+        if (-not (Test-Path -LiteralPath $rootPath)) {
+            $missingEntry = [ordered]@{
+                key_path        = $rootPath
+                value_name      = $null
+                value_type      = $null
+                value_data      = $null
+                value_data_kind = 'unknown'
+                captured_at     = (Get-Date).ToString('o')
+                access_status   = 'NotFound'
+                error_message   = 'Registry path not found.'
+            }
+            $result.entries += $missingEntry
+            $result.summary.entries_total++
+            $result.summary.not_found++
+            continue
+        }
+
+        $pending = New-Object System.Collections.Generic.Queue[string]
+        $pending.Enqueue($rootPath)
+
+        while ($pending.Count -gt 0) {
+            $currentPath = $pending.Dequeue()
+            if (Test-IsExcluded -Path $currentPath -Patterns $effectiveExcludePatterns) {
+                $result.summary.excluded++
+                continue
+            }
+
+            $result.summary.keys_scanned++
+
+            try {
+                $item = Get-Item -LiteralPath $currentPath -ErrorAction Stop
+
+                $valueNames = @($item.GetValueNames())
+                if ($valueNames.Count -eq 0) {
+                    $result.entries += [ordered]@{
+                        key_path        = $currentPath
+                        value_name      = $null
+                        value_type      = $null
+                        value_data      = $null
+                        value_data_kind = 'unknown'
+                        captured_at     = (Get-Date).ToString('o')
+                        access_status   = 'Captured'
+                        error_message   = $null
+                    }
+                    $result.summary.entries_total++
+                    $result.summary.captured++
+                }
+                else {
+                    foreach ($valueName in $valueNames) {
+                        $rawValue = $item.GetValue($valueName, $null)
+                        $kind = Get-ValueDataKind -Value $rawValue
+                        $valueData = Convert-ValueData -Value $rawValue
+                        $valueKind = $item.GetValueKind($valueName).ToString()
+
+                        $result.entries += [ordered]@{
+                            key_path        = $currentPath
+                            value_name      = if ([string]::IsNullOrEmpty($valueName)) { '(Default)' } else { $valueName }
+                            value_type      = $valueKind
+                            value_data      = $valueData
+                            value_data_kind = $kind
+                            captured_at     = (Get-Date).ToString('o')
+                            access_status   = 'Captured'
+                            error_message   = $null
+                        }
+                        $result.summary.entries_total++
+                        $result.summary.captured++
+                    }
+                }
+
+                try {
+                    $children = Get-ChildItem -LiteralPath $currentPath -ErrorAction Stop
+                    foreach ($child in $children) {
+                        if (-not (Test-IsExcluded -Path $child.PSPath.Replace('Microsoft.PowerShell.Core\Registry::', '') -Patterns $effectiveExcludePatterns)) {
+                            $pending.Enqueue($child.PSPath.Replace('Microsoft.PowerShell.Core\Registry::', ''))
+                        }
+                        else {
+                            $result.summary.excluded++
+                        }
+                    }
+                }
+                catch {
+                    $result.errors += [ordered]@{
+                        key_path      = $currentPath
+                        access_status = 'Error'
+                        error_message = $_.Exception.Message
+                        captured_at   = (Get-Date).ToString('o')
+                    }
+                    $result.summary.errors++
+                }
+            }
+            catch {
+                $message = $_.Exception.Message
+                $status = if ($message -match 'denied') { 'AccessDenied' } else { 'Error' }
+
+                $result.entries += [ordered]@{
+                    key_path        = $currentPath
+                    value_name      = $null
+                    value_type      = $null
+                    value_data      = $null
+                    value_data_kind = 'unknown'
+                    captured_at     = (Get-Date).ToString('o')
+                    access_status   = $status
+                    error_message   = $message
+                }
+                $result.summary.entries_total++
+                if ($status -eq 'AccessDenied') {
+                    $result.summary.access_denied++
+                }
+                else {
+                    $result.summary.errors++
+                }
+            }
+        }
+    }
+}
+
+if ($OutputPath) {
+    $outDir = Split-Path -Path $OutputPath -Parent
+    if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
+        New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+    }
+    ($result | ConvertTo-Json -Depth 8) | Set-Content -Path $OutputPath -Encoding UTF8
+}
+
+$result


### PR DESCRIPTION
## **User description**
### Motivation
- Provide a read-only evidence capture layer for the Registry Install Diff Pipeline so registry state can be captured before/after installs without making changes.  
- Ensure the snapshot format is structured and machine-readable to support later diffs, classification, and export workflows.

### Description
- Add `scripts/powershell/Get-RegistrySnapshot.ps1`, a read-only PowerShell script that recursively captures specified registry root paths with support for `-Target`, `-RegistryPath`/`-RegistryPaths`, `-ExcludePattern`/`-ExcludePatterns`, and `-OutputPath`, and includes comment-based help and examples.  
- Use a stable structured result object and JSON export containing `schema_version`, `run_id`, `target`, `captured_at`, `source`, `registry_paths`, `entries`, `errors`, `summary`, and `output_path`, and ensure each `entry` has `key_path`, `value_name`, `value_type`, `value_data`, `value_data_kind`, `captured_at`, `access_status`, and `error_message`.  
- Preserve keys that have no values (emit an entry with `value_name = $null` and `access_status = 'Captured'`) so downstream create/delete diffs can be detected.  
- Implement remote-target behavior as an explicit, non-destructive stub that returns `RemoteRegistrySnapshotNotImplemented` without changing remoting, services, or prompting for credentials, and avoid any registry write or service commands (forbidden operations are not present). 

### Testing
- Added Pester tests at `Tests/Pester/RegistrySnapshot.Tests.ps1` that assert script presence, comment-based help, localhost invocation with a narrow safe key, JSON output creation/parsing, missing-path handling, exclude-pattern acceptance, and absence of forbidden write/remoting/installer commands.  
- Attempted to run the script with `pwsh` in this environment but the PowerShell runtime is not available (`pwsh: command not found`), so automated execution and Pester runs could not be completed here.  
- The changes were committed locally (`64082952e67de9500791fa79edf346783cdab535`), but pushing to the remote branch failed because this environment has no configured `origin` remote, so remote CI/test execution was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1269bafd1483228720a74610abd3b0)


___

## **CodeAnt-AI Description**
**Add a read-only registry snapshot script for install-diff capture**

### What Changed
- Added a PowerShell script that captures registry keys and values into a structured snapshot for later comparison.
- The script can target local registry paths, skip matching paths, and save the snapshot as JSON when an output file is provided.
- Missing registry paths, access issues, and empty keys are recorded in the output instead of stopping the run.
- Remote snapshot capture is not available yet; non-local targets return a clear `RemoteRegistrySnapshotNotImplemented` result without making changes.
- Added tests that verify the script exists, produces structured output, writes JSON, handles missing paths, accepts exclude patterns, and avoids write or remoting actions.

### Impact
`✅ Read-only registry evidence capture`
`✅ Fewer failed snapshot runs on missing keys`
`✅ Clearer export files for diff review`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
