### PR TITLE
Add numeric hostname availability with AD/tracker/DNS evidence

### DIFF
--- a/deployment-audit/tests/test_hostname_availability_contracts.sh
+++ b/deployment-audit/tests/test_hostname_availability_contracts.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT/survey/output/test-hostname-availability"
+SUMMARY_OUT="$OUT_DIR/hostname_availability_summary.csv"
+DETAIL_OUT="$OUT_DIR/hostname_availability_detail.csv"
+DASHBOARD_OUT="$OUT_DIR/hostname_availability.html"
+WRAP_OUT_DIR="$OUT_DIR/wrapper"
+FIXTURE="$ROOT/survey/fixtures/hostname_availability_sample.txt"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+python3 "$ROOT/survey/sas-hostname-availability.py" \
+  --convention WNH270OPR \
+  --convention WMH300OPR \
+  --suffix-mode numeric \
+  --width 3 \
+  --used-names "$FIXTURE" \
+  --summary-output "$SUMMARY_OUT" \
+  --detail-output "$DETAIL_OUT" \
+  --dashboard "$DASHBOARD_OUT" \
+  --candidate-count 5
+
+[[ -f "$SUMMARY_OUT" ]] || { echo "FAIL: missing summary output" >&2; exit 1; }
+[[ -f "$DETAIL_OUT" ]] || { echo "FAIL: missing detail output" >&2; exit 1; }
+[[ -f "$DASHBOARD_OUT" ]] || { echo "FAIL: missing dashboard output" >&2; exit 1; }
+
+for col in ConventionPrefix FirstGapName NextAfterHighestName GapCandidates NextCandidates SuffixMode; do
+  grep -q "$col" "$SUMMARY_OUT" || { echo "FAIL: missing summary column $col" >&2; exit 1; }
+done
+
+grep -q 'WNH270OPR003' "$SUMMARY_OUT" || { echo "FAIL: expected WNH first gap WNH270OPR003" >&2; exit 1; }
+grep -q 'WNH270OPR011' "$SUMMARY_OUT" || { echo "FAIL: expected WNH next after highest WNH270OPR011" >&2; exit 1; }
+grep -q 'WMH300OPR135' "$SUMMARY_OUT" || { echo "FAIL: expected WMH next after highest WMH300OPR135" >&2; exit 1; }
+
+for detail in OCCUPIED AVAILABLE_GAP AVAILABLE_AFTER_HIGHEST; do
+  grep -q "$detail" "$DETAIL_OUT" || { echo "FAIL: expected detail record $detail" >&2; exit 1; }
+done
+
+for dash_text in 'SysAdminSuite Hostname Availability' 'First gap' 'Next after highest'; do
+  grep -q "$dash_text" "$DASHBOARD_OUT" || { echo "FAIL: missing dashboard text $dash_text" >&2; exit 1; }
+done
+
+bash "$ROOT/survey/sas-survey-hostname-availability.sh" \
+  --convention WNH270OPR \
+  --used-names "$FIXTURE" \
+  --suffix-mode numeric \
+  --width 3 \
+  --run-id testwrapper \
+  --output-dir "$WRAP_OUT_DIR" \
+  --candidate-count 5
+
+[[ -f "$WRAP_OUT_DIR/testwrapper_hostname_availability_summary.csv" ]] || { echo "FAIL: wrapper missing summary" >&2; exit 1; }
+grep -q 'WNH270OPR003' "$WRAP_OUT_DIR/testwrapper_hostname_availability_summary.csv" || { echo "FAIL: wrapper expected WNH first gap" >&2; exit 1; }
+
+echo "PASS: hostname availability contracts"

--- a/docs/COMMAND_CATALOG.md
+++ b/docs/COMMAND_CATALOG.md
@@ -146,6 +146,20 @@ systemctl status
 journalctl
 ```
 
+## Hostname Availability
+
+Read-only naming sequence analysis for conventions such as `WNH270OPR###`:
+
+```bash
+bash survey/sas-survey-hostname-availability.sh \
+  --convention WNH270OPR \
+  --suffix-mode numeric \
+  --width 3 \
+  --used-names survey/fixtures/hostname_availability_sample.txt
+```
+
+See `docs/HOSTNAME_AVAILABILITY.md` for AD export, tracker union, and DNS check options.
+
 ## Rule For New Commands
 
 If a needed command is not listed here, add it to this catalog and wrap it in a script before sending it to a technician.

--- a/docs/HOSTNAME_AVAILABILITY.md
+++ b/docs/HOSTNAME_AVAILABILITY.md
@@ -1,0 +1,89 @@
+# Hostname Availability Workflow
+
+## Purpose
+
+Find the next available hostname for fixed naming conventions such as `WNH270OPR###` (three-digit suffix) or alphabetic site patterns. The workflow unions evidence from:
+
+- Active Directory (prefix export, read-only)
+- Deployment and ticket trackers
+- Optional forward DNS checks on candidates and occupied names
+
+It reports **both** recommendations:
+
+| Field | When to use |
+|-------|-------------|
+| `FirstGapName` | Lowest missing suffix in the observed sequence |
+| `NextAfterHighestName` | First suffix after the highest observed name (safer when stale AD/DNS objects exist) |
+
+## Files
+
+| File | Role |
+|------|------|
+| `survey/sas-hostname-availability.py` | Analyzer (numeric or alphabetic suffix modes) |
+| `survey/sas-survey-hostname-availability.sh` | Field wrapper: AD export, tracker extract, DNS, analyze |
+| `survey/sas-ad-computer-prefix-export.ps1` | Read-only AD `Name -like Prefix*` export |
+| `survey/sas-extract-tracker-hostnames.sh` | Read-only tracker hostname column extract |
+| `survey/sas-dns-hostname-evidence.sh` | Read-only forward DNS evidence |
+| `survey/fixtures/hostname_availability_sample.txt` | Sample-safe fixture |
+| `deployment-audit/tests/test_hostname_availability_contracts.sh` | Contract test |
+
+Neuron-specific alphabetic tooling remains in `survey/sas-neuron-name-availability.py` and `docs/NEURON_NAME_AVAILABILITY.md`.
+
+## Evidence posture
+
+```text
+Collect evidence (AD, tracker, optional DNS)
+        |
+        v
+Analyze once (gaps + next-after-highest)
+        |
+        v
+Optional DNS re-pass if --dns-check
+```
+
+Default recommended mode: saved evidence (`--used-names`) or `--ad-export` from an admin workstation with RSAT/AD module access.
+
+## Example: WNH270OPR numeric
+
+```bash
+bash survey/sas-survey-hostname-availability.sh \
+  --convention WNH270OPR \
+  --suffix-mode numeric \
+  --width 3 \
+  --ad-export \
+  --tracker-workbook /path/to/ActiveDeploymentTracker.xlsx \
+  --ticket-workbook /path/to/ActiveTicketTracker.xlsx \
+  --dns-check \
+  --output-dir survey/output/wnh270opr-availability
+```
+
+Fixture-only (no live AD):
+
+```bash
+bash survey/sas-survey-hostname-availability.sh \
+  --convention WNH270OPR \
+  --suffix-mode numeric \
+  --width 3 \
+  --used-names survey/fixtures/hostname_availability_sample.txt
+```
+
+## Suffix modes
+
+| Mode | Example | Notes |
+|------|---------|-------|
+| `numeric` | `WNH270OPR001` | `--width` sets digit count (default 3) |
+| `alphabetic` | `LIJ-MACH-A` | Excel-style A, B, … Z, AA (same model as Neuron tool) |
+
+## Operating rule
+
+Network or AD evidence alone is not enough for final production naming. Validate the chosen name against AD, DNS, and the deployment tracker before assignment.
+
+## Test
+
+```bash
+bash deployment-audit/tests/test_hostname_availability_contracts.sh
+```
+
+## Privacy
+
+Do not commit live outputs under `survey/output/` or `survey/artifacts/`.

