### PR TITLE
Add Invoke-TrackedInstall PowerShell runner and Pester tests

### DIFF
--- a/Tests/Pester/TrackedInstall.Tests.ps1
+++ b/Tests/Pester/TrackedInstall.Tests.ps1
@@ -1,0 +1,68 @@
+Describe 'Invoke-TrackedInstall' {
+    BeforeAll {
+        $ScriptPath = Join-Path $PSScriptRoot '../../scripts/powershell/Invoke-TrackedInstall.ps1'
+    }
+
+    It 'script exists' {
+        Test-Path -LiteralPath $ScriptPath | Should -BeTrue
+    }
+
+    It 'has comment-based help synopsis' {
+        $content = Get-Content -LiteralPath $ScriptPath -Raw
+        $content | Should -Match '\.SYNOPSIS'
+        $content | Should -Match '\.DESCRIPTION'
+    }
+
+    It 'dry-run works with direct InstallerPath and does not execute installer' {
+        Mock Start-Process { throw 'Should not execute on dry run' }
+        $result = & $ScriptPath -Target localhost -DryRun -SoftwareId EXAMPLE-SOFTWARE-ID -InstallerPath 'C:\Installers\ExampleApp\setup.exe' -InstallerType exe -SilentArgs '/quiet /norestart'
+        $result.status | Should -Be 'DryRun'
+        Assert-MockCalled Start-Process -Times 0
+    }
+
+    It 'creates output JSON when OutputPath is supplied and JSON parses' {
+        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ('trackedinstall-' + [guid]::NewGuid().Guid)
+        $outPath = Join-Path $tempDir 'installer_result.json'
+        $null = & $ScriptPath -Target localhost -DryRun -InstallerPath 'C:\Installers\ExampleApp\setup.exe' -InstallerType exe -SilentArgs '/quiet' -OutputPath $outPath
+
+        Test-Path -LiteralPath $outPath | Should -BeTrue
+        $json = Get-Content -LiteralPath $outPath -Raw | ConvertFrom-Json
+        $json.status | Should -Be 'DryRun'
+        $json.installer.installer_path | Should -Be 'C:\Installers\ExampleApp\setup.exe'
+        $json.installer.installer_type | Should -Be 'exe'
+        $json.installer.silent_args | Should -Be '/quiet'
+        $json.installer.PSObject.Properties.Name | Should -Contain 'resolved_from_sources_yaml'
+
+        Remove-Item -LiteralPath $tempDir -Recurse -Force
+    }
+
+    It 'non-localhost target returns Unsupported with RemoteInstallNotImplemented' {
+        $result = & $ScriptPath -Target 'server01' -DryRun -InstallerPath 'C:\Installers\ExampleApp\setup.exe' -InstallerType exe
+        $result.status | Should -Be 'Unsupported'
+        $result.errors | Should -Contain 'RemoteInstallNotImplemented'
+    }
+
+    It 'missing installer path in execution mode fails safely' {
+        $result = & $ScriptPath -Target localhost -SoftwareId EXAMPLE-SOFTWARE-ID
+        $result.status | Should -Be 'Failed'
+        $result.errors | Should -Contain 'INSTALLER_PATH_REQUIRED_FOR_EXECUTION'
+    }
+
+    It 'attempts source config lookup or reports parser/config issue gracefully' {
+        $result = & $ScriptPath -Target localhost -DryRun -SoftwareId 'NotPresentApp' -SourceConfigPath 'Config/sources.yaml'
+        @('SOFTWARE_ID_NOT_FOUND','YAML_PARSER_UNAVAILABLE','SOURCE_CONFIG_SHAPE_UNSUPPORTED','SOURCE_CONFIG_NOT_FOUND','SOURCE_CONFIG_PARSE_FAILED') | Should -Contain $result.errors[0]
+    }
+
+    It 'does not contain forbidden registry write/remoting/snapshot/diff commands' {
+        $content = Get-Content -LiteralPath $ScriptPath -Raw
+        $forbidden = @(
+            'Set-ItemProperty','New-ItemProperty','Remove-ItemProperty','reg add','reg delete','reg import','reg restore',
+            'Start-Service RemoteRegistry','Stop-Service RemoteRegistry','Set-Service RemoteRegistry','Enable-PSRemoting',
+            'RegistrySnapshot','Compare-Object.*Registry','reg export'
+        )
+
+        foreach ($token in $forbidden) {
+            $content | Should -Not -Match [regex]::Escape($token)
+        }
+    }
+}

