### PR TITLE
Add Compare-RegistrySnapshots.ps1 and Pester tests for registry diffing

### DIFF
--- a/Tests/Pester/RegistryDiff.Tests.ps1
+++ b/Tests/Pester/RegistryDiff.Tests.ps1
@@ -1,0 +1,97 @@
+Describe 'Compare-RegistrySnapshots script' {
+    $scriptPath = Join-Path $PSScriptRoot '..\..\scripts\powershell\Compare-RegistrySnapshots.ps1'
+
+    It 'exists' {
+        Test-Path -LiteralPath $scriptPath | Should -BeTrue
+    }
+
+    It 'contains comment-based help sections' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        $content | Should -Match '\.SYNOPSIS'
+        $content | Should -Match '\.DESCRIPTION'
+        $content | Should -Match '\.PARAMETER BeforeSnapshotPath'
+        $content | Should -Match '\.EXAMPLE'
+    }
+
+    It 'does not include forbidden registry mutation or remote registry commands' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        @( 
+            'Set-ItemProperty','New-ItemProperty','Remove-ItemProperty','reg add','reg delete','reg import','reg restore',
+            'Start-Service RemoteRegistry','Stop-Service RemoteRegistry','Set-Service RemoteRegistry','Enable-PSRemoting',
+            'Start-Process .*msi','msiexec','winget install','choco install'
+        ) | ForEach-Object {
+            $content | Should -Not -Match $_
+        }
+    }
+
+    It 'classifies created/deleted/modified and applies rules and writes outputs' {
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("registry-diff-test-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $tempRoot | Out-Null
+
+        $beforePath = Join-Path $tempRoot 'before.json'
+        $afterPath = Join-Path $tempRoot 'after.json'
+        $rulesPath = Join-Path $tempRoot 'rules.json'
+        $outJson = Join-Path $tempRoot 'out.json'
+        $outCsv = Join-Path $tempRoot 'out.csv'
+
+        $before = @{
+            target = 'LAB-PC-001'
+            entries = @(
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp\OldKey' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'DeleteMe'; value_type = 'String'; value_data = 'A'; value_data_kind = 'text'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'ModifyMe'; value_type = 'String'; value_data = 'Before'; value_data_kind = 'text'; access_status = 'ok' },
+                @{ key_path = 'HKCU\Software\RecentDocs'; value_name = 'MRU1'; value_type = 'String'; value_data = 'old'; value_data_kind = 'text'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'ExpectedSetting'; value_type = 'DWord'; value_data = 0; value_data_kind = 'number'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'SuspiciousToggle'; value_type = 'DWord'; value_data = 0; value_data_kind = 'number'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'CandidateSetting'; value_type = 'String'; value_data = 'Off'; value_data_kind = 'text'; access_status = 'ok' }
+            )
+        }
+        $after = @{
+            target = 'LAB-PC-001'
+            entries = @(
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp\NewKey' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'CreateMe'; value_type = 'String'; value_data = 'B'; value_data_kind = 'text'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'ModifyMe'; value_type = 'String'; value_data = 'After'; value_data_kind = 'text'; access_status = 'ok' },
+                @{ key_path = 'HKCU\Software\RecentDocs'; value_name = 'MRU1'; value_type = 'String'; value_data = 'new'; value_data_kind = 'text'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'ExpectedSetting'; value_type = 'DWord'; value_data = 1; value_data_kind = 'number'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'SuspiciousToggle'; value_type = 'DWord'; value_data = 1; value_data_kind = 'number'; access_status = 'ok' },
+                @{ key_path = 'HKLM\Software\ExampleVendor\ExampleApp'; value_name = 'CandidateSetting'; value_type = 'String'; value_data = 'On'; value_data_kind = 'text'; access_status = 'ok' }
+            )
+        }
+        $rules = @{
+            expected_change_rules = @(
+                @{ id = 'expected-1'; key_path_regex = 'ExampleApp'; value_name_regex = 'ExpectedSetting'; reason = 'Installer sets expected setting' }
+            )
+            noise_patterns = @(
+                @{ id = 'noise-1'; key_path_regex = 'RecentDocs'; reason = 'Volatile MRU noise' }
+            )
+            suspicious_change_rules = @(
+                @{ id = 'susp-1'; value_name_regex = 'SuspiciousToggle'; reason = 'Unexpected security toggle' }
+            )
+            remediation_candidate_rules = @(
+                @{ id = 'rem-1'; value_name_regex = 'CandidateSetting'; reason = 'Candidate for post-install hardening' }
+            )
+        }
+
+        $before | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $beforePath -Encoding UTF8
+        $after | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $afterPath -Encoding UTF8
+        $rules | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $rulesPath -Encoding UTF8
+
+        $resultRaw = & $scriptPath -BeforeSnapshotPath $beforePath -AfterSnapshotPath $afterPath -SoftwareId 'EXAMPLE-SOFTWARE-ID' -ExpectedRulesPath $rulesPath -WatchlistPath $rulesPath -OutputJson $outJson -OutputCsv $outCsv
+        $result = $resultRaw | ConvertFrom-Json -Depth 20
+
+        $result.summary.created_keys | Should -BeGreaterThan 0
+        $result.summary.deleted_keys | Should -BeGreaterThan 0
+        $result.summary.created_values | Should -BeGreaterThan 0
+        $result.summary.deleted_values | Should -BeGreaterThan 0
+        $result.summary.modified_values | Should -BeGreaterThan 0
+        $result.summary.noise_changes | Should -BeGreaterThan 0
+        $result.summary.expected_changes | Should -BeGreaterThan 0
+        ($result.summary.suspicious_changes + $result.summary.remediation_candidates) | Should -BeGreaterThan 0
+
+        Test-Path -LiteralPath $outJson | Should -BeTrue
+        Test-Path -LiteralPath $outCsv | Should -BeTrue
+
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+}

--- a/scripts/powershell/Compare-RegistrySnapshots.ps1
+++ b/scripts/powershell/Compare-RegistrySnapshots.ps1
@@ -1,0 +1,398 @@
+<#
+.SYNOPSIS
+Compares two registry snapshot JSON files and classifies before/after changes.
+
+.DESCRIPTION
+Compare-RegistrySnapshots.ps1 performs offline evidence comparison between two previously
+captured registry snapshots. It does not query the registry, run installers, or modify system state.
+
+The script normalizes registry key/value identities, computes Created/Deleted/Modified key/value
+changes, applies optional rule classifications (expected/noise/suspicious/remediation candidate),
+and emits a structured diff object. JSON and CSV outputs are optional.
+
+.PARAMETER BeforeSnapshotPath
+Path to the pre-install registry snapshot JSON.
+
+.PARAMETER AfterSnapshotPath
+Path to the post-install registry snapshot JSON.
+
+.PARAMETER SoftwareId
+Optional software identifier (for example EXAMPLE-SOFTWARE-ID) included in output metadata.
+
+.PARAMETER ExpectedRulesPath
+Optional JSON path containing expected-change rule sections.
+
+.PARAMETER WatchlistPath
+Optional JSON path containing noise/suspicious/remediation rule sections.
+
+.PARAMETER OutputJson
+Optional output path for structured JSON diff results.
+
+.PARAMETER OutputCsv
+Optional output path for flattened CSV changes.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Compare-RegistrySnapshots.ps1 `
+  -BeforeSnapshotPath .\before.json -AfterSnapshotPath .\after.json
+
+Compare two snapshot files and print structured JSON to stdout.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Compare-RegistrySnapshots.ps1 `
+  -BeforeSnapshotPath .\before.json -AfterSnapshotPath .\after.json -SoftwareId EXAMPLE-SOFTWARE-ID
+
+Compare two snapshot files and stamp the software id in evidence output.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Compare-RegistrySnapshots.ps1 `
+  -BeforeSnapshotPath .\before.json -AfterSnapshotPath .\after.json `
+  -ExpectedRulesPath .\config\expected_rules.json -WatchlistPath .\config\watchlist.json
+
+Compare with rules for expected/noise/suspicious/remediation classification.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Compare-RegistrySnapshots.ps1 `
+  -BeforeSnapshotPath .\before.json -AfterSnapshotPath .\after.json `
+  -OutputJson .\registry_diff.json -OutputCsv .\registry_diff.csv
+
+Compare snapshots and write both JSON and CSV outputs.
+
+.NOTES
+Safety: read-only evidence diff only. This script does not read live registry state,
+does not apply registry edits, and does not execute installers.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BeforeSnapshotPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AfterSnapshotPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$SoftwareId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ExpectedRulesPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$WatchlistPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputJson,
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputCsv
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$KeySentinelName = '__REGISTRY_KEY_ONLY__'
+
+function Normalize-KeyPath {
+    param([string]$KeyPath)
+    if ([string]::IsNullOrWhiteSpace($KeyPath)) { return '' }
+    $normalized = $KeyPath -replace '/', '\\'
+    $normalized = $normalized.Trim()
+    while ($normalized.EndsWith('\\')) { $normalized = $normalized.Substring(0, $normalized.Length - 1) }
+    return $normalized.ToLowerInvariant()
+}
+
+function Normalize-ValueName {
+    param([string]$ValueName)
+    if ([string]::IsNullOrWhiteSpace($ValueName)) { return '(default)' }
+    return $ValueName.Trim().ToLowerInvariant()
+}
+
+function New-ValueState {
+    param($Item)
+    [pscustomobject]@{
+        value_type      = if ($null -ne $Item.value_type) { [string]$Item.value_type } else { $null }
+        value_data      = if ($null -ne $Item.value_data) { $Item.value_data } else { $null }
+        value_data_kind = if ($null -ne $Item.value_data_kind) { [string]$Item.value_data_kind } else { $null }
+        access_status   = if ($null -ne $Item.access_status) { [string]$Item.access_status } else { $null }
+    }
+}
+
+function Read-JsonFile {
+    param([string]$Path, [ref]$Errors)
+    if (-not $Path) { return $null }
+    if (-not (Test-Path -LiteralPath $Path)) {
+        $Errors.Value += "File not found: $Path"
+        return $null
+    }
+    try {
+        return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -Depth 50)
+    }
+    catch {
+        $Errors.Value += "Failed to parse JSON file '$Path': $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Get-SnapshotEntries {
+    param($Snapshot)
+    if ($null -eq $Snapshot) { return @() }
+
+    if ($Snapshot -is [array]) { return $Snapshot }
+
+    foreach ($candidate in @('entries', 'items', 'snapshot_entries', 'data')) {
+        if ($null -ne $Snapshot.$candidate) {
+            if ($Snapshot.$candidate -is [array]) { return $Snapshot.$candidate }
+            return @($Snapshot.$candidate)
+        }
+    }
+
+    return @()
+}
+
+function Test-RuleMatch {
+    param($Change, $Rule)
+
+    $match = $true
+
+    if ($Rule.software_id -and $SoftwareId) {
+        if ([string]$Rule.software_id -ne [string]$SoftwareId) { $match = $false }
+    }
+
+    if ($match -and $Rule.classification -and [string]$Rule.classification -ne [string]$Change.classification) {
+        $match = $false
+    }
+
+    if ($match -and $Rule.key_path_regex) {
+        if (-not ([string]$Change.key_path -match [string]$Rule.key_path_regex)) { $match = $false }
+    }
+
+    if ($match -and $Rule.value_name_regex) {
+        if (-not ([string]$Change.value_name -match [string]$Rule.value_name_regex)) { $match = $false }
+    }
+
+    if ($match -and $Rule.reason_contains) {
+        if (-not ([string]$Change.reason -like "*$($Rule.reason_contains)*")) { $match = $false }
+    }
+
+    return $match
+}
+
+function Get-RuleSection {
+    param($RuleDoc, [string]$PrimaryName, [string]$AliasName)
+    if ($null -eq $RuleDoc) { return @() }
+    if ($null -ne $RuleDoc.$PrimaryName) { return @($RuleDoc.$PrimaryName) }
+    if ($AliasName -and $null -ne $RuleDoc.$AliasName) { return @($RuleDoc.$AliasName) }
+    return @()
+}
+
+$errors = @()
+$beforeSnapshot = Read-JsonFile -Path $BeforeSnapshotPath -Errors ([ref]$errors)
+$afterSnapshot = Read-JsonFile -Path $AfterSnapshotPath -Errors ([ref]$errors)
+$expectedDoc = Read-JsonFile -Path $ExpectedRulesPath -Errors ([ref]$errors)
+$watchlistDoc = Read-JsonFile -Path $WatchlistPath -Errors ([ref]$errors)
+
+$beforeEntries = Get-SnapshotEntries -Snapshot $beforeSnapshot
+$afterEntries = Get-SnapshotEntries -Snapshot $afterSnapshot
+
+$beforeMap = @{}
+$afterMap = @{}
+
+foreach ($item in $beforeEntries) {
+    $keyPath = if ($null -ne $item.key_path) { [string]$item.key_path } elseif ($null -ne $item.path) { [string]$item.path } else { '' }
+    $valueName = if ($null -ne $item.value_name) { [string]$item.value_name } elseif ($null -ne $item.name) { [string]$item.name } else { $KeySentinelName }
+
+    $normKey = Normalize-KeyPath -KeyPath $keyPath
+    $normValue = if ($valueName -eq $KeySentinelName) { $KeySentinelName } else { Normalize-ValueName -ValueName $valueName }
+    $identity = "$normKey|$normValue"
+
+    $beforeMap[$identity] = [pscustomobject]@{
+        key_path           = $keyPath
+        value_name         = $valueName
+        normalized_key     = $normKey
+        normalized_name    = $normValue
+        is_key_only        = ($valueName -eq $KeySentinelName)
+        state              = New-ValueState -Item $item
+    }
+}
+
+foreach ($item in $afterEntries) {
+    $keyPath = if ($null -ne $item.key_path) { [string]$item.key_path } elseif ($null -ne $item.path) { [string]$item.path } else { '' }
+    $valueName = if ($null -ne $item.value_name) { [string]$item.value_name } elseif ($null -ne $item.name) { [string]$item.name } else { $KeySentinelName }
+
+    $normKey = Normalize-KeyPath -KeyPath $keyPath
+    $normValue = if ($valueName -eq $KeySentinelName) { $KeySentinelName } else { Normalize-ValueName -ValueName $valueName }
+    $identity = "$normKey|$normValue"
+
+    $afterMap[$identity] = [pscustomobject]@{
+        key_path           = $keyPath
+        value_name         = $valueName
+        normalized_key     = $normKey
+        normalized_name    = $normValue
+        is_key_only        = ($valueName -eq $KeySentinelName)
+        state              = New-ValueState -Item $item
+    }
+}
+
+$allIds = @($beforeMap.Keys + $afterMap.Keys | Sort-Object -Unique)
+$changes = @()
+
+foreach ($id in $allIds) {
+    $before = if ($beforeMap.ContainsKey($id)) { $beforeMap[$id] } else { $null }
+    $after = if ($afterMap.ContainsKey($id)) { $afterMap[$id] } else { $null }
+
+    $baseClassification = $null
+    $reason = $null
+
+    if ($null -eq $before -and $null -ne $after) {
+        if ($after.is_key_only) {
+            $baseClassification = 'CreatedKey'
+            $reason = 'Registry key exists after snapshot only.'
+        } else {
+            $baseClassification = 'CreatedValue'
+            $reason = 'Registry value exists after snapshot only.'
+        }
+    }
+    elseif ($null -ne $before -and $null -eq $after) {
+        if ($before.is_key_only) {
+            $baseClassification = 'DeletedKey'
+            $reason = 'Registry key exists before snapshot only.'
+        } else {
+            $baseClassification = 'DeletedValue'
+            $reason = 'Registry value exists before snapshot only.'
+        }
+    }
+    elseif ($null -ne $before -and $null -ne $after -and -not $before.is_key_only -and -not $after.is_key_only) {
+        $isModified = $false
+        if ($before.state.value_type -ne $after.state.value_type) { $isModified = $true }
+        elseif (($before.state.value_data | ConvertTo-Json -Depth 20 -Compress) -ne ($after.state.value_data | ConvertTo-Json -Depth 20 -Compress)) { $isModified = $true }
+        elseif ($before.state.value_data_kind -ne $after.state.value_data_kind) { $isModified = $true }
+        elseif ($before.state.access_status -ne $after.state.access_status) { $isModified = $true }
+
+        if ($isModified) {
+            $baseClassification = 'ModifiedValue'
+            $reason = 'Value data, type, data kind, or access status changed.'
+        }
+    }
+
+    if (-not $baseClassification) { continue }
+
+    $change = [pscustomobject]@{
+        base_classification = $baseClassification
+        classification      = $baseClassification
+        key_path            = if ($null -ne $after) { $after.key_path } else { $before.key_path }
+        value_name          = if ($null -ne $after) { $after.value_name } else { $before.value_name }
+        before              = if ($null -ne $before) { $before.state } else { $null }
+        after               = if ($null -ne $after) { $after.state } else { $null }
+        reason              = $reason
+        evidence            = [pscustomobject]@{ identity = $id }
+        confidence          = 'medium'
+        matched_rule_id     = $null
+        requires_review     = $true
+    }
+
+    $changes += $change
+}
+
+$expectedRules = @((Get-RuleSection -RuleDoc $expectedDoc -PrimaryName 'expected_change_rules' -AliasName 'expected_rules'))
+$noiseRules = @((Get-RuleSection -RuleDoc $watchlistDoc -PrimaryName 'noise_patterns' -AliasName 'noise_rules'))
+$suspiciousRules = @((Get-RuleSection -RuleDoc $watchlistDoc -PrimaryName 'suspicious_change_rules' -AliasName 'suspicious_rules'))
+$remediationRules = @((Get-RuleSection -RuleDoc $watchlistDoc -PrimaryName 'remediation_candidate_rules' -AliasName 'remediation_rules'))
+
+foreach ($change in $changes) {
+    $matched = $false
+
+    foreach ($rule in $noiseRules) {
+        if (Test-RuleMatch -Change $change -Rule $rule) {
+            $change.classification = 'Noise'
+            $change.reason = if ($rule.reason) { [string]$rule.reason } else { 'Matched noise pattern.' }
+            $change.matched_rule_id = if ($rule.id) { [string]$rule.id } else { 'noise-rule' }
+            $change.confidence = if ($rule.confidence) { [string]$rule.confidence } else { 'high' }
+            $change.requires_review = $false
+            $matched = $true
+            break
+        }
+    }
+
+    if ($matched) { continue }
+
+    foreach ($rule in $expectedRules) {
+        if (Test-RuleMatch -Change $change -Rule $rule) {
+            $change.classification = 'ExpectedChange'
+            $change.reason = if ($rule.reason) { [string]$rule.reason } else { 'Matched expected change rule.' }
+            $change.matched_rule_id = if ($rule.id) { [string]$rule.id } else { 'expected-rule' }
+            $change.confidence = if ($rule.confidence) { [string]$rule.confidence } else { 'high' }
+            $change.requires_review = $false
+            $matched = $true
+            break
+        }
+    }
+
+    if ($matched) { continue }
+
+    foreach ($rule in $remediationRules) {
+        if (Test-RuleMatch -Change $change -Rule $rule) {
+            $change.classification = 'RemediationCandidate'
+            $change.reason = if ($rule.reason) { [string]$rule.reason } else { 'Matched remediation candidate rule.' }
+            $change.matched_rule_id = if ($rule.id) { [string]$rule.id } else { 'remediation-rule' }
+            $change.confidence = if ($rule.confidence) { [string]$rule.confidence } else { 'medium' }
+            $change.requires_review = $true
+            $matched = $true
+            break
+        }
+    }
+
+    if ($matched) { continue }
+
+    foreach ($rule in $suspiciousRules) {
+        if (Test-RuleMatch -Change $change -Rule $rule) {
+            $change.classification = 'SuspiciousChange'
+            $change.reason = if ($rule.reason) { [string]$rule.reason } else { 'Matched suspicious change rule.' }
+            $change.matched_rule_id = if ($rule.id) { [string]$rule.id } else { 'suspicious-rule' }
+            $change.confidence = if ($rule.confidence) { [string]$rule.confidence } else { 'medium' }
+            $change.requires_review = $true
+            break
+        }
+    }
+}
+
+$result = [pscustomobject]@{
+    schema_version = '1.0.0'
+    run_id         = [guid]::NewGuid().ToString()
+    target         = if ($afterSnapshot.target) { [string]$afterSnapshot.target } elseif ($beforeSnapshot.target) { [string]$beforeSnapshot.target } else { 'unknown' }
+    software_id    = if ($SoftwareId) { $SoftwareId } else { $null }
+    compared_at    = (Get-Date).ToString('o')
+    before_snapshot = [pscustomobject]@{ path = $BeforeSnapshotPath; entries = $beforeEntries.Count }
+    after_snapshot  = [pscustomobject]@{ path = $AfterSnapshotPath; entries = $afterEntries.Count }
+    summary = [pscustomobject]@{
+        total_changes          = $changes.Count
+        created_keys           = @($changes | Where-Object { $_.base_classification -eq 'CreatedKey' }).Count
+        deleted_keys           = @($changes | Where-Object { $_.base_classification -eq 'DeletedKey' }).Count
+        created_values         = @($changes | Where-Object { $_.base_classification -eq 'CreatedValue' }).Count
+        deleted_values         = @($changes | Where-Object { $_.base_classification -eq 'DeletedValue' }).Count
+        modified_values        = @($changes | Where-Object { $_.base_classification -eq 'ModifiedValue' }).Count
+        expected_changes       = @($changes | Where-Object { $_.classification -eq 'ExpectedChange' }).Count
+        noise_changes          = @($changes | Where-Object { $_.classification -eq 'Noise' }).Count
+        suspicious_changes     = @($changes | Where-Object { $_.classification -eq 'SuspiciousChange' }).Count
+        remediation_candidates = @($changes | Where-Object { $_.classification -eq 'RemediationCandidate' }).Count
+        requires_review_count  = @($changes | Where-Object { $_.requires_review -eq $true }).Count
+    }
+    changes = $changes
+    errors  = $errors
+    output_paths = [pscustomobject]@{
+        json = $OutputJson
+        csv  = $OutputCsv
+    }
+}
+
+if ($OutputJson) {
+    ($result | ConvertTo-Json -Depth 20) | Set-Content -LiteralPath $OutputJson -Encoding UTF8
+}
+
+if ($OutputCsv) {
+    $changes | Select-Object classification, base_classification, key_path, value_name, reason, confidence, matched_rule_id, requires_review,
+    @{ Name = 'before_value_type'; Expression = { if ($_.before) { $_.before.value_type } else { $null } } },
+    @{ Name = 'before_value_data'; Expression = { if ($_.before) { ($_.before.value_data | ConvertTo-Json -Compress -Depth 10) } else { $null } } },
+    @{ Name = 'after_value_type'; Expression = { if ($_.after) { $_.after.value_type } else { $null } } },
+    @{ Name = 'after_value_data'; Expression = { if ($_.after) { ($_.after.value_data | ConvertTo-Json -Compress -Depth 10) } else { $null } } } |
+    Export-Csv -LiteralPath $OutputCsv -NoTypeInformation -Encoding UTF8
+}
+
+$result | ConvertTo-Json -Depth 20


### PR DESCRIPTION
## **User description**
### Motivation
- Implement an evidence-first registry snapshot diff layer to compare pre-/post-install registry JSON snapshots without reading or mutating the live registry.
- Provide stable identity normalization and key/value sentinel support so key-only changes and value-level changes can be detected reliably across captures.
- Enable rule-driven classification (expected, noise, suspicious, remediation candidate) so diffs can be triaged automatically while preserving evidence for review.

### Description
- Added `scripts/powershell/Compare-RegistrySnapshots.ps1` which accepts before/after snapshot JSON, optional `SoftwareId`, optional rule/watchlist JSON files, and optional `OutputJson`/`OutputCsv` export paths, and emits a structured diff envelope. 
- Implemented normalization (case-insensitive paths, slash normalization, trailing-slash trimming), a stable comparison identity of `normalized_key_path|normalized_value_name`, and a key-only sentinel to detect CreatedKey/DeletedKey scenarios. 
- Implemented base diff classifications (`CreatedKey`, `DeletedKey`, `CreatedValue`, `DeletedValue`, `ModifiedValue`) and overlay classifications (`ExpectedChange`, `Noise`, `SuspiciousChange`, `RemediationCandidate`) applied via a soft adapter for rule documents, plus per-change evidence fields and summary counters. 
- Added `Tests/Pester/RegistryDiff.Tests.ps1` with synthetic fixtures exercising created/deleted/modified detection, JSON/CSV output behavior, noise and expected-rule application, suspicious/remediation marking, and guardrails asserting the absence of forbidden registry mutation, remoting, or installer-execution commands.

### Testing
- Added an automated Pester test (`Tests/Pester/RegistryDiff.Tests.ps1`) that constructs small synthetic before/after snapshots and a rules doc and asserts detection, classification, and output file writes. 
- Static validation included inspection of the script's comment-based help and checks for the absence of forbidden commands such as registry write operations, RemoteRegistry service manipulation, PSRemoting enablement, and installer execution calls. 
- Runtime execution of PowerShell and Pester was not possible in this environment because `pwsh`/`powershell` are unavailable, so the authored Pester test could not be executed here. 
- The script is intentionally read-only and will perform raw diffs even when rules files are missing or malformed, and the test suite is designed to run where PowerShell/Pester are available in CI or on a developer machine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1269dac5308322953767424e4e13a0)


___

## **CodeAnt-AI Description**
**Compare two registry snapshots and classify the changes**

### What Changed
- Added a script that compares two saved registry snapshots without touching the live registry or running installers
- It now detects created, deleted, and modified keys and values, including key-only changes
- Snapshot paths are normalized so matching entries are found even when path formatting differs
- Optional rules can mark changes as expected, noise, suspicious, or remediation candidates, and the output can be saved as JSON or CSV
- Added tests that verify the script exists, includes user help, avoids registry-changing commands, and produces the expected classifications and output files

### Impact
`✅ Safer registry review`
`✅ Clearer install-change triage`
`✅ Faster snapshot diff exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