--- a/survey/fixtures/hostname_availability_sample.txt
+++ b/survey/fixtures/hostname_availability_sample.txt
@@ -1,0 +1,6 @@
+# Sample-safe hostname evidence (not operational data)
+WNH270OPR001
+WNH270OPR002
+WNH270OPR005
+WNH270OPR010
+WMH300OPR134

--- a/survey/sas-ad-computer-prefix-export.ps1
+++ b/survey/sas-ad-computer-prefix-export.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+  Read-only Active Directory export of computer names matching a naming prefix.
+
+.DESCRIPTION
+  Enumerates AD computer objects whose Name matches Prefix* using the ActiveDirectory
+  module when available, then dsquery as a limited fallback. Does not modify AD.
+
+  Output CSV is suitable for --used-names evidence in sas-hostname-availability.py.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Prefix,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Output,
+
+    [string]$Server
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Normalize-Prefix {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        throw 'Prefix cannot be blank.'
+    }
+    return ($Value.Trim() -replace '\s+', '').ToUpperInvariant()
+}
+
+function New-ExportRow {
+    param(
+        [string]$ComputerName,
+        [string]$DNSHostName = '',
+        [string]$Enabled = '',
+        [string]$DistinguishedName = '',
+        [string]$ADStatus = '',
+        [string]$ADProbeMethod = '',
+        [string]$Notes = ''
+    )
+    [pscustomobject]@{
+        ComputerName      = $ComputerName
+        DNSHostName       = $DNSHostName
+        Enabled           = $Enabled
+        DistinguishedName = $DistinguishedName
+        EvidenceSource    = 'active_directory'
+        ADStatus          = $ADStatus
+        ADProbeMethod     = $ADProbeMethod
+        Notes             = $Notes
+    }
+}
+
+$normalizedPrefix = Normalize-Prefix $Prefix
+$likePattern = "$normalizedPrefix*"
+
+$outDir = Split-Path -Parent $Output
+if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+}
+
+$rows = @()
+$hasADModule = $null -ne (Get-Module -ListAvailable -Name ActiveDirectory | Select-Object -First 1)
+$hasDsquery = $null -ne (Get-Command dsquery.exe -ErrorAction SilentlyContinue)
+
+if ($hasADModule) {
+    Import-Module ActiveDirectory -ErrorAction Stop | Out-Null
+    $params = @{
+        Filter      = "Name -like '$likePattern'"
+        Properties  = @('Name', 'DNSHostName', 'Enabled', 'DistinguishedName')
+        ErrorAction = 'Stop'
+    }
+    if ($Server) { $params['Server'] = $Server }
+
+    try {
+        $computers = @(Get-ADComputer @params)
+        foreach ($c in $computers) {
+            $rows += New-ExportRow `
+                -ComputerName ([string]$c.Name) `
+                -DNSHostName ([string]$c.DNSHostName) `
+                -Enabled ([string]$c.Enabled) `
+                -DistinguishedName ([string]$c.DistinguishedName) `
+                -ADStatus 'ad_object_found' `
+                -ADProbeMethod 'active_directory_module_prefix' `
+                -Notes ("Prefix filter: {0}" -f $likePattern)
+        }
+        if ($rows.Count -eq 0) {
+            $rows += New-ExportRow `
+                -ComputerName '' `
+                -ADStatus 'ad_no_match' `
+                -ADProbeMethod 'active_directory_module_prefix' `
+                -Notes ("No AD computers matched prefix filter: {0}" -f $likePattern)
+        }
+    } catch {
+        $rows += New-ExportRow `
+            -ComputerName '' `
+            -ADStatus 'ad_query_failed' `
+            -ADProbeMethod 'active_directory_module_prefix' `
+            -Notes $_.Exception.Message
+    }
+}
+elseif ($hasDsquery) {
+    try {
+        $raw = & dsquery.exe computer -name $likePattern 2>&1
+        if ($LASTEXITCODE -eq 0 -and $raw) {
+            foreach ($line in @($raw | Where-Object { $_ -and $_.ToString().Trim() })) {
+                $host = ''
+                if ($line -match '^"CN=([^,"]+)') { $host = $matches[1] }
+                elseif ($line -match '^CN=([^,]+)') { $host = $matches[1] }
+                if ($host) {
+                    $rows += New-ExportRow `
+                        -ComputerName $host `
+                        -DistinguishedName ([string]$line) `
+                        -ADStatus 'ad_object_found' `
+                        -ADProbeMethod 'dsquery_prefix' `
+                        -Notes ("Prefix filter: {0}" -f $likePattern)
+                }
+            }
+        }
+        if ($rows.Count -eq 0) {
+            $rows += New-ExportRow `
+                -ComputerName '' `
+                -ADStatus 'ad_no_match' `
+                -ADProbeMethod 'dsquery_prefix' `
+                -Notes (($raw | Out-String).Trim())
+        }
+    } catch {
+        $rows += New-ExportRow `
+            -ComputerName '' `
+            -ADStatus 'ad_query_failed' `
+            -ADProbeMethod 'dsquery_prefix' `
+            -Notes $_.Exception.Message
+    }
+}
+else {
+    $rows += New-ExportRow `
+        -ComputerName '' `
+        -ADStatus 'ad_probe_unavailable' `
+        -ADProbeMethod 'none' `
+        -Notes 'Neither ActiveDirectory PowerShell module nor dsquery.exe is available.'
+}
+
+$rows | Export-Csv -LiteralPath $Output -NoTypeInformation -Encoding UTF8
+Write-Host ("AD prefix export written: {0} ({1} rows)" -f $Output, $rows.Count)

