### PR TITLE
Add registry install diff orchestrator, Bash wrapper, tests and docs

### DIFF
--- a/Tests/Pester/RegistryInstallDiff.Orchestrator.Tests.ps1
+++ b/Tests/Pester/RegistryInstallDiff.Orchestrator.Tests.ps1
@@ -1,0 +1,48 @@
+Describe 'Registry Install Diff Orchestrator' {
+    $scriptPath = Join-Path $PSScriptRoot '..\..\scripts\powershell\Invoke-RegistryInstallDiff.ps1'
+
+    It 'exists' {
+        Test-Path -LiteralPath $scriptPath | Should -BeTrue
+    }
+
+    It 'has comment based help synopsis' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        $content | Should -Match '\.SYNOPSIS'
+        $content | Should -Match '\.DESCRIPTION'
+    }
+
+    It 'blocks approved remediation as unsupported' {
+        $outRoot = Join-Path $env:TEMP ('rid-approved-' + [guid]::NewGuid())
+        $result = & $scriptPath -Mode ReconOnly -Target localhost -OutputRoot $outRoot -ApprovedRemediation 2>&1
+        ($result | Out-String) | Should -Match 'ApprovedRemediationNotImplemented|Unsupported'
+    }
+
+    It 'does not contain forbidden registry write or remoting patterns' {
+        $content = Get-Content -LiteralPath $scriptPath -Raw
+        $forbidden = @(
+            'Set-ItemProperty','New-ItemProperty','Remove-ItemProperty','reg add','reg delete','reg import','reg restore',
+            'Start-Service\s+RemoteRegistry','Stop-Service\s+RemoteRegistry','Set-Service\s+RemoteRegistry','Enable-PSRemoting','PsExec'
+        )
+        foreach ($pattern in $forbidden) {
+            $content | Should -Not -Match $pattern
+        }
+    }
+
+    It 'recononly runs or records missing dependency gracefully' {
+        $outRoot = Join-Path $env:TEMP ('rid-recon-' + [guid]::NewGuid())
+        $null = & $scriptPath -Mode ReconOnly -Target localhost -OutputRoot $outRoot 2>&1
+        $runDir = Get-ChildItem -LiteralPath $outRoot -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        $manifest = Join-Path $runDir.FullName 'run_manifest.json'
+        Test-Path $manifest | Should -BeTrue
+        $manifestContent = Get-Content $manifest -Raw
+        $manifestContent | Should -Match 'MissingDependency|dependency_scripts'
+    }
+
+    It 'analyzeinstall dry-run emits manifest and summary' {
+        $outRoot = Join-Path $env:TEMP ('rid-analyze-' + [guid]::NewGuid())
+        $null = & $scriptPath -Mode AnalyzeInstall -Target localhost -SoftwareId TEST-SW -DryRun -OutputRoot $outRoot 2>&1
+        $runDir = Get-ChildItem -LiteralPath $outRoot -Directory | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        Test-Path (Join-Path $runDir.FullName 'run_manifest.json') | Should -BeTrue
+        Test-Path (Join-Path $runDir.FullName 'summary.md') | Should -BeTrue
+    }
+}