--- a/scripts/powershell/Invoke-TrackedInstall.ps1
+++ b/scripts/powershell/Invoke-TrackedInstall.ps1
@@ -1,0 +1,290 @@
+<#
+.SYNOPSIS
+Runs a tracked installer in dry-run or local execution mode for evidence-oriented install workflows.
+
+.DESCRIPTION
+Invoke-TrackedInstall resolves installer metadata from Config/sources.yaml (when possible) and/or
+explicit parameter overrides, builds the command, and optionally executes it locally.
+
+This command is designed for Registry Install Diff pipeline orchestration where installer activity
+must be tracked and exported as structured evidence. This script does not edit registry values,
+does not capture registry snapshots, and does not perform registry diffs.
+
+.PARAMETER SoftwareId
+Software identifier to resolve from the software source configuration.
+Matches `software_id`, `id`, `name`, or `display_name` when present.
+
+.PARAMETER SourceConfigPath
+Path to source tracking YAML file (default: Config/sources.yaml).
+
+.PARAMETER Target
+Execution target. Only localhost is implemented in this slice.
+
+.PARAMETER DryRun
+When set, command construction is performed but no installer process is executed.
+
+.PARAMETER InstallerPath
+Explicit installer path override for controlled testing or local execution.
+
+.PARAMETER InstallerType
+Explicit installer type override (exe, msi, msix, batch, powershell, unknown).
+
+.PARAMETER SilentArgs
+Explicit silent arguments override.
+
+.PARAMETER OutputPath
+Optional path to write structured JSON output.
+
+.PARAMETER LogPath
+Optional path to append execution log lines.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Invoke-TrackedInstall.ps1 -Target localhost -DryRun -SoftwareId "Git for Windows" -SourceConfigPath "Config/sources.yaml"
+Dry-run using SoftwareId and Config/sources.yaml.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Invoke-TrackedInstall.ps1 -Target localhost -DryRun -SoftwareId EXAMPLE-SOFTWARE-ID -InstallerPath "C:\Installers\ExampleApp\setup.exe" -InstallerType exe -SilentArgs "/quiet /norestart"
+Dry-run using direct InstallerPath.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Invoke-TrackedInstall.ps1 -Target localhost -SoftwareId EXAMPLE-SOFTWARE-ID -InstallerPath "C:\Installers\ExampleApp\setup.exe" -InstallerType exe -SilentArgs "/quiet /norestart"
+Localhost execution with explicit installer path.
+
+.EXAMPLE
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/powershell/Invoke-TrackedInstall.ps1 -Target localhost -DryRun -SoftwareId EXAMPLE-SOFTWARE-ID -InstallerPath "C:\Installers\ExampleApp\setup.exe" -InstallerType exe -SilentArgs "/quiet /norestart" -OutputPath "exports/registry-install-diff/test/installer_result.json"
+Writes installer_result.json for evidence review.
+
+.NOTES
+Safety notes:
+- Default behavior is read-first and dry-run friendly.
+- No registry write operations are performed.
+- Remote install is not implemented; non-local targets return Unsupported.
+#>
+[CmdletBinding()]
+param(
+    [string]$SoftwareId,
+    [string]$SourceConfigPath = 'Config/sources.yaml',
+    [string]$Target = 'localhost',
+    [switch]$DryRun,
+    [string]$InstallerPath,
+    [ValidateSet('exe','msi','msix','batch','powershell','unknown')]
+    [string]$InstallerType,
+    [string]$SilentArgs,
+    [string]$OutputPath,
+    [string]$LogPath
+)
+
+function Write-TrackedInstallLog {
+    param([string]$Message)
+    if (-not $script:LogPath) { return }
+    $dir = Split-Path -Path $script:LogPath -Parent
+    if ($dir -and -not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    "$(Get-Date -Format o) $Message" | Add-Content -Path $script:LogPath
+}
+
+function Read-SourcesYaml {
+    param([string]$Path)
+
+    $result = [ordered]@{
+        Success = $false
+        Reason = $null
+        Entry = $null
+        Key = $null
+    }
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        $result.Reason = 'SOURCE_CONFIG_NOT_FOUND'
+        return $result
+    }
+
+    if (-not (Get-Command ConvertFrom-Yaml -ErrorAction SilentlyContinue)) {
+        $result.Reason = 'YAML_PARSER_UNAVAILABLE'
+        return $result
+    }
+
+    try {
+        $yamlData = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Yaml
+    } catch {
+        $result.Reason = 'SOURCE_CONFIG_PARSE_FAILED'
+        return $result
+    }
+
+    # Narrow adapter for current sources.yaml model.
+    # Supports top-level `apps` array with keys such as name/type/silent_args.
+    $apps = @()
+    if ($yamlData -and $yamlData.apps) { $apps = @($yamlData.apps) }
+
+    if (-not $apps -or $apps.Count -eq 0) {
+        $result.Reason = 'SOURCE_CONFIG_SHAPE_UNSUPPORTED'
+        return $result
+    }
+
+    $match = $apps | Where-Object {
+        ($_ .software_id -eq $SoftwareId) -or
+        ($_ .id -eq $SoftwareId) -or
+        ($_ .name -eq $SoftwareId) -or
+        ($_ .display_name -eq $SoftwareId)
+    } | Select-Object -First 1
+
+    if (-not $match) {
+        $result.Reason = 'SOFTWARE_ID_NOT_FOUND'
+        return $result
+    }
+
+    $result.Success = $true
+    $result.Entry = $match
+    $result.Key = if ($match.software_id) { $match.software_id } elseif ($match.id) { $match.id } elseif ($match.name) { $match.name } else { $SoftwareId }
+    return $result
+}
+
+$runId = [guid]::NewGuid().Guid
+$startedAt = Get-Date
+$status = 'NotStarted'
+$errors = New-Object System.Collections.Generic.List[string]
+$mode = if ($DryRun) { 'DryRun' } else { 'Execute' }
+
+$installer = [ordered]@{
+    installer_path = $InstallerPath
+    installer_type = $InstallerType
+    silent_args = $SilentArgs
+    source_config_path = $SourceConfigPath
+    source_config_key = $null
+    resolved_from_sources_yaml = $false
+    expected_registry_keys = @()
+    expected_files = @()
+    requires_reboot = $false
+    command = $null
+    command_args = $null
+}
+
+if ($SoftwareId) {
+    $sourceResult = Read-SourcesYaml -Path $SourceConfigPath
+    if ($sourceResult.Success) {
+        $entry = $sourceResult.Entry
+        $installer.source_config_key = $sourceResult.Key
+        $installer.resolved_from_sources_yaml = $true
+
+        if (-not $installer.installer_path) { $installer.installer_path = if ($entry.installer_path) { $entry.installer_path } else { $entry.path } }
+        if (-not $installer.installer_type) { $installer.installer_type = if ($entry.installer_type) { $entry.installer_type } else { $entry.type } }
+        if (-not $installer.silent_args) { $installer.silent_args = if ($entry.silent_args) { $entry.silent_args } else { $entry.arguments } }
+
+        if ($entry.expected_registry_keys) { $installer.expected_registry_keys = @($entry.expected_registry_keys) }
+        elseif ($entry.detect_type -eq 'regkey' -and $entry.detect_value) { $installer.expected_registry_keys = @($entry.detect_value) }
+
+        if ($entry.expected_files) { $installer.expected_files = @($entry.expected_files) }
+        elseif ($entry.detect_type -eq 'file' -and $entry.detect_value) { $installer.expected_files = @($entry.detect_value) }
+
+        if ($null -ne $entry.requires_reboot) { $installer.requires_reboot = [bool]$entry.requires_reboot }
+    } else {
+        $errors.Add($sourceResult.Reason)
+    }
+}
+
+if (-not $installer.installer_type) {
+    if ($installer.installer_path) {
+        switch -Regex ($installer.installer_path.ToLowerInvariant()) {
+            '\.msi$' { $installer.installer_type = 'msi'; break }
+            '\.msix$' { $installer.installer_type = 'msix'; break }
+            '\.ps1$' { $installer.installer_type = 'powershell'; break }
+            '\.(bat|cmd)$' { $installer.installer_type = 'batch'; break }
+            '\.exe$' { $installer.installer_type = 'exe'; break }
+            default { $installer.installer_type = 'unknown' }
+        }
+    } else {
+        $installer.installer_type = 'unknown'
+    }
+}
+
+$targetNormalized = $Target.ToLowerInvariant()
+if ($targetNormalized -notin @('localhost','127.0.0.1','::1',$env:COMPUTERNAME.ToLowerInvariant())) {
+    $status = 'Unsupported'
+    $errors.Add('RemoteInstallNotImplemented')
+}
+
+switch ($installer.installer_type) {
+    'msi' {
+        $installer.command = 'msiexec.exe'
+        $installer.command_args = "/i `"$($installer.installer_path)`" $($installer.silent_args)".Trim()
+    }
+    'powershell' {
+        $installer.command = 'powershell.exe'
+        $installer.command_args = "-NoProfile -ExecutionPolicy Bypass -File `"$($installer.installer_path)`" $($installer.silent_args)".Trim()
+    }
+    'batch' {
+        $installer.command = 'cmd.exe'
+        $installer.command_args = "/c `"$($installer.installer_path)`" $($installer.silent_args)".Trim()
+    }
+    default {
+        $installer.command = $installer.installer_path
+        $installer.command_args = $installer.silent_args
+    }
+}
+
+if ($DryRun -and $status -eq 'NotStarted') {
+    $status = 'DryRun'
+}
+
+$exitCode = $null
+if (-not $DryRun -and $status -eq 'NotStarted') {
+    if (-not $installer.installer_path) {
+        $status = 'Failed'
+        $errors.Add('INSTALLER_PATH_REQUIRED_FOR_EXECUTION')
+    } elseif (-not (Test-Path -LiteralPath $installer.installer_path)) {
+        $status = 'Failed'
+        $errors.Add('INSTALLER_PATH_NOT_FOUND')
+    } elseif ($installer.installer_type -eq 'unknown') {
+        $status = 'Unsupported'
+        $errors.Add('UNKNOWN_INSTALLER_TYPE_EXECUTION_NOT_ALLOWED')
+    } else {
+        $status = 'Started'
+        Write-TrackedInstallLog "Starting installer command: $($installer.command) $($installer.command_args)"
+        try {
+            $proc = Start-Process -FilePath $installer.command -ArgumentList $installer.command_args -Wait -PassThru -NoNewWindow -RedirectStandardOutput ([System.IO.Path]::GetTempFileName()) -RedirectStandardError ([System.IO.Path]::GetTempFileName())
+            $exitCode = $proc.ExitCode
+            if ($exitCode -eq 0) {
+                $status = 'Succeeded'
+            } else {
+                $status = 'Failed'
+                $errors.Add("INSTALLER_EXIT_CODE_$exitCode")
+            }
+        } catch {
+            $status = 'Failed'
+            $errors.Add('INSTALLER_EXECUTION_ERROR')
+            $errors.Add($_.Exception.Message)
+        }
+    }
+}
+
+$endedAt = Get-Date
+$duration = [int][Math]::Round((New-TimeSpan -Start $startedAt -End $endedAt).TotalMilliseconds)
+Write-TrackedInstallLog "Finished with status=$status exit_code=$exitCode duration_ms=$duration"
+
+$result = [ordered]@{
+    schema_version = '1.0.0'
+    run_id = $runId
+    software_id = $SoftwareId
+    target = $Target
+    mode = $mode
+    dry_run = [bool]$DryRun
+    installer = $installer
+    started_at = $startedAt.ToString('o')
+    ended_at = $endedAt.ToString('o')
+    duration_ms = $duration
+    exit_code = $exitCode
+    status = $status
+    log_path = $LogPath
+    errors = @($errors)
+    output_path = $OutputPath
+}
+
+if ($OutputPath) {
+    $outDir = Split-Path -Path $OutputPath -Parent
+    if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
+        New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+    }
+    $result | ConvertTo-Json -Depth 8 | Set-Content -Path $OutputPath
+}
+
+$result


### PR DESCRIPTION
## **User description**
### Motivation

- Provide a tracked installer runner for the Registry Install Diff pipeline that is evidence-first, safe-by-default, and Windows/PowerShell-native for registry-area attestations.
- Enable resolving installer metadata from the existing `Config/sources.yaml` tracker while allowing explicit overrides for controlled testing and dry-runs.
- Prevent any registry mutation, remote execution, or automatic remediation in this sprint slice by gating execution to localhost and dry-run first.

### Description

- Add `scripts/powershell/Invoke-TrackedInstall.ps1` which implements comment-based help, resolves installer metadata from `Config/sources.yaml` (via `ConvertFrom-Yaml` when available), and builds installer commands without performing registry reads/writes or diffs. 
- Support dry-run mode that constructs the command and returns `status = DryRun` without executing the installer, plus an execution mode that runs locally only and preserves exit codes for `msi`, `exe`, `batch`, and `powershell` installers; `unknown` types are blocked from execution unless explicitly allowed.
- Implement a local-only guard that returns `Unsupported` with reason `RemoteInstallNotImplemented` for non-local targets, and provide structured JSON output (schema fields such as `schema_version`, `run_id`, `software_id`, `target`, `mode`, `dry_run`, `installer`, `started_at`, `ended_at`, `duration_ms`, `exit_code`, `status`, `log_path`, `errors`, `output_path`) and optional `-OutputPath`/`-LogPath` export.
- Add a narrow adapter mapping from the `apps` entries in `Config/sources.yaml` to fields used by the runner (installer path/type, `silent_args`, `expected_registry_keys`/`expected_files`, `requires_reboot`), and soft-fail reasons such as `YAML_PARSER_UNAVAILABLE`, `SOURCE_CONFIG_SHAPE_UNSUPPORTED`, and `SOFTWARE_ID_NOT_FOUND` when lookup/parsing is unavailable or mismatched.

### Testing

- Added `Tests/Pester/TrackedInstall.Tests.ps1` containing Pester tests that assert script existence, presence of comment-based help, correct dry-run behavior (no `Start-Process` calls), JSON output creation/parsing when `-OutputPath` is supplied, `installer` object fields (`installer_path`, `installer_type`, `silent_args`, `resolved_from_sources_yaml`), non-localhost `Unsupported` behavior, safe failure when installer path is missing in execution mode, and static checks for forbidden registry/remoting/snapshot/diff tokens.
- Automated tests could not be executed in this environment because neither `pwsh` nor `powershell` was available, so Pester tests were not run here and an attempted `pwsh` invocation failed with `command not found` (reportable as `POWERSHELL_UNAVAILABLE_IN_ENVIRONMENT`).
- The script is designed to return clear soft-failure codes for missing YAML parser or unsupported config shapes (`YAML_PARSER_UNAVAILABLE`, `SOURCE_CONFIG_SHAPE_UNSUPPORTED`, etc.), which the tests exercise by design when the runtime supports `ConvertFrom-Yaml` and Pester execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1269f7fcf88322aee4a65064fd0ffa)


___

## **CodeAnt-AI Description**
**Add a tracked installer runner with dry-run support and structured output**

### What Changed
- Added a PowerShell runner that can resolve installer details from `Config/sources.yaml` or use direct overrides, then either dry-run or run the installer locally
- Dry-run now returns a structured JSON result instead of starting the installer, and optional output/log files can be written for review
- Non-local targets are blocked with a clear unsupported result, and registry write, snapshot, and diff actions are explicitly not part of this workflow
- Added Pester coverage for script presence, help text, dry-run behavior, JSON export, remote target handling, and safe failure cases

### Impact
`✅ Safer installer validation`
`✅ Clearer dry-run evidence`
`✅ Fewer accidental remote installs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