--- a/survey/sas-dns-hostname-evidence.sh
+++ b/survey/sas-dns-hostname-evidence.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Read-only forward DNS checks for hostname naming evidence.
+set -euo pipefail
+
+HOSTNAMES=()
+HOSTNAME_FILE=""
+OUTPUT=""
+TIMEOUT=3
+
+usage(){ cat <<'USAGE'
+SysAdminSuite DNS Hostname Evidence
+
+Usage:
+  bash survey/sas-dns-hostname-evidence.sh --hostname WNH270OPR001 ...
+  bash survey/sas-dns-hostname-evidence.sh --hostnames-file names.txt --output evidence.csv
+
+Options:
+  --hostname VALUE        Hostname to check. Repeatable.
+  --hostnames-file PATH   One hostname per line (# comments allowed).
+  --output PATH           Output CSV path (required).
+  --timeout SEC           Lookup timeout hint. Default: 3
+  -h, --help              Show help
+
+Read-only. Does not modify DNS.
+USAGE
+}
+
+fail(){ echo "[dns-hostname] ERROR: $*" >&2; exit 1; }
+trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
+has_cmd(){ command -v "$1" >/dev/null 2>&1; }
+
+resolve_host(){
+  local host="$1"
+  local ip=""
+  if has_cmd getent; then
+    ip="$(getent ahostsv4 "$host" 2>/dev/null | awk 'NR==1{print $1; exit}')"
+  elif has_cmd nslookup; then
+    ip="$(nslookup "$host" 2>/dev/null | awk '/^Address: /{print $2}' | tail -n 1)"
+  fi
+  if [[ -n "$ip" ]]; then
+    printf 'Resolved|%s' "$ip"
+  else
+    printf 'NoRecord|'
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --hostname) HOSTNAMES+=("${2:?}"); shift 2 ;;
+    --hostnames-file) HOSTNAME_FILE="${2:?}"; shift 2 ;;
+    --output) OUTPUT="${2:?}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$OUTPUT" ]] || fail "--output is required"
+[[ "$TIMEOUT" =~ ^[0-9]+$ ]] || fail "--timeout must be numeric"
+
+if [[ -n "$HOSTNAME_FILE" ]]; then
+  [[ -f "$HOSTNAME_FILE" ]] || fail "hostnames file not found: $HOSTNAME_FILE"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(trim "$line")"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    HOSTNAMES+=("$line")
+  done < "$HOSTNAME_FILE"
+fi
+
+[[ "${#HOSTNAMES[@]}" -gt 0 ]] || fail "No hostnames supplied"
+mkdir -p "$(dirname "$OUTPUT")"
+
+{
+  printf '"HostName","LookupStatus","ResolvedAddress","EvidenceSource"\n'
+  for host in "${HOSTNAMES[@]}"; do
+    host="$(echo "$host" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+    [[ -n "$host" ]] || continue
+    result="$(resolve_host "$host")"
+    status="${result%%|*}"
+    ip="${result#*|}"
+    printf '"%s","%s","%s","dns_forward"\n' "$host" "$status" "$ip"
+  done
+} > "$OUTPUT"
+
+echo "[dns-hostname] Wrote DNS evidence: $OUTPUT (${#HOSTNAMES[@]} hostnames)" >&2

--- a/survey/sas-extract-tracker-hostnames.sh
+++ b/survey/sas-extract-tracker-hostnames.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Extract hostname values from deployment/ticket tracker workbooks for naming evidence.
+set -euo pipefail
+
+WORKBOOK=""
+TICKET_WORKBOOK=""
+DEPLOYMENT_SHEET="Deployments"
+TICKET_SHEET="General"
+OUTPUT=""
+
+usage(){ cat <<'USAGE'
+SysAdminSuite Tracker Hostname Extract
+
+Usage:
+  bash survey/sas-extract-tracker-hostnames.sh \
+    --workbook tracker.xlsx \
+    [--ticket-workbook tickets.xlsx] \
+    --output survey/artifacts/tracker_hostnames.csv
+
+Options:
+  --workbook PATH           Deployment tracker .xlsx (Deployments sheet).
+  --ticket-workbook PATH    Ticket tracker .xlsx (Hostname Used on General sheet).
+  --deployment-sheet NAME   Sheet name. Default: Deployments
+  --ticket-sheet NAME       Ticket sheet. Default: General
+  --output PATH             Output CSV (HostName, SourceColumn, SourceWorkbook)
+  -h, --help                Show help
+
+Read-only. Does not modify workbooks.
+USAGE
+}
+
+fail(){ echo "[tracker-hostnames] ERROR: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workbook) WORKBOOK="${2:?}"; shift 2 ;;
+    --ticket-workbook) TICKET_WORKBOOK="${2:?}"; shift 2 ;;
+    --deployment-sheet) DEPLOYMENT_SHEET="${2:?}"; shift 2 ;;
+    --ticket-sheet) TICKET_SHEET="${2:?}"; shift 2 ;;
+    --output) OUTPUT="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$OUTPUT" ]] || fail "--output is required"
+[[ -n "$WORKBOOK" || -n "$TICKET_WORKBOOK" ]] || fail "Supply --workbook and/or --ticket-workbook"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+python3 - "$WORKBOOK" "$TICKET_WORKBOOK" "$DEPLOYMENT_SHEET" "$TICKET_SHEET" "$OUTPUT" <<'PY'
+import csv, re, sys, zipfile, xml.etree.ElementTree as ET
+
+deployment_wb, ticket_wb, dep_sheet, tix_sheet, output = sys.argv[1:6]
+ns = {
+    'm': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main',
+    'r': 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+    'p': 'http://schemas.openxmlformats.org/package/2006/relationships',
+}
+
+def q(k, t):
+    return '{%s}%s' % (ns[k], t)
+
+def norm_header(v):
+    return re.sub(r'\s+', ' ', str(v or '').strip()).lower()
+
+def col_to_idx(ref):
+    letters = ''.join(c for c in ref if c.isalpha())
+    out = 0
+    for c in letters.upper():
+        out = out * 26 + ord(c) - 64
+    return out - 1
+
+def norm_hostname(v):
+    v = re.sub(r'\s+', '', str(v or '').strip())
+    if not v or v.upper() in {'N/A', 'NA', 'NONE', 'NULL', 'TBD', '#N/A'}:
+        return ''
+    return v.upper()
+
+def shared_strings(z):
+    if 'xl/sharedStrings.xml' not in z.namelist():
+        return []
+    root = ET.fromstring(z.read('xl/sharedStrings.xml'))
+    return [''.join(t.text or '' for t in si.iter(q('m', 't'))) for si in root.findall(q('m', 'si'))]
+
+def cell_value(cell, shared):
+    typ = cell.attrib.get('t')
+    if typ == 'inlineStr':
+        node = cell.find(q('m', 'is'))
+        return ''.join(t.text or '' for t in node.iter(q('m', 't'))) if node is not None else ''
+    v = cell.find(q('m', 'v'))
+    if v is None:
+        return ''
+    raw = v.text or ''
+    if typ == 's':
+        try:
+            return shared[int(raw)]
+        except Exception:
+            return raw
+    return raw
+
+def sheet_map(z):
+    wb = ET.fromstring(z.read('xl/workbook.xml'))
+    rels = ET.fromstring(z.read('xl/_rels/workbook.xml.rels'))
+    rid = {r.attrib['Id']: r.attrib['Target'] for r in rels.findall(q('p', 'Relationship'))}
+    out = {}
+    for s in wb.find(q('m', 'sheets')).findall(q('m', 'sheet')):
+        target = rid[s.attrib[q('r', 'id')]]
+        if not target.startswith('xl/'):
+            target = 'xl/' + target.lstrip('/')
+        out[s.attrib['name']] = target
+    return out
+
+def read_sheet(z, sheet_name, shared):
+    paths = sheet_map(z)
+    if sheet_name not in paths:
+        return [], []
+    root = ET.fromstring(z.read(paths[sheet_name]))
+    rows = []
+    for row in root.iter(q('m', 'row')):
+        cells = {}
+        for c in row.findall(q('m', 'c')):
+            cells[col_to_idx(c.attrib['r'])] = cell_value(c, shared)
+        if cells:
+            rows.append([cells.get(i, '') for i in range(max(cells) + 1)])
+    if not rows:
+        return [], []
+    headers = [norm_header(x) for x in rows[0]]
+    data = []
+    for raw in rows[1:]:
+        rec = {}
+        for i, h in enumerate(headers):
+            if h:
+                rec[h] = raw[i] if i < len(raw) else ''
+        data.append(rec)
+    return headers, data
+
+DEPLOYMENT_COLUMNS = [
+    'cybernet hostname',
+    'neuron hostname',
+    'replaced hostname',
+    'old hostname',
+]
+TICKET_COLUMNS = ['hostname used']
+
+rows_out = []
+
+def add_host(value, column, workbook):
+    for part in re.split(r'[\r\n;,]+', str(value or '')):
+        host = norm_hostname(part)
+        if host:
+            rows_out.append({'HostName': host, 'SourceColumn': column, 'SourceWorkbook': workbook, 'EvidenceSource': 'deployment_tracker'})
+
+def process_workbook(path, sheet, columns, label):
+    if not path:
+        return
+    with zipfile.ZipFile(path) as z:
+        shared = shared_strings(z)
+        headers, data = read_sheet(z, sheet, shared)
+        if not headers:
+            return
+        header_map = {h: i for i, h in enumerate(headers)}
+        for rec in data:
+            for col in columns:
+                value = ''
+                for hk, hv in rec.items():
+                    if norm_header(hk) == col:
+                        value = hv
+                        break
+                add_host(value, col, label)
+
+process_workbook(deployment_wb, dep_sheet, DEPLOYMENT_COLUMNS, deployment_wb)
+process_workbook(ticket_wb, tix_sheet, TICKET_COLUMNS, ticket_wb)
+
+with open(output, 'w', newline='', encoding='utf-8') as handle:
+    writer = csv.DictWriter(handle, fieldnames=['HostName', 'SourceColumn', 'SourceWorkbook', 'EvidenceSource'], lineterminator='\n')
+    writer.writeheader()
+    writer.writerows(rows_out)
+
+print(f"Wrote {len(rows_out)} tracker hostname rows: {output}")
+PY
+
+echo "[tracker-hostnames] Wrote: $OUTPUT" >&2