--- a/docs/REGISTRY_INSTALL_DIFF_BASH_WRAPPER.md
+++ b/docs/REGISTRY_INSTALL_DIFF_BASH_WRAPPER.md
@@ -1,0 +1,50 @@
+# Registry Install Diff Bash Wrapper
+
+## Purpose
+`scripts/sas_registry_install_diff.sh` is a Bash-on-Windows field entrypoint for the Registry Install Diff Pipeline. It provides a technician-friendly CLI that forwards execution to the PowerShell orchestrator.
+
+## Relationship to PowerShell orchestrator
+The wrapper calls `scripts/powershell/Invoke-RegistryInstallDiff.ps1` and only performs argument translation / runtime selection. Registry snapshotting, tracked install execution, diffing, classification, and evidence export all remain in PowerShell.
+
+## Safety posture
+- Evidence-first workflow.
+- No registry parsing in Bash.
+- No registry writes from Bash.
+- No direct installer execution from Bash.
+- If PowerShell is unavailable, the wrapper fails clearly.
+
+## Usage examples
+```bash
+./scripts/sas_registry_install_diff.sh --mode ReconOnly --target localhost
+./scripts/sas_registry_install_diff.sh --mode SnapshotOnly --target localhost --output-root exports/registry-install-diff
+./scripts/sas_registry_install_diff.sh --mode AnalyzeInstall --target localhost --software-id EXAMPLE-SOFTWARE-ID --dry-run
+```
+
+## Argument mapping
+- `--mode` -> `-Mode`
+- `--target` -> `-Target`
+- `--targets-csv` -> `-TargetsCsv`
+- `--software-id` -> `-SoftwareId`
+- `--source-config-path` -> `-SourceConfigPath`
+- `--registry-watchlist-path` -> `-RegistryWatchlistPath`
+- `--output-root` -> `-OutputRoot`
+- `--dry-run` -> `-DryRun`
+- `--installer-path` -> `-InstallerPath`
+- `--installer-type` -> `-InstallerType`
+- `--silent-args` -> `-SilentArgs`
+
+## PowerShell availability behavior
+Wrapper runtime selection order:
+1. `pwsh`
+2. `powershell`
+
+If neither is available, the wrapper exits with:
+`POWERSHELL_UNAVAILABLE_IN_ENVIRONMENT`
+
+## Known limitations
+- Localhost-first behavior; remote batch install execution is not implemented in this slice.
+- Dependency scripts must exist for full pipeline execution.
+- ApprovedRemediation mode is intentionally unsupported.
+
+## No registry parsing in Bash
+Bash is an invocation layer only. Registry operations and evidence analysis remain in PowerShell dependency scripts and orchestrator workflow.

--- a/scripts/powershell/Invoke-RegistryInstallDiff.ps1
+++ b/scripts/powershell/Invoke-RegistryInstallDiff.ps1
@@ -1,0 +1,312 @@
+<#
+.SYNOPSIS
+Orchestrates evidence-first registry install diff runs.
+
+.DESCRIPTION
+Runs Recon -> Decide -> Act -> Log -> Export workflow for localhost-first registry install diff analysis.
+This orchestrator is read-oriented by default and does not perform registry mutation.
+It coordinates dependency scripts when present and records MissingDependency status when they are not.
+
+.PARAMETER Mode
+Pipeline mode: ReconOnly, SnapshotOnly, AnalyzeInstall, DiffOnly, ExportOnly.
+
+.PARAMETER Target
+Single target host (default localhost).
+
+.PARAMETER TargetsCsv
+Optional CSV of targets. Remote execution is intentionally unsupported in this slice.
+
+.PARAMETER SoftwareId
+Software identifier used for run naming and installer lookup.
+
+.PARAMETER SourceConfigPath
+Path to software source configuration file (default Config/sources.yaml).
+
+.PARAMETER RegistryWatchlistPath
+Path to registry watchlist JSON.
+
+.PARAMETER OutputRoot
+Root output folder for evidence bundles.
+
+.PARAMETER DryRun
+Requests dry-run installer execution behavior.
+
+.PARAMETER InstallerPath
+Optional installer path override for tracked install runner.
+
+.PARAMETER InstallerType
+Optional installer type passed through to tracked install runner.
+
+.PARAMETER SilentArgs
+Optional silent arguments passed through to tracked install runner.
+
+.PARAMETER PreSnapshotPath
+For DiffOnly mode: path to pre-install snapshot JSON.
+
+.PARAMETER PostSnapshotPath
+For DiffOnly mode: path to post-install snapshot JSON.
+
+.PARAMETER ApprovedRemediation
+Reserved switch. Not implemented in this sprint slice.
+
+.EXAMPLE
+pwsh -File scripts/powershell/Invoke-RegistryInstallDiff.ps1 -Mode ReconOnly -Target localhost
+
+.EXAMPLE
+pwsh -File scripts/powershell/Invoke-RegistryInstallDiff.ps1 -Mode SnapshotOnly -Target localhost
+
+.EXAMPLE
+pwsh -File scripts/powershell/Invoke-RegistryInstallDiff.ps1 -Mode AnalyzeInstall -Target localhost -SoftwareId EXAMPLE-SOFTWARE-ID -DryRun
+
+.EXAMPLE
+pwsh -File scripts/powershell/Invoke-RegistryInstallDiff.ps1 -Mode DiffOnly -Target localhost -PreSnapshotPath .\before.json -PostSnapshotPath .\after.json
+
+.EXAMPLE
+pwsh -File scripts/powershell/Invoke-RegistryInstallDiff.ps1 -Mode ReconOnly -Target localhost -OutputRoot exports/registry-install-diff/custom
+
+.NOTES
+Safety: registry writes are forbidden in this slice. ApprovedRemediation always returns Unsupported.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('ReconOnly','SnapshotOnly','AnalyzeInstall','DiffOnly','ExportOnly')]
+    [string]$Mode,
+    [string]$Target = 'localhost',
+    [string]$TargetsCsv,
+    [string]$SoftwareId = 'UNSPECIFIED-SOFTWARE',
+    [string]$SourceConfigPath = 'Config/sources.yaml',
+    [string]$RegistryWatchlistPath = 'config/registry_watchlist.example.json',
+    [string]$OutputRoot = 'exports/registry-install-diff',
+    [switch]$DryRun,
+    [string]$InstallerPath,
+    [ValidateSet('exe','msi','msix','unknown')]
+    [string]$InstallerType = 'unknown',
+    [string]$SilentArgs,
+    [string]$PreSnapshotPath,
+    [string]$PostSnapshotPath,
+    [switch]$ApprovedRemediation
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-JsonFile {
+    param([string]$Path,[object]$InputObject)
+    $parent = Split-Path -Path $Path -Parent
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    $InputObject | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Invoke-Phase {
+    param([string]$Name,[scriptblock]$Action)
+    try {
+        & $Action
+        return [pscustomobject]@{ name = $Name; status = 'Success'; error = $null; timestamp = (Get-Date).ToString('o') }
+    } catch {
+        return [pscustomobject]@{ name = $Name; status = 'Failed'; error = $_.Exception.Message; timestamp = (Get-Date).ToString('o') }
+    }
+}
+
+$dependencyScripts = @{
+    readiness = 'scripts/powershell/Test-TargetReadiness.ps1'
+    snapshot = 'scripts/powershell/Get-RegistrySnapshot.ps1'
+    install = 'scripts/powershell/Invoke-TrackedInstall.ps1'
+    diff = 'scripts/powershell/Compare-RegistrySnapshots.ps1'
+}
+
+$targets = @()
+if ($Target) { $targets += $Target }
+if ($TargetsCsv -and (Test-Path -LiteralPath $TargetsCsv)) {
+    try {
+        $csvTargets = Import-Csv -LiteralPath $TargetsCsv | ForEach-Object { $_.Target }
+        $targets += $csvTargets
+    } catch {}
+}
+$targets = $targets | Where-Object { $_ } | Select-Object -Unique
+if ($targets.Count -eq 0) { $targets = @('localhost') }
+
+$nonLocal = $targets | Where-Object { $_ -ne 'localhost' -and $_ -ne '.' -and $_ -ne $env:COMPUTERNAME }
+if ($nonLocal.Count -gt 0) {
+    throw "Unsupported: remote target execution is not implemented in this agent slice. Targets: $($nonLocal -join ', ')"
+}
+
+$timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+$safeSoftware = ($SoftwareId -replace '[^A-Za-z0-9._-]', '_')
+$runId = "${timestamp}_${safeSoftware}"
+$runDir = Join-Path -Path $OutputRoot -ChildPath $runId
+$targetsDir = Join-Path -Path $runDir -ChildPath 'targets'
+New-Item -ItemType Directory -Path $targetsDir -Force | Out-Null
+
+$manifest = [ordered]@{
+    schema_version = '1.0'
+    run_id = $runId
+    created_at = (Get-Date).ToString('o')
+    mode = $Mode
+    dry_run = [bool]$DryRun
+    software_id = $SoftwareId
+    source_config_path = $SourceConfigPath
+    registry_watchlist_path = $RegistryWatchlistPath
+    output_root = $OutputRoot
+    target_count = $targets.Count
+    targets = $targets
+    dependency_scripts = @{}
+    phases = @()
+    safety_flags = [ordered]@{
+        registry_mutation_allowed = $false
+        remote_install_allowed = $false
+        dry_run = [bool]$DryRun
+        approved_remediation_mode = [bool]$ApprovedRemediation
+    }
+}
+
+foreach ($k in $dependencyScripts.Keys) {
+    $p = $dependencyScripts[$k]
+    $manifest.dependency_scripts[$k] = [ordered]@{ path = $p; exists = (Test-Path -LiteralPath $p) }
+}
+
+if ($ApprovedRemediation) {
+    $manifest.phases += [pscustomobject]@{ name='ApprovedRemediation'; status='Unsupported'; reason='ApprovedRemediationNotImplemented' }
+    Write-JsonFile -Path (Join-Path $runDir 'run_manifest.json') -InputObject $manifest
+    "Unsupported: ApprovedRemediationNotImplemented"
+    exit 2
+}
+
+$summaryRows = @()
+foreach ($t in $targets) {
+    $targetDir = Join-Path $targetsDir ($t -replace '[^A-Za-z0-9._-]','_')
+    New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+
+    $row = [ordered]@{run_id=$runId;target=$t;software_id=$SoftwareId;mode=$Mode;readiness_status='Skipped';install_status='Skipped';diff_status='Skipped';total_changes='';suspicious_changes='';remediation_candidates='';evidence_path=$targetDir;notes=''}
+
+    if ($Mode -in @('ReconOnly','AnalyzeInstall','SnapshotOnly')) {
+        if (-not (Test-Path $dependencyScripts.readiness)) {
+            $row.readiness_status = 'MissingDependency'
+            $row.notes = "MissingDependency: $($dependencyScripts.readiness)"
+        } else {
+            $ph = Invoke-Phase -Name "Readiness:$t" -Action {
+                & $dependencyScripts.readiness -Target $t | ConvertTo-Json -Depth 10 | Set-Content (Join-Path $targetDir 'readiness.json') -Encoding UTF8
+            }
+            $manifest.phases += $ph
+            $row.readiness_status = $ph.status
+        }
+    }
+
+    if ($Mode -in @('SnapshotOnly','AnalyzeInstall')) {
+        if (-not (Test-Path $dependencyScripts.snapshot)) {
+            $row.notes = ($row.notes + ' MissingDependency: ' + $dependencyScripts.snapshot).Trim()
+        } else {
+            $manifest.phases += Invoke-Phase -Name "SnapshotBefore:$t" -Action {
+                & $dependencyScripts.snapshot -Target $t -WatchlistPath $RegistryWatchlistPath | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $targetDir 'registry_before.json') -Encoding UTF8
+            }
+        }
+    }
+
+    if ($Mode -eq 'AnalyzeInstall') {
+        if (-not (Test-Path $dependencyScripts.install)) {
+            $row.install_status = 'MissingDependency'
+            $row.notes = ($row.notes + ' MissingDependency: ' + $dependencyScripts.install).Trim()
+        } else {
+            $installPhase = Invoke-Phase -Name "Install:$t" -Action {
+                $args = @('-Target', $t, '-SoftwareId', $SoftwareId, '-SourceConfigPath', $SourceConfigPath)
+                if ($DryRun) { $args += '-DryRun' }
+                if ($InstallerPath) { $args += @('-InstallerPath', $InstallerPath) }
+                if ($InstallerType) { $args += @('-InstallerType', $InstallerType) }
+                if ($SilentArgs) { $args += @('-SilentArgs', $SilentArgs) }
+                & $dependencyScripts.install @args | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $targetDir 'installer_result.json') -Encoding UTF8
+            }
+            $manifest.phases += $installPhase
+            $row.install_status = $installPhase.status
+        }
+
+        if (Test-Path $dependencyScripts.snapshot) {
+            $manifest.phases += Invoke-Phase -Name "SnapshotAfter:$t" -Action {
+                & $dependencyScripts.snapshot -Target $t -WatchlistPath $RegistryWatchlistPath | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $targetDir 'registry_after.json') -Encoding UTF8
+            }
+        }
+
+        if (-not (Test-Path $dependencyScripts.diff)) {
+            $row.diff_status = 'MissingDependency'
+            $row.notes = ($row.notes + ' MissingDependency: ' + $dependencyScripts.diff).Trim()
+        } else {
+            $beforePath = Join-Path $targetDir 'registry_before.json'
+            $afterPath = Join-Path $targetDir 'registry_after.json'
+            if ((Test-Path $beforePath) -and (Test-Path $afterPath)) {
+                $diffPhase = Invoke-Phase -Name "Diff:$t" -Action {
+                    & $dependencyScripts.diff -BeforePath $beforePath -AfterPath $afterPath -WatchlistPath $RegistryWatchlistPath | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $targetDir 'registry_diff.json') -Encoding UTF8
+                }
+                $manifest.phases += $diffPhase
+                $row.diff_status = $diffPhase.status
+            } else {
+                $row.diff_status = 'Skipped'
+                Write-JsonFile -Path (Join-Path $targetDir 'registry_diff.json') -InputObject @{status='Skipped';reason='MissingSnapshotEvidence'}
+            }
+        }
+    }
+
+    if ($Mode -eq 'DiffOnly') {
+        $beforePath = $PreSnapshotPath
+        $afterPath = $PostSnapshotPath
+        if (-not (Test-Path $dependencyScripts.diff)) {
+            $row.diff_status = 'MissingDependency'
+            $row.notes = "MissingDependency: $($dependencyScripts.diff)"
+        } elseif (-not $beforePath -or -not $afterPath) {
+            $row.diff_status = 'Failed'
+            $row.notes = 'DiffOnly requires -PreSnapshotPath and -PostSnapshotPath'
+        } else {
+            $diffPhase = Invoke-Phase -Name "Diff:$t" -Action {
+                & $dependencyScripts.diff -BeforePath $beforePath -AfterPath $afterPath -WatchlistPath $RegistryWatchlistPath | ConvertTo-Json -Depth 20 | Set-Content (Join-Path $targetDir 'registry_diff.json') -Encoding UTF8
+            }
+            $manifest.phases += $diffPhase
+            $row.diff_status = $diffPhase.status
+        }
+    }
+
+    $summaryRows += [pscustomobject]$row
+}
+
+Write-JsonFile -Path (Join-Path $runDir 'run_manifest.json') -InputObject $manifest
+$summaryCsvPath = Join-Path $runDir 'summary.csv'
+$summaryRows | Export-Csv -Path $summaryCsvPath -NoTypeInformation -Encoding UTF8
+
+$phaseBullets = if ($manifest.phases.Count -gt 0) {
+    ($manifest.phases | ForEach-Object { "- $($_.name): $($_.status)" }) -join "`n"
+} else {
+    '- No phases executed.'
+}
+
+$summaryMd = @"
+# Registry Install Diff Summary
+
+- **Run ID:** $runId
+- **Software ID:** $SoftwareId
+- **Mode:** $Mode
+- **Targets:** $($targets -join ', ')
+
+## Phase Results
+$phaseBullets
+
+## Evidence Files
+- run_manifest.json
+- summary.md
+- summary.csv
+- targets/<target>/readiness.json (when available)
+- targets/<target>/registry_before.json (when available)
+- targets/<target>/installer_result.json (when available)
+- targets/<target>/registry_after.json (when available)
+- targets/<target>/registry_diff.json (when available or skipped with reason)
+
+## Failures / Skips
+- Missing dependencies are recorded as **MissingDependency** and include script paths.
+- Remote target execution is unsupported in this slice.
+
+## Next Action
+- Validate dependency script availability and rerun in localhost dry-run mode first.
+
+> Warning: Registry edits were not performed by this orchestrator.
+"@
+$summaryMd | Set-Content -Path (Join-Path $runDir 'summary.md') -Encoding UTF8
+
+Write-Output "RunComplete: $runDir"