--- a/survey/sas-hostname-availability.py
+++ b/survey/sas-hostname-availability.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Analyze hostname naming conventions from saved AD/tracker/DNS evidence.
+
+Supports alphabetic suffixes (LIJ-MACH-A) and fixed-width numeric suffixes (WNH270OPR001).
+Does not scan the network or modify AD. Generated outputs may contain operational hostnames.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import html
+import re
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SUMMARY_FIELDS = [
+    "ConventionPrefix",
+    "SuffixMode",
+    "SuffixWidth",
+    "UsedCount",
+    "HighestUsedName",
+    "HighestUsedSuffix",
+    "HighestUsedOrdinal",
+    "FirstGapName",
+    "FirstGapSuffix",
+    "FirstGapOrdinal",
+    "NextAfterHighestName",
+    "NextAfterHighestSuffix",
+    "NextAfterHighestOrdinal",
+    "GapCandidates",
+    "NextCandidates",
+    "EvidenceSources",
+    "Notes",
+]
+
+DETAIL_FIELDS = [
+    "ConventionPrefix",
+    "RecordType",
+    "Name",
+    "Suffix",
+    "Ordinal",
+    "ObservedAs",
+    "EvidenceSource",
+    "Notes",
+]
+
+
+@dataclass(frozen=True)
+class NameEvidence:
+    convention_prefix: str
+    name: str
+    suffix: str
+    ordinal: int
+    observed_as: str
+    evidence_source: str
+
+
+def clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def normalize_prefix(value: str) -> str:
+    value = clean(value).upper()
+    if not value:
+        raise ValueError("Convention prefix cannot be blank")
+    return value
+
+
+def suffix_to_ordinal_alphabetic(suffix: str) -> int:
+    suffix = clean(suffix).upper()
+    if not suffix or not re.fullmatch(r"[A-Z]+", suffix):
+        raise ValueError(f"Invalid alphabetic suffix: {suffix!r}")
+    value = 0
+    for char in suffix:
+        value = value * 26 + (ord(char) - ord("A") + 1)
+    return value
+
+
+def ordinal_to_suffix_alphabetic(value: int) -> str:
+    if value < 1:
+        raise ValueError("Ordinal must be >= 1")
+    chars: list[str] = []
+    while value:
+        value, rem = divmod(value - 1, 26)
+        chars.append(chr(ord("A") + rem))
+    return "".join(reversed(chars))
+
+
+def suffix_to_ordinal_numeric(suffix: str, width: int) -> int:
+    suffix = clean(suffix)
+    if not re.fullmatch(rf"\d{{{width}}}", suffix):
+        raise ValueError(f"Invalid numeric suffix (width {width}): {suffix!r}")
+    return int(suffix, 10)
+
+
+def ordinal_to_suffix_numeric(value: int, width: int) -> str:
+    if value < 1:
+        raise ValueError("Ordinal must be >= 1")
+    if value >= 10**width:
+        raise ValueError(f"Ordinal {value} exceeds width {width}")
+    return str(value).zfill(width)
+
+
+def find_convention_names(
+    text: str,
+    prefixes: list[str],
+    source: str,
+    *,
+    suffix_mode: str,
+    suffix_width: int,
+) -> list[NameEvidence]:
+    observed = clean(text)
+    upper = observed.upper()
+    rows: list[NameEvidence] = []
+    for prefix in prefixes:
+        if suffix_mode == "numeric":
+            pattern = re.compile(
+                rf"(?<![A-Z0-9])({re.escape(prefix)})(\d{{{suffix_width}}})(?!\d)",
+                re.IGNORECASE,
+            )
+            for match in pattern.finditer(upper):
+                suffix = match.group(2)
+                ordinal = suffix_to_ordinal_numeric(suffix, suffix_width)
+                name = f"{prefix}{suffix}"
+                rows.append(
+                    NameEvidence(
+                        convention_prefix=prefix,
+                        name=name,
+                        suffix=suffix,
+                        ordinal=ordinal,
+                        observed_as=observed,
+                        evidence_source=source,
+                    )
+                )
+        else:
+            pattern = re.compile(rf"(?<![A-Z0-9])({re.escape(prefix)})([A-Z]+)(?![A-Z0-9])")
+            for match in pattern.finditer(upper):
+                suffix = match.group(2)
+                ordinal = suffix_to_ordinal_alphabetic(suffix)
+                name = f"{prefix}{suffix}"
+                rows.append(
+                    NameEvidence(
+                        convention_prefix=prefix,
+                        name=name,
+                        suffix=suffix,
+                        ordinal=ordinal,
+                        observed_as=observed,
+                        evidence_source=source,
+                    )
+                )
+    return rows
+
+
+def parse_nmap_xml(
+    path: Path, prefixes: list[str], *, suffix_mode: str, suffix_width: int
+) -> list[NameEvidence]:
+    root = ET.parse(path).getroot()
+    rows: list[NameEvidence] = []
+    for host in root.findall("host"):
+        hostnames = host.find("hostnames")
+        if hostnames is None:
+            continue
+        for hostname in hostnames.findall("hostname"):
+            value = clean(hostname.get("name"))
+            if value:
+                rows.extend(
+                    find_convention_names(
+                        value, prefixes, str(path), suffix_mode=suffix_mode, suffix_width=suffix_width
+                    )
+                )
+    return rows
+
+
+def parse_textish(
+    path: Path, prefixes: list[str], *, suffix_mode: str, suffix_width: int
+) -> list[NameEvidence]:
+    text = path.read_text(encoding="utf-8-sig", errors="replace")
+    return find_convention_names(
+        text, prefixes, str(path), suffix_mode=suffix_mode, suffix_width=suffix_width
+    )
+
+
+def parse_csv(
+    path: Path, prefixes: list[str], *, suffix_mode: str, suffix_width: int
+) -> list[NameEvidence]:
+    rows: list[NameEvidence] = []
+    with path.open(newline="", encoding="utf-8-sig", errors="replace") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames:
+            for row in reader:
+                for value in row.values():
+                    rows.extend(
+                        find_convention_names(
+                            clean(value),
+                            prefixes,
+                            str(path),
+                            suffix_mode=suffix_mode,
+                            suffix_width=suffix_width,
+                        )
+                    )
+        else:
+            handle.seek(0)
+            for raw in handle:
+                rows.extend(
+                    find_convention_names(
+                        raw,
+                        prefixes,
+                        str(path),
+                        suffix_mode=suffix_mode,
+                        suffix_width=suffix_width,
+                    )
+                )
+    return rows
+
+
+def load_evidence(
+    prefixes: list[str],
+    nmap_xml: list[Path],
+    used_names: list[Path],
+    *,
+    suffix_mode: str,
+    suffix_width: int,
+) -> list[NameEvidence]:
+    rows: list[NameEvidence] = []
+    for path in nmap_xml:
+        if not path.exists():
+            raise FileNotFoundError(f"nmap XML not found: {path}")
+        rows.extend(parse_nmap_xml(path, prefixes, suffix_mode=suffix_mode, suffix_width=suffix_width))
+    for path in used_names:
+        if not path.exists():
+            raise FileNotFoundError(f"used-name evidence not found: {path}")
+        if path.suffix.lower() == ".csv":
+            rows.extend(parse_csv(path, prefixes, suffix_mode=suffix_mode, suffix_width=suffix_width))
+        else:
+            rows.extend(parse_textish(path, prefixes, suffix_mode=suffix_mode, suffix_width=suffix_width))
+    return rows
+
+
+def first_missing(used_ordinals: set[int], start: int = 1) -> int:
+    value = start
+    while value in used_ordinals:
+        value += 1
+    return value
+
+
+def build_outputs(
+    *,
+    prefixes: list[str],
+    evidence: list[NameEvidence],
+    candidate_count: int,
+    max_gap_scan: int,
+    suffix_mode: str,
+    suffix_width: int,
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    def to_suffix(ordinal: int) -> str:
+        if suffix_mode == "numeric":
+            return ordinal_to_suffix_numeric(ordinal, suffix_width)
+        return ordinal_to_suffix_alphabetic(ordinal)
+
+    by_prefix: dict[str, dict[int, list[NameEvidence]]] = {prefix: defaultdict(list) for prefix in prefixes}
+    for row in evidence:
+        by_prefix[row.convention_prefix][row.ordinal].append(row)
+
+    summaries: list[dict[str, str]] = []
+    details: list[dict[str, str]] = []
+
+    for prefix in prefixes:
+        ordinal_map = by_prefix[prefix]
+        used = set(ordinal_map.keys())
+        highest = max(used) if used else 0
+        highest_suffix = to_suffix(highest) if highest else ""
+        highest_name = f"{prefix}{highest_suffix}" if highest else ""
+        first_gap = first_missing(used, 1)
+        first_gap_suffix = to_suffix(first_gap)
+        next_after_highest = highest + 1 if highest else 1
+        next_after_highest_suffix = to_suffix(next_after_highest)
+
+        gap_candidates: list[int] = []
+        scan_limit = max(highest, first_gap)
+        if max_gap_scan > 0:
+            scan_limit = min(scan_limit, max_gap_scan)
+        for value in range(1, scan_limit + 1):
+            if value not in used:
+                gap_candidates.append(value)
+            if len(gap_candidates) >= candidate_count:
+                break
+
+        next_candidates = list(range(next_after_highest, next_after_highest + candidate_count))
+        sources = sorted({item.evidence_source for items in ordinal_map.values() for item in items})
+
+        summaries.append(
+            {
+                "ConventionPrefix": prefix,
+                "SuffixMode": suffix_mode,
+                "SuffixWidth": str(suffix_width) if suffix_mode == "numeric" else "",
+                "UsedCount": str(len(used)),
+                "HighestUsedName": highest_name,
+                "HighestUsedSuffix": highest_suffix,
+                "HighestUsedOrdinal": str(highest) if highest else "",
+                "FirstGapName": f"{prefix}{first_gap_suffix}",
+                "FirstGapSuffix": first_gap_suffix,
+                "FirstGapOrdinal": str(first_gap),
+                "NextAfterHighestName": f"{prefix}{next_after_highest_suffix}",
+                "NextAfterHighestSuffix": next_after_highest_suffix,
+                "NextAfterHighestOrdinal": str(next_after_highest),
+                "GapCandidates": ";".join(f"{prefix}{to_suffix(value)}" for value in gap_candidates),
+                "NextCandidates": ";".join(f"{prefix}{to_suffix(value)}" for value in next_candidates),
+                "EvidenceSources": ";".join(sources),
+                "Notes": "FirstGap preserves continuity. NextAfterHighest avoids reuse when stale AD/DNS objects may exist.",
+            }
+        )
+
+        for ordinal in sorted(used):
+            suffix = to_suffix(ordinal)
+            for item in ordinal_map[ordinal]:
+                details.append(
+                    {
+                        "ConventionPrefix": prefix,
+                        "RecordType": "OCCUPIED",
+                        "Name": f"{prefix}{suffix}",
+                        "Suffix": suffix,
+                        "Ordinal": str(ordinal),
+                        "ObservedAs": item.observed_as,
+                        "EvidenceSource": item.evidence_source,
+                        "Notes": "Observed in supplied evidence",
+                    }
+                )
+
+        for ordinal in gap_candidates:
+            suffix = to_suffix(ordinal)
+            details.append(
+                {
+                    "ConventionPrefix": prefix,
+                    "RecordType": "AVAILABLE_GAP",
+                    "Name": f"{prefix}{suffix}",
+                    "Suffix": suffix,
+                    "Ordinal": str(ordinal),
+                    "ObservedAs": "",
+                    "EvidenceSource": "computed",
+                    "Notes": "Available within observed sequence gap",
+                }
+            )
+
+        for ordinal in next_candidates:
+            suffix = to_suffix(ordinal)
+            details.append(
+                {
+                    "ConventionPrefix": prefix,
+                    "RecordType": "AVAILABLE_AFTER_HIGHEST",
+                    "Name": f"{prefix}{suffix}",
+                    "Suffix": suffix,
+                    "Ordinal": str(ordinal),
+                    "ObservedAs": "",
+                    "EvidenceSource": "computed",
+                    "Notes": "Available after highest observed suffix",
+                }
+            )
+
+    return summaries, details
+
+
+def write_csv(path: Path, rows: list[dict[str, str]], fields: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def e(value: object) -> str:
+    return html.escape(str(value or ""))
+
+
+def render_dashboard(summary_rows: list[dict[str, str]], detail_rows: list[dict[str, str]], source_note: str) -> str:
+    cards = []
+    for row in summary_rows:
+        cards.append(
+            f"""
+<article class="card">
+  <h2>{e(row['ConventionPrefix'])}</h2>
+  <p><span>Mode</span><strong>{e(row.get('SuffixMode', ''))}</strong></p>
+  <p><span>Used</span><strong>{e(row['UsedCount'])}</strong></p>
+  <p><span>First gap</span><b class="good">{e(row['FirstGapName'])}</b></p>
+  <p><span>Next after highest</span><b class="info">{e(row['NextAfterHighestName'])}</b></p>
+  <p><span>Highest observed</span><b>{e(row['HighestUsedName'])}</b></p>
+</article>"""
+        )
+    head = "".join(f"<th>{e(col)}</th>" for col in DETAIL_FIELDS)
+    body = []
+    for row in detail_rows:
+        cls = row.get("RecordType", "").lower().replace("_", "-")
+        cells = "".join(f"<td>{e(row.get(col, ''))}</td>" for col in DETAIL_FIELDS)
+        body.append(f'<tr class="{cls}">{cells}</tr>')
+    return f"""<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SysAdminSuite Hostname Availability</title>
+<style>
+:root{{--bg:#020617;--panel:#0f172a;--text:#e5e7eb;--muted:#94a3b8;--green:#22c55e;--cyan:#22d3ee;}}
+*{{box-sizing:border-box}} body{{margin:0;background:linear-gradient(180deg,#020617,#111827);color:var(--text);font-family:Segoe UI,Arial,sans-serif}}
+header{{padding:28px 34px;border-bottom:1px solid rgba(96,165,250,.3)}} main{{padding:24px 34px 70px}}
+h1{{margin:0}} header p{{color:var(--muted)}} .cards{{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-bottom:18px}}
+.card,.panel,.notice{{border:1px solid rgba(96,165,250,.28);background:rgba(15,23,42,.88);border-radius:18px;padding:16px}}
+.card p{{display:flex;justify-content:space-between;color:var(--muted)}} .good{{color:#bbf7d0}} .info{{color:#cffafe}}
+.notice{{margin-bottom:18px;color:#dbeafe}} .filter{{width:100%;margin:0 0 12px;padding:10px;border-radius:12px;background:#020617;color:var(--text);border:1px solid rgba(96,165,250,.28)}}
+.table-wrap{{overflow:auto;max-height:650px}} table{{width:100%;min-width:1200px;border-collapse:collapse}} th,td{{padding:9px 10px;border-bottom:1px solid rgba(51,65,85,.75);font-size:13px}}
+</style>
+</head>
+<body>
+<header><h1>SysAdminSuite Hostname Availability</h1><p>{e(source_note)}</p></header>
+<main>
+<div class="notice">Local operational artifact. Validate against AD/DNS before assigning production hostnames.</div>
+<section class="cards">{''.join(cards)}</section>
+<section class="panel"><h2>Name Detail</h2><input class="filter" placeholder="Filter names or sources"><div class="table-wrap"><table><thead><tr>{head}</tr></thead><tbody>{''.join(body)}</tbody></table></div></section>
+</main>
+<script>const input=document.querySelector('.filter');const rows=document.querySelectorAll('tbody tr');input.addEventListener('input',()=>{{const n=input.value.toLowerCase();for(const r of rows)r.style.display=r.innerText.toLowerCase().includes(n)?'':'none';}});</script>
+</body>
+</html>"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze hostname naming availability from saved evidence.")
+    parser.add_argument("--convention", action="append", required=True, help="Naming prefix. Repeatable.")
+    parser.add_argument("--suffix-mode", choices=("alphabetic", "numeric"), default="numeric")
+    parser.add_argument("--width", type=int, default=3, help="Numeric suffix width. Default 3.")
+    parser.add_argument("--nmap-xml", action="append", default=[], help="Saved nmap XML. Repeatable.")
+    parser.add_argument("--used-names", action="append", default=[], help="Text or CSV evidence. Repeatable.")
+    parser.add_argument("--summary-output", default="survey/output/hostname_availability_summary.csv")
+    parser.add_argument("--detail-output", default="survey/output/hostname_availability_detail.csv")
+    parser.add_argument("--dashboard", default="", help="Optional HTML dashboard path")
+    parser.add_argument("--candidate-count", type=int, default=10)
+    parser.add_argument("--max-gap-scan", type=int, default=5000)
+    args = parser.parse_args()
+
+    prefixes = []
+    for value in args.convention:
+        prefix = normalize_prefix(value)
+        if prefix not in prefixes:
+            prefixes.append(prefix)
+
+    if args.candidate_count < 1:
+        print("ERROR: --candidate-count must be >= 1", file=sys.stderr)
+        return 2
+    if args.suffix_mode == "numeric" and (args.width < 1 or args.width > 6):
+        print("ERROR: --width must be between 1 and 6 for numeric mode", file=sys.stderr)
+        return 2
+    if not args.nmap_xml and not args.used_names:
+        print("ERROR: supply at least one --nmap-xml or --used-names evidence file", file=sys.stderr)
+        return 2
+
+    evidence = load_evidence(
+        prefixes,
+        [Path(p) for p in args.nmap_xml],
+        [Path(p) for p in args.used_names],
+        suffix_mode=args.suffix_mode,
+        suffix_width=args.width,
+    )
+    summaries, details = build_outputs(
+        prefixes=prefixes,
+        evidence=evidence,
+        candidate_count=args.candidate_count,
+        max_gap_scan=args.max_gap_scan,
+        suffix_mode=args.suffix_mode,
+        suffix_width=args.width,
+    )
+
+    summary_path = Path(args.summary_output)
+    detail_path = Path(args.detail_output)
+    write_csv(summary_path, summaries, SUMMARY_FIELDS)
+    write_csv(detail_path, details, DETAIL_FIELDS)
+    print(f"Wrote naming summary: {summary_path}")
+    print(f"Wrote naming detail: {detail_path}")
+
+    if args.dashboard:
+        dashboard_path = Path(args.dashboard)
+        dashboard_path.parent.mkdir(parents=True, exist_ok=True)
+        source_note = "Evidence: " + "; ".join(args.nmap_xml + args.used_names)
+        dashboard_path.write_text(render_dashboard(summaries, details, source_note), encoding="utf-8")
+        print(f"Wrote naming dashboard: {dashboard_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/survey/sas-survey-hostname-availability.sh
+++ b/survey/sas-survey-hostname-availability.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONVENTIONS=()
+USED_NAMES=()
+OUTPUT_DIR="survey/output/hostname-availability"
+ARTIFACT_DIR="survey/artifacts/hostname-availability"
+RUN_ID="$(date '+%Y%m%d_%H%M%S')"
+CANDIDATE_COUNT=10
+MAX_GAP_SCAN=5000
+SUFFIX_MODE="numeric"
+SUFFIX_WIDTH=3
+AD_EXPORT=0
+AD_SERVER=""
+TRACKER_WORKBOOK=""
+TICKET_WORKBOOK=""
+DNS_CHECK=0
+PASS_THRU=0
+
+usage(){ cat <<'USAGE'
+SysAdminSuite Hostname Availability Survey
+
+Usage:
+  bash survey/sas-survey-hostname-availability.sh \
+    --convention WNH270OPR \
+    --suffix-mode numeric --width 3 \
+    --ad-export \
+    --tracker-workbook /path/to/tracker.xlsx \
+    --dns-check
+
+Usage, saved evidence only:
+  bash survey/sas-survey-hostname-availability.sh \
+    --convention WNH270OPR \
+    --used-names survey/fixtures/hostname_availability_sample.txt \
+    --suffix-mode numeric --width 3
+
+Options:
+  --convention PREFIX         Naming prefix (e.g. WNH270OPR). Repeatable.
+  --suffix-mode MODE          alphabetic or numeric. Default: numeric
+  --width N                   Numeric suffix width. Default: 3
+  --used-names PATH           Saved evidence CSV/text/XML. Repeatable.
+  --ad-export                 Export AD computers matching each convention prefix (read-only).
+  --ad-server FQDN            Optional domain controller for AD export.
+  --tracker-workbook PATH     Deployment tracker .xlsx for hostname columns.
+  --ticket-workbook PATH      Ticket tracker .xlsx (Hostname Used column).
+  --dns-check                 Forward DNS lookup on occupied names and reported candidates.
+  --output-dir PATH           Output folder. Default: survey/output/hostname-availability
+  --artifact-dir PATH         Evidence artifacts. Default: survey/artifacts/hostname-availability
+  --run-id VALUE              Run identifier for output filenames.
+  --candidate-count N         Candidates per convention. Default: 10.
+  --max-gap-scan N            Max ordinal for gap scan. Default: 5000.
+  --pass-thru                 Print summary CSV after writing.
+  -h, --help                  Show help.
+
+Safety:
+  Read-only. Does not rename devices or modify AD/DNS/tracker data.
+  Generated outputs may contain operational hostnames. Do not commit them.
+USAGE
+}
+
+fail(){ echo "[hostname-survey] ERROR: $*" >&2; exit 1; }
+log(){ echo "[hostname-survey] $*" >&2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --convention) CONVENTIONS+=("${2:?}"); shift 2 ;;
+    --used-names) USED_NAMES+=("${2:?}"); shift 2 ;;
+    --suffix-mode) SUFFIX_MODE="${2:?}"; shift 2 ;;
+    --width) SUFFIX_WIDTH="${2:?}"; shift 2 ;;
+    --ad-export) AD_EXPORT=1; shift ;;
+    --ad-server) AD_SERVER="${2:?}"; shift 2 ;;
+    --tracker-workbook) TRACKER_WORKBOOK="${2:?}"; shift 2 ;;
+    --ticket-workbook) TICKET_WORKBOOK="${2:?}"; shift 2 ;;
+    --dns-check) DNS_CHECK=1; shift ;;
+    --output-dir) OUTPUT_DIR="${2:?}"; shift 2 ;;
+    --artifact-dir) ARTIFACT_DIR="${2:?}"; shift 2 ;;
+    --run-id) RUN_ID="${2:?}"; shift 2 ;;
+    --candidate-count) CANDIDATE_COUNT="${2:?}"; shift 2 ;;
+    --max-gap-scan) MAX_GAP_SCAN="${2:?}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ "${#CONVENTIONS[@]}" -gt 0 ]] || fail "At least one --convention is required"
+[[ "$SUFFIX_MODE" == "alphabetic" || "$SUFFIX_MODE" == "numeric" ]] || fail "--suffix-mode must be alphabetic or numeric"
+[[ "$CANDIDATE_COUNT" =~ ^[0-9]+$ && "$CANDIDATE_COUNT" -ge 1 ]] || fail "--candidate-count must be >= 1"
+[[ "$MAX_GAP_SCAN" =~ ^[0-9]+$ ]] || fail "--max-gap-scan must be numeric"
+[[ "$SUFFIX_WIDTH" =~ ^[0-9]+$ && "$SUFFIX_WIDTH" -ge 1 ]] || fail "--width must be >= 1"
+
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+ANALYZER="survey/sas-hostname-availability.py"
+[[ -f "$ANALYZER" ]] || fail "Analyzer not found: $ANALYZER"
+
+mkdir -p "$OUTPUT_DIR" "$ARTIFACT_DIR"
+
+if [[ "$AD_EXPORT" -eq 1 ]]; then
+  AD_SCRIPT="survey/sas-ad-computer-prefix-export.ps1"
+  [[ -f "$AD_SCRIPT" ]] || fail "AD export script not found: $AD_SCRIPT"
+  idx=1
+  for convention in "${CONVENTIONS[@]}"; do
+    prefix="$(echo "$convention" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')"
+    ad_out="$ARTIFACT_DIR/${RUN_ID}_ad_${idx}_${prefix}.csv"
+    log "Exporting AD prefix evidence: $prefix"
+    if [[ -n "$AD_SERVER" ]]; then
+      powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$AD_SCRIPT" -Prefix "$prefix" -Output "$ad_out" -Server "$AD_SERVER"
+    else
+      powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$AD_SCRIPT" -Prefix "$prefix" -Output "$ad_out"
+    fi
+    USED_NAMES+=("$ad_out")
+    idx=$((idx + 1))
+  done
+fi
+
+if [[ -n "$TRACKER_WORKBOOK" || -n "$TICKET_WORKBOOK" ]]; then
+  tracker_out="$ARTIFACT_DIR/${RUN_ID}_tracker_hostnames.csv"
+  EXTRACT_ARGS=(--output "$tracker_out")
+  [[ -n "$TRACKER_WORKBOOK" ]] && EXTRACT_ARGS+=(--workbook "$TRACKER_WORKBOOK")
+  [[ -n "$TICKET_WORKBOOK" ]] && EXTRACT_ARGS+=(--ticket-workbook "$TICKET_WORKBOOK")
+  log "Extracting tracker hostname evidence"
+  bash survey/sas-extract-tracker-hostnames.sh "${EXTRACT_ARGS[@]}"
+  USED_NAMES+=("$tracker_out")
+fi
+
+run_analyzer(){
+  local summary="$1" detail="$2" dashboard="$3"
+  local -a args=()
+  for convention in "${CONVENTIONS[@]}"; do args+=(--convention "$convention"); done
+  for evidence in "${USED_NAMES[@]}"; do args+=(--used-names "$evidence"); done
+  args+=(
+    --suffix-mode "$SUFFIX_MODE"
+    --width "$SUFFIX_WIDTH"
+    --summary-output "$summary"
+    --detail-output "$detail"
+    --dashboard "$dashboard"
+    --candidate-count "$CANDIDATE_COUNT"
+    --max-gap-scan "$MAX_GAP_SCAN"
+  )
+  python3 "$ANALYZER" "${args[@]}"
+}
+
+SUMMARY_OUT="$OUTPUT_DIR/${RUN_ID}_hostname_availability_summary.csv"
+DETAIL_OUT="$OUTPUT_DIR/${RUN_ID}_hostname_availability_detail.csv"
+DASHBOARD_OUT="$OUTPUT_DIR/${RUN_ID}_hostname_availability.html"
+
+if [[ "${#USED_NAMES[@]}" -eq 0 ]]; then
+  fail "Supply --used-names, --ad-export, and/or --tracker-workbook evidence"
+fi
+
+run_analyzer "$SUMMARY_OUT" "$DETAIL_OUT" "$DASHBOARD_OUT"
+
+if [[ "$DNS_CHECK" -eq 1 ]]; then
+  DNS_LIST="$ARTIFACT_DIR/${RUN_ID}_dns_check_hostnames.txt"
+  python3 - "$DETAIL_OUT" "$SUMMARY_OUT" "$DNS_LIST" <<'PY'
+import csv, sys
+detail, summary, out = sys.argv[1:4]
+names = set()
+with open(detail, newline="", encoding="utf-8") as handle:
+    for row in csv.DictReader(handle):
+        name = (row.get("Name") or "").strip().upper()
+        if name:
+            names.add(name)
+with open(summary, newline="", encoding="utf-8") as handle:
+    for row in csv.DictReader(handle):
+        for field in ("FirstGapName", "NextAfterHighestName", "GapCandidates", "NextCandidates"):
+            for part in (row.get(field) or "").split(";"):
+                part = part.strip().upper()
+                if part:
+                    names.add(part)
+with open(out, "w", encoding="utf-8") as handle:
+    for name in sorted(names):
+        handle.write(name + "\n")
+PY
+  if [[ -s "$DNS_LIST" ]]; then
+    dns_out="$ARTIFACT_DIR/${RUN_ID}_dns_evidence.csv"
+    log "Running forward DNS checks"
+    bash survey/sas-dns-hostname-evidence.sh --hostnames-file "$DNS_LIST" --output "$dns_out"
+    USED_NAMES+=("$dns_out")
+    run_analyzer "$SUMMARY_OUT" "$DETAIL_OUT" "$DASHBOARD_OUT"
+  fi
+fi
+
+log "Summary CSV: $SUMMARY_OUT"
+log "Detail CSV: $DETAIL_OUT"
+log "Dashboard HTML: $DASHBOARD_OUT"
+[[ "$PASS_THRU" -eq 1 ]] && cat "$SUMMARY_OUT" || true


### PR DESCRIPTION
## **User description**
## Summary
- Adds Bash-first hostname availability for numeric conventions (e.g. WNH270OPR###) with gap and next-after-highest recommendations.
- Read-only AD prefix export, deployment/ticket tracker hostname extraction, and optional DNS cross-check.
- Sibling to existing Neuron alphabetic tooling; contract test and docs included.

## Related issues
- Extends AD evidence work tracked in #17
- Branched from current main per #13 convergence guidance

## Test plan
- [x] `bash deployment-audit/tests/test_hostname_availability_contracts.sh`
- [ ] Lab: `bash survey/sas-survey-hostname-availability.sh --convention WNH270OPR --ad-export` with RSAT/AD module
- [ ] Lab: union tracker workbooks and confirm FirstGap vs NextAfterHighest choices

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Check hostname availability from saved AD, tracker, and DNS evidence**

### What Changed
- Adds a read-only hostname survey for numeric prefixes like `WNH270OPR001`, including the lowest missing name and the next name after the highest one found.
- Can gather evidence from Active Directory, deployment/ticket tracker workbooks, and forward DNS lookups, then merge them into one report.
- Produces a summary CSV, detailed name list, and HTML dashboard so teams can review occupied and available names before assigning them.
- Includes a sample fixture, contract test, and command/docs entry for the new workflow.

### Impact
`✅ Faster hostname selection`
`✅ Fewer naming conflicts from stale records`
`✅ Clearer evidence for AD, tracker, and DNS checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