--- a/scripts/sas_registry_install_diff.sh
+++ b/scripts/sas_registry_install_diff.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./scripts/sas_registry_install_diff.sh --mode <Mode> [options]
+
+Examples:
+  ./scripts/sas_registry_install_diff.sh --mode ReconOnly --target localhost
+  ./scripts/sas_registry_install_diff.sh --mode AnalyzeInstall --target localhost --software-id EXAMPLE-SOFTWARE-ID --dry-run
+
+Argument mapping:
+  --mode -> -Mode
+  --target -> -Target
+  --targets-csv -> -TargetsCsv
+  --software-id -> -SoftwareId
+  --source-config-path -> -SourceConfigPath
+  --registry-watchlist-path -> -RegistryWatchlistPath
+  --output-root -> -OutputRoot
+  --dry-run -> -DryRun
+  --installer-path -> -InstallerPath
+  --installer-type -> -InstallerType
+  --silent-args -> -SilentArgs
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if command -v pwsh >/dev/null 2>&1; then
+  PS_BIN="pwsh"
+elif command -v powershell >/dev/null 2>&1; then
+  PS_BIN="powershell"
+else
+  echo "POWERSHELL_UNAVAILABLE_IN_ENVIRONMENT: required pwsh or powershell was not found in PATH." >&2
+  exit 127
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ORCH="$REPO_ROOT/scripts/powershell/Invoke-RegistryInstallDiff.ps1"
+
+if [[ ! -f "$ORCH" ]]; then
+  echo "MissingDependency: $ORCH" >&2
+  exit 3
+fi
+
+PS_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) PS_ARGS+=("-Mode" "$2"); shift 2 ;;
+    --target) PS_ARGS+=("-Target" "$2"); shift 2 ;;
+    --targets-csv) PS_ARGS+=("-TargetsCsv" "$2"); shift 2 ;;
+    --software-id) PS_ARGS+=("-SoftwareId" "$2"); shift 2 ;;
+    --source-config-path) PS_ARGS+=("-SourceConfigPath" "$2"); shift 2 ;;
+    --registry-watchlist-path) PS_ARGS+=("-RegistryWatchlistPath" "$2"); shift 2 ;;
+    --output-root) PS_ARGS+=("-OutputRoot" "$2"); shift 2 ;;
+    --dry-run) PS_ARGS+=("-DryRun"); shift ;;
+    --installer-path) PS_ARGS+=("-InstallerPath" "$2"); shift 2 ;;
+    --installer-type) PS_ARGS+=("-InstallerType" "$2"); shift 2 ;;
+    --silent-args) PS_ARGS+=("-SilentArgs" "$2"); shift 2 ;;
+    --approved-remediation) PS_ARGS+=("-ApprovedRemediation"); shift ;;
+    -*) PS_ARGS+=("$1"); if [[ $# -gt 1 && "$2" != -* ]]; then PS_ARGS+=("$2"); shift 2; else shift; fi ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+exec "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$ORCH" "${PS_ARGS[@]}"

--- a/tests/bash/test_registry_install_diff_wrapper_contracts.sh
+++ b/tests/bash/test_registry_install_diff_wrapper_contracts.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WRAPPER="scripts/sas_registry_install_diff.sh"
+[[ -f "$WRAPPER" ]] || { echo "missing wrapper"; exit 1; }
+[[ -x "$WRAPPER" ]] || { echo "wrapper not executable"; exit 1; }
+
+bash -n "$WRAPPER"
+
+grep -q "Invoke-RegistryInstallDiff.ps1" "$WRAPPER"
+
+grep -Eq "pwsh|powershell" "$WRAPPER"
+
+grep -q "POWERSHELL_UNAVAILABLE_IN_ENVIRONMENT" "$WRAPPER"
+
+! grep -Eqi "reg (add|delete|import|restore)" "$WRAPPER"
+! grep -Eqi "Set-ItemProperty|New-ItemProperty|Remove-ItemProperty" "$WRAPPER"
+
+"$WRAPPER" --help >/dev/null
+
+echo "PASS: wrapper contracts"


### PR DESCRIPTION
## **User description**
### Motivation
- Provide an evidence-first orchestrator to capture registry state around tracked installs and produce reproducible evidence bundles for review. 
- Keep a Bash-on-Windows field entrypoint while preserving PowerShell as the registry-capable engine and enforcing read-only/default-safety behaviors.

### Description
- Add `scripts/powershell/Invoke-RegistryInstallDiff.ps1`, a PowerShell orchestrator implementing modes `ReconOnly`, `SnapshotOnly`, `AnalyzeInstall`, `DiffOnly`, and `ExportOnly`, with run-folder / `run_manifest.json` creation, per-target evidence paths, summary `.md`/`.csv` exports, dependency-script detection, and MissingDependency reporting. 
- Implement localhost-first enforcement and explicit rejection of the `-ApprovedRemediation` switch (returns `Unsupported` with reason `ApprovedRemediationNotImplemented`) so no registry mutation logic is added in this sprint. 
- Add `scripts/sas_registry_install_diff.sh`, a Bash-on-Windows wrapper that prefers `pwsh` then `powershell`, validates the orchestrator exists, translates/forwards arguments, and fails clearly if PowerShell is unavailable. 
- Add automated test contracts and docs: `Tests/Pester/RegistryInstallDiff.Orchestrator.Tests.ps1` (Pester contracts for help, safety patterns, and manifest behavior), `tests/bash/test_registry_install_diff_wrapper_contracts.sh` (wrapper contract checks), and `docs/REGISTRY_INSTALL_DIFF_BASH_WRAPPER.md` (usage, safety, and argument mapping).

### Testing
- `bash -n scripts/sas_registry_install_diff.sh` was executed and passed syntax check. 
- `tests/bash/test_registry_install_diff_wrapper_contracts.sh` was executed and passed (wrapper presence, executable bit, syntax, PowerShell messaging, forbidden-regex checks, and help invocation). 
- A direct PowerShell runtime check of the orchestrator was attempted but failed in this environment with `POWERSHELL_UNAVAILABLE_IN_ENVIRONMENT`, so Pester specs were created but not executed here due to missing PowerShell/Pester in the container. 
- The orchestrator was implemented to explicitly record MissingDependency states so downstream test runs with PowerShell/Pester available will surface dependency-related outcomes rather than silently skipping phases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126a19c768832290b209dc98a93a00)


___

## **CodeAnt-AI Description**
**Add a localhost-first registry install diff workflow with a Bash entrypoint**

### What Changed
- Added a PowerShell orchestrator that runs registry install diff steps, creates a run folder, and writes a manifest plus summary files for each run
- The workflow now records missing dependency scripts instead of failing silently, and it marks remote target execution as unsupported in this slice
- Approved remediation is explicitly blocked and returns an unsupported result instead of allowing registry changes
- Added a Bash wrapper that picks PowerShell automatically, maps common CLI arguments, and fails clearly when PowerShell is not available
- Added contract tests and usage docs for the wrapper and orchestrator behavior

### Impact
`✅ Clearer install evidence for review`
`✅ Fewer silent pipeline skips`
`✅ Safer localhost-only runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
