### PR TITLE
feat(host): add PS-independent dashboard tray host

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -31,3 +31,13 @@ jobs:
       - name: Restore and test
         run: dotnet test SysAdminSuite.sln -c Release --verbosity normal
 
+      - name: Publish DashboardHost (framework-dependent)
+        run: dotnet publish src/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.csproj -c Release -r win-x64 --self-contained false -o tools/publish/SysAdminSuite.DashboardHost
+
+      - name: Verify DashboardHost publish artifact
+        shell: pwsh
+        run: |
+          $exe = 'tools/publish/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.exe'
+          if (-not (Test-Path -LiteralPath $exe)) { throw "Missing publish artifact: $exe" }
+          Write-Host "DashboardHost publish artifact OK: $exe"
+

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,12 @@ dist/
 bin/*
 !bin/.gitkeep
 
+# .NET build output (managed projects under src/ and managed-tests/)
+**/bin/
+**/obj/
+# Published host output staging (see docs/GUI_HOST_MIGRATION.md)
+tools/publish/
+
 # Local reference tree (install scripts, shortcuts, installers — not product code; never commit)
 tech emulation/
 Alex Emulation/

--- a/Launch-SysAdminSuite-Runtime.bat
+++ b/Launch-SysAdminSuite-Runtime.bat
@@ -7,15 +7,17 @@ set "APP_ROOT=%ROOT%app"
 
 echo SysAdminSuite - Runtime Launcher
 echo.
-echo  [1] Launch GUI
-echo  [2] Launch Web Dashboard
+echo  [1] Launch GUI (PowerShell WinForms)
+echo  [2] Launch Web Dashboard (PowerShell + Python)
+echo  [3] Launch Web Dashboard (no PowerShell, tray host)
 echo.
-set /p CHOICE="Select an option (1 or 2): "
+set /p CHOICE="Select an option (1, 2, or 3): "
 
 if "%CHOICE%"=="1" goto :launch_gui
 if "%CHOICE%"=="2" goto :launch_dashboard
+if "%CHOICE%"=="3" goto :launch_dashboard_host
 
-echo Invalid selection. Please enter 1 or 2.
+echo Invalid selection. Please enter 1, 2, or 3.
 exit /b 1
 
 :launch_gui
@@ -44,4 +46,24 @@ if exist "%ROOT%Launch-SysAdminSuiteDashboard.ps1" (
 )
 
 echo Unable to locate Launch-SysAdminSuiteDashboard.ps1 in app\ or repo root.
+exit /b 1
+
+:launch_dashboard_host
+rem PS-independent dashboard host (.NET 8 tray + Kestrel; see docs/GUI_HOST_MIGRATION.md)
+if exist "%APP_ROOT%\bin\SysAdminSuite.DashboardHost.exe" (
+    start "" /B "%APP_ROOT%\bin\SysAdminSuite.DashboardHost.exe"
+    exit /b 0
+)
+
+if exist "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" (
+    start "" /B "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe"
+    exit /b 0
+)
+
+if exist "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" (
+    call "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat"
+    exit /b %ERRORLEVEL%
+)
+
+echo Unable to locate SysAdminSuite.DashboardHost.exe or Launch-SysAdminSuiteDashboard.Host.bat.
 exit /b 1

--- a/Launch-SysAdminSuiteDashboard.Host.bat
+++ b/Launch-SysAdminSuiteDashboard.Host.bat
@@ -1,0 +1,38 @@
+@echo off
+:: Launch-SysAdminSuiteDashboard.Host.bat
+:: PS-independent launcher for the SysAdminSuite web dashboard.
+:: Spawns SysAdminSuite.DashboardHost.exe which serves dashboard/ over
+:: http://127.0.0.1:5000 and shows a tray icon (Open, Copy URL, Stop).
+:: No powershell.exe and no Python required.
+
+setlocal
+set "ROOT=%~dp0"
+
+:: 1) Portable layout (zip): app\bin\SysAdminSuite.DashboardHost.exe
+if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
+    start "" /B "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" %*
+    exit /b 0
+)
+
+:: 2) Documented publish output (run dotnet publish to populate)
+if exist "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" (
+    start "" /B "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" %*
+    exit /b 0
+)
+
+:: 3) Dev tree fallback (Release build)
+if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" (
+    start "" /B "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" %*
+    exit /b 0
+)
+
+:: 4) Dev tree fallback (Debug build)
+if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" (
+    start "" /B "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" %*
+    exit /b 0
+)
+
+echo Unable to locate SysAdminSuite.DashboardHost.exe.
+echo Build with:
+echo     dotnet publish src\SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false -o tools\publish\SysAdminSuite.DashboardHost
+exit /b 1

--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ powershell.exe -STA -File .\GUI\Start-SysAdminSuiteGui.ps1
 
 > **Why `-STA`?** WinForms requires Single Threaded Apartment mode. Without it the window won't render.
 
+### Launch the Web Dashboard (no PowerShell)
+
+For endpoints where `powershell.exe` is blocked or constrained, the dashboard ships
+as a standalone .NET 8 tray host. Double-click:
+
+```
+Launch-SysAdminSuiteDashboard.Host.bat
+```
+
+Or pick `[3]` in `Launch-SysAdminSuite-Runtime.bat`. The host serves
+`http://127.0.0.1:5000/dashboard/` and shows a NotifyIcon with Open / Copy URL /
+Stop. The original PowerShell + Python dashboard launcher
+(`Launch-SysAdminSuiteDashboard.bat`) is preserved for permissive sites. See
+[`docs/GUI_HOST_MIGRATION.md`](docs/GUI_HOST_MIGRATION.md) for the lane diagram,
+launcher matrix, and host CLI flags.
+
 On first launch a **menu-based tutorial** appears with 12 use-case tracks. Pick the one you need and follow 3-5 focused steps that end with real example output. Reopen anytime with **Ctrl+T** or the **Tutorial** button in the status bar.
 
 **Tutorial tracks:**

--- a/SysAdminSuite.sln
+++ b/SysAdminSuite.sln
@@ -1,10 +1,18 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SysAdminSuite.Core", "src\SysAdminSuite.Core\SysAdminSuite.Core.csproj", "{15C6C6E6-326B-4BA5-8286-8E83E0EE4702}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SysAdminSuite.Core.Tests", "managed-tests\SysAdminSuite.Core.Tests\SysAdminSuite.Core.Tests.csproj", "{025F89A7-EB8F-4435-BEF9-534D7FD0C426}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6F430D75-1347-49AC-B1B2-FA44BE199517}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SysAdminSuite.DashboardHost", "src\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.csproj", "{B04D6CB9-F980-46CC-A24C-7BBD464D0FAF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "managed-tests", "managed-tests", "{E5BFCAB1-F7F0-419C-AA8B-078F2CBD8F14}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SysAdminSuite.DashboardHost.Tests", "managed-tests\SysAdminSuite.DashboardHost.Tests\SysAdminSuite.DashboardHost.Tests.csproj", "{FFBDAE1C-6CCD-4CB2-ADC0-A94965D99210}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,6 +28,17 @@ Global
 		{025F89A7-EB8F-4435-BEF9-534D7FD0C426}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{025F89A7-EB8F-4435-BEF9-534D7FD0C426}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{025F89A7-EB8F-4435-BEF9-534D7FD0C426}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B04D6CB9-F980-46CC-A24C-7BBD464D0FAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B04D6CB9-F980-46CC-A24C-7BBD464D0FAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B04D6CB9-F980-46CC-A24C-7BBD464D0FAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B04D6CB9-F980-46CC-A24C-7BBD464D0FAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFBDAE1C-6CCD-4CB2-ADC0-A94965D99210}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFBDAE1C-6CCD-4CB2-ADC0-A94965D99210}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFBDAE1C-6CCD-4CB2-ADC0-A94965D99210}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFBDAE1C-6CCD-4CB2-ADC0-A94965D99210}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B04D6CB9-F980-46CC-A24C-7BBD464D0FAF} = {6F430D75-1347-49AC-B1B2-FA44BE199517}
+		{FFBDAE1C-6CCD-4CB2-ADC0-A94965D99210} = {E5BFCAB1-F7F0-419C-AA8B-078F2CBD8F14}
 	EndGlobalSection
 EndGlobal
-

--- a/docs/DEPLOYMENT_ARTIFACTS.md
+++ b/docs/DEPLOYMENT_ARTIFACTS.md
@@ -8,6 +8,8 @@ Ship SysAdminSuite to restricted runtime endpoints as versioned artifacts, not a
 - Version source: explicit script parameter (`-Version`).
 - Artifact root layout:
   - `app/` - runtime scripts and launchers
+    - `app/dashboard/` - vanilla web dashboard assets (Log Mode + Live Mode)
+    - `app/bin/` - published `SysAdminSuite.DashboardHost.exe` and its runtime dependencies (PS-independent dashboard host)
   - `data/` - endpoint-local mutable data
   - `logs/` - runtime logs
   - `manifest/` - update manifest snapshot bundled with release
@@ -15,11 +17,14 @@ Ship SysAdminSuite to restricted runtime endpoints as versioned artifacts, not a
 
 ## Build Path (Trusted Build Machine)
 1. Build from repository checkout.
-2. Execute:
+2. (Optional, recommended) Publish the PS-independent dashboard host so the portable zip includes `app/bin/SysAdminSuite.DashboardHost.exe`:
+   - `dotnet publish src/SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false -o tools/publish/SysAdminSuite.DashboardHost`
+   - See [GUI_HOST_MIGRATION.md](GUI_HOST_MIGRATION.md) for context.
+3. Execute:
    - `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\build\New-PortableArtifact.ps1 -Version 0.1.0`
-3. The build writes **`dist/SysAdminSuite-Portable-v{Version}.zip`** and a matching **`dist/SysAdminSuite-Portable-v{Version}.manifest.json`** with a real SHA256 and UTC timestamp (and `gitCommit` when built inside a git repo).
-4. Publish **both** the zip and the manifest to your approved distribution location. See [releases/PUBLISH.md](releases/PUBLISH.md).
-5. Optional offline verification:
+4. The build writes **`dist/SysAdminSuite-Portable-v{Version}.zip`** and a matching **`dist/SysAdminSuite-Portable-v{Version}.manifest.json`** with a real SHA256 and UTC timestamp (and `gitCommit` when built inside a git repo).
+5. Publish **both** the zip and the manifest to your approved distribution location. See [releases/PUBLISH.md](releases/PUBLISH.md).
+6. Optional offline verification:
    - `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\Test-PortableArtifactSmoke.ps1 -ZipPath .\dist\SysAdminSuite-Portable-v0.1.0.zip -ManifestPath .\dist\SysAdminSuite-Portable-v0.1.0.manifest.json` (adjust version paths; see [releases/PUBLISH.md](releases/PUBLISH.md)).
 
 ## Runtime Layout (Restricted Endpoint)

--- a/docs/GUI_HOST_MIGRATION.md
+++ b/docs/GUI_HOST_MIGRATION.md
@@ -1,0 +1,123 @@
+# GUI Host Migration
+
+Status: slice 1 landed — PS-independent dashboard host. Earlier WinForms control center
+(`GUI/Start-SysAdminSuiteGui.ps1`) is preserved per
+[`docs/POWERSHELL_LEGACY_POLICY.md`](POWERSHELL_LEGACY_POLICY.md) and remains the only
+path for printer mapping run control, Kronos lookup, Machine Info, Compare/Deploy, and
+UTF-8 BOM Sync. Slice 1 only replaces the dashboard launcher.
+
+## Lane diagram
+
+```
++---------------------------+    +------------------------------+    +------------------+
+| Launch-SysAdminSuite-     |    | Launch-SysAdminSuiteDashboard|    | Launch-          |
+| Runtime.bat               |    | .Host.bat                    |    | SysAdminSuiteDash|
+| [1] PS GUI (WinForms)     |    | (no PowerShell, no Python)   |    | board.bat        |
+| [2] PS dashboard launcher |--> | SysAdminSuite.DashboardHost  |    | (PS + Python)    |
+| [3] .NET dashboard host   |    |  .exe  (.NET 8 tray)         |    | server.py        |
++---------------------------+    +--------------+---------------+    +--------+---------+
+                                                |                             |
+                                                v                             v
+                                          http://127.0.0.1:5000/dashboard/  (vanilla HTML/JS)
+```
+
+## Launcher matrix
+
+| Launcher | Requires PowerShell | Requires Python | Process model | Notes |
+|----------|---------------------|-----------------|---------------|-------|
+| `Launch-SysAdminSuite.bat` | yes (PS 5.1+) | no | WinForms GUI (`Start-SysAdminSuiteGui.ps1`) | Full control center (printer mapping, Kronos, Machine Info, BOM, tutorial). |
+| `Launch-SysAdminSuiteDashboard.bat` | yes | yes | PS WinForms tray + `server.py` | Original Harold-splash launcher; preserved for permissive sites. |
+| `Launch-SysAdminSuiteDashboard.Host.bat` | **no** | **no** | `SysAdminSuite.DashboardHost.exe` (.NET 8 tray + Kestrel) | Slice 1 deliverable. |
+| `Launch-SysAdminSuite-Runtime.bat` `[3]` | no | no | Same as host `.bat` | Portable-zip entry point. |
+
+## When to use the host
+
+Use `Launch-SysAdminSuiteDashboard.Host.bat` (or Runtime `[3]`) when:
+
+- `powershell.exe` is blocked, AppLocker-restricted, or governed by Constrained Language Mode.
+- Python is not available on the endpoint.
+- An operator only needs the dashboard surface (Log Mode + Live Mode command generation),
+  not the full WinForms control center.
+
+Use `Launch-SysAdminSuite.bat` when any of these are needed: printer mapping Run Control,
+Kronos / Machine Info / Compare / Deploy vs AD probes, UTF-8 BOM Sync, or the guided tour.
+
+## Host command-line options
+
+```
+SysAdminSuite.DashboardHost.exe [--port <int>] [--bind <ip>] [--dashboard-root <path>]
+                                [--no-browser] [--no-tray]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | `5000` | TCP port for Kestrel to bind. |
+| `--bind` | `127.0.0.1` | Interface address. Keep `127.0.0.1` unless the dashboard must be reachable from other hosts. |
+| `--dashboard-root` | auto-resolved | Override the `dashboard/` directory location (useful for tests and split installs). |
+| `--no-browser` | off | Do not auto-launch the default browser. |
+| `--no-tray` | off | Run as a console process without a NotifyIcon (CI / smoke). |
+
+## Build and publish
+
+Local dev:
+
+```
+dotnet build SysAdminSuite.sln -c Release
+dotnet test SysAdminSuite.sln -c Release
+```
+
+Publish for portable packaging (framework-dependent, requires .NET 8 runtime on the target):
+
+```
+dotnet publish src/SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false ^
+  -o tools/publish/SysAdminSuite.DashboardHost
+```
+
+The publish output is what `tools/build/New-PortableArtifact.ps1` copies into
+`app/bin/` in the portable zip, and what the host `.bat` looks for first.
+
+## Behavior parity with `server.py`
+
+`DashboardStaticServer` mirrors `server.py do_GET` (lines 562-598):
+
+- `GET /dashboard` -> 301 redirect to `/dashboard/`.
+- `GET /dashboard/` -> serves `dashboard/index.html`.
+- `GET /dashboard/<path>` -> serves the file if it resolves inside `dashboard/`,
+  otherwise 403 (path traversal) / 404 (missing).
+- MIME table matches `server.py MIME_TYPES`; everything else falls back to
+  `application/octet-stream`.
+- `GET /` -> 302 redirect to `/dashboard/`. The host does **not** port the large
+  embedded overview HTML from `server.py` (deferred to a later slice).
+
+## Follow-up slices (separate branches)
+
+1. `feature/runtime-menu-host-default` - make Runtime menu prefer host path by default.
+2. `feature/gui-run-control-host` - C# Run Control panel calling native mapping EXEs.
+3. `feature/gui-probe-launcher` - C# Machine Info / survey probe runner.
+4. Installer / Authenticode signing - sign `SysAdminSuite.DashboardHost.exe` like
+   the native mapping binaries under `mapping/native/`.
+
+## Field smoke (operator)
+
+From a portable zip:
+
+```
+Launch-SysAdminSuite-Runtime.bat   (choose [3])
+```
+
+Or directly:
+
+```
+Launch-SysAdminSuiteDashboard.Host.bat
+```
+
+Expected:
+
+- Tray icon appears.
+- Default browser opens `http://127.0.0.1:5000/dashboard/`.
+- Right-click tray -> Open Dashboard / Copy URL / Stop Dashboard.
+- Stop returns the port immediately.
+
+Restricted-endpoint classification on success: `OK_LOCAL_SMOKE` per
+[`docs/WAB_TEST_READINESS.md`](WAB_TEST_READINESS.md). Network-feature claims still
+require the preflight gate per [`docs/TEST_RESULT_CLASSIFICATION.md`](TEST_RESULT_CLASSIFICATION.md).

--- a/docs/WAB_TEST_READINESS.md
+++ b/docs/WAB_TEST_READINESS.md
@@ -63,6 +63,18 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\QRTasks\Invoke-TechTas
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\QRTasks\Invoke-TechTask.ps1 -Task NetworkInfo
 ```
 
+PS-independent dashboard host (no `powershell.exe`, no Python; see [GUI_HOST_MIGRATION.md](GUI_HOST_MIGRATION.md)):
+
+```bat
+:: Direct
+Launch-SysAdminSuiteDashboard.Host.bat
+
+:: Via runtime menu option [3]
+Launch-SysAdminSuite-Runtime.bat
+```
+
+Expected smoke result: tray icon appears, browser opens `http://127.0.0.1:5000/dashboard/`, Stop from tray frees the port. Classify success as `OK_LOCAL_SMOKE`.
+
 Evidence to save:
 
 - Screenshot showing the GUI opened.

--- a/managed-tests/SysAdminSuite.DashboardHost.Tests/DashboardStaticServerTests.cs
+++ b/managed-tests/SysAdminSuite.DashboardHost.Tests/DashboardStaticServerTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using SysAdminSuite.DashboardHost;
+using Xunit;
+
+namespace SysAdminSuite.DashboardHost.Tests;
+
+public sealed class DashboardStaticServerTests : IDisposable
+{
+    private readonly string _root;
+
+    public DashboardStaticServerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "sas-dashhost-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(Path.Combine(_root, "index.html"), "<html></html>");
+        var jsDir = Path.Combine(_root, "js");
+        Directory.CreateDirectory(jsDir);
+        File.WriteAllText(Path.Combine(jsDir, "app.js"), "console.log('ok');");
+        File.WriteAllText(Path.Combine(_root, "style.css"), "body{}");
+        File.WriteAllText(Path.Combine(_root, "sample.json"), "{}");
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Resolve_BareDashboard_RedirectsToSlash()
+    {
+        var result = DashboardStaticServer.Resolve("/dashboard", _root);
+        Assert.Equal(DashboardStaticServer.ResultKind.Redirect, result.Kind);
+        Assert.Equal("/dashboard/", result.RedirectLocation);
+    }
+
+    [Fact]
+    public void Resolve_DashboardSlash_ReturnsIndexHtml()
+    {
+        var result = DashboardStaticServer.Resolve("/dashboard/", _root);
+        Assert.Equal(DashboardStaticServer.ResultKind.File, result.Kind);
+        Assert.Equal(Path.Combine(_root, "index.html"), result.FilePath);
+        Assert.Equal("text/html; charset=utf-8", result.MimeType);
+    }
+
+    [Fact]
+    public void Resolve_KnownJs_ReturnsJavascriptMime()
+    {
+        var result = DashboardStaticServer.Resolve("/dashboard/js/app.js", _root);
+        Assert.Equal(DashboardStaticServer.ResultKind.File, result.Kind);
+        Assert.Equal("application/javascript; charset=utf-8", result.MimeType);
+    }
+
+    [Theory]
+    [InlineData("/dashboard/style.css", "text/css; charset=utf-8")]
+    [InlineData("/dashboard/sample.json", "application/json; charset=utf-8")]
+    public void Resolve_KnownMimeTypes_AreApplied(string url, string expectedMime)
+    {
+        var result = DashboardStaticServer.Resolve(url, _root);
+        Assert.Equal(DashboardStaticServer.ResultKind.File, result.Kind);
+        Assert.Equal(expectedMime, result.MimeType);
+    }
+
+    [Fact]
+    public void Resolve_TraversalAttempt_IsForbidden()
+    {
+        var result = DashboardStaticServer.Resolve("/dashboard/../secret.txt", _root);
+        Assert.True(
+            result.Kind == DashboardStaticServer.ResultKind.Forbidden ||
+            result.Kind == DashboardStaticServer.ResultKind.NotFound,
+            $"Expected Forbidden or NotFound, got {result.Kind}");
+        Assert.NotEqual(DashboardStaticServer.ResultKind.File, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_AbsoluteWindowsPath_IsForbidden()
+    {
+        var result = DashboardStaticServer.Resolve("/dashboard/C:/Windows/win.ini", _root);
+        Assert.NotEqual(DashboardStaticServer.ResultKind.File, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_MissingFile_Returns404()
+    {
+        var result = DashboardStaticServer.Resolve("/dashboard/no-such-file.html", _root);
+        Assert.Equal(DashboardStaticServer.ResultKind.NotFound, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_UnknownPrefix_IsPassThrough()
+    {
+        var result = DashboardStaticServer.Resolve("/api/foo", _root);
+        Assert.Equal(DashboardStaticServer.ResultKind.PassThrough, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_EmptyPath_IsBadRequest()
+    {
+        var result = DashboardStaticServer.Resolve("", _root);
+        Assert.Equal(DashboardStaticServer.ResultKind.BadRequest, result.Kind);
+    }
+
+    [Fact]
+    public void GetMimeType_UnknownExtension_FallsBackToOctetStream()
+    {
+        Assert.Equal(DashboardStaticServer.DefaultMime, DashboardStaticServer.GetMimeType(".xyz"));
+    }
+}

--- a/managed-tests/SysAdminSuite.DashboardHost.Tests/HostOptionsTests.cs
+++ b/managed-tests/SysAdminSuite.DashboardHost.Tests/HostOptionsTests.cs
@@ -1,0 +1,57 @@
+using SysAdminSuite.DashboardHost;
+using Xunit;
+
+namespace SysAdminSuite.DashboardHost.Tests;
+
+public sealed class HostOptionsTests
+{
+    [Fact]
+    public void Parse_NoArgs_UsesDefaults()
+    {
+        var options = HostOptions.Parse(System.Array.Empty<string>());
+        Assert.Equal(HostOptions.DefaultPort, options.Port);
+        Assert.Equal(HostOptions.DefaultBindAddress, options.BindAddress);
+        Assert.True(options.OpenBrowser);
+        Assert.True(options.ShowTray);
+        Assert.Null(options.DashboardRootOverride);
+        Assert.Equal("http://127.0.0.1:5000/dashboard/", options.Url);
+    }
+
+    [Fact]
+    public void Parse_Port_Overrides()
+    {
+        var options = HostOptions.Parse(new[] { "--port", "5050" });
+        Assert.Equal(5050, options.Port);
+        Assert.Equal("http://127.0.0.1:5050/dashboard/", options.Url);
+    }
+
+    [Fact]
+    public void Parse_InvalidPort_KeepsDefault()
+    {
+        var options = HostOptions.Parse(new[] { "--port", "not-a-number" });
+        Assert.Equal(HostOptions.DefaultPort, options.Port);
+    }
+
+    [Fact]
+    public void Parse_NoBrowserAndNoTray_FlagsAreRespected()
+    {
+        var options = HostOptions.Parse(new[] { "--no-browser", "--no-tray" });
+        Assert.False(options.OpenBrowser);
+        Assert.False(options.ShowTray);
+    }
+
+    [Fact]
+    public void Parse_DashboardRootOverride_IsCaptured()
+    {
+        var options = HostOptions.Parse(new[] { "--dashboard-root", @"C:\custom\dashboard" });
+        Assert.Equal(@"C:\custom\dashboard", options.DashboardRootOverride);
+    }
+
+    [Fact]
+    public void Parse_Bind_Overrides()
+    {
+        var options = HostOptions.Parse(new[] { "--bind", "0.0.0.0", "--port", "8080" });
+        Assert.Equal("0.0.0.0", options.BindAddress);
+        Assert.Equal(8080, options.Port);
+    }
+}

--- a/managed-tests/SysAdminSuite.DashboardHost.Tests/RepoRootResolverTests.cs
+++ b/managed-tests/SysAdminSuite.DashboardHost.Tests/RepoRootResolverTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using SysAdminSuite.DashboardHost;
+using Xunit;
+
+namespace SysAdminSuite.DashboardHost.Tests;
+
+public sealed class RepoRootResolverTests : IDisposable
+{
+    private readonly string _scratch;
+
+    public RepoRootResolverTests()
+    {
+        _scratch = Path.Combine(Path.GetTempPath(), "sas-resolver-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void FindDashboardDirectory_DevTreeLayout_LocatesDashboard()
+    {
+        var dashboardDir = Path.Combine(_scratch, "dashboard");
+        Directory.CreateDirectory(dashboardDir);
+        File.WriteAllText(Path.Combine(dashboardDir, "index.html"), "<html></html>");
+
+        var fromNested = Path.Combine(_scratch, "src", "SysAdminSuite.DashboardHost", "bin", "Release", "net8.0-windows");
+        Directory.CreateDirectory(fromNested);
+
+        var found = RepoRootResolver.FindDashboardDirectory(fromNested);
+        Assert.Equal(dashboardDir, found);
+    }
+
+    [Fact]
+    public void FindDashboardDirectory_PortableAppLayout_LocatesDashboard()
+    {
+        var portable = Path.Combine(_scratch, "portable");
+        var dashboardDir = Path.Combine(portable, "app", "dashboard");
+        Directory.CreateDirectory(dashboardDir);
+        File.WriteAllText(Path.Combine(dashboardDir, "index.html"), "<html></html>");
+
+        var found = RepoRootResolver.FindDashboardDirectory(portable);
+        Assert.Equal(dashboardDir, found);
+    }
+
+    [Fact]
+    public void FindDashboardDirectory_NoDashboard_ReturnsNull()
+    {
+        var found = RepoRootResolver.FindDashboardDirectory(_scratch);
+        Assert.Null(found);
+    }
+}

--- a/managed-tests/SysAdminSuite.DashboardHost.Tests/SysAdminSuite.DashboardHost.Tests.csproj
+++ b/managed-tests/SysAdminSuite.DashboardHost.Tests/SysAdminSuite.DashboardHost.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <UseWindowsForms>true</UseWindowsForms>
+    <RootNamespace>SysAdminSuite.DashboardHost.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SysAdminSuite.DashboardHost/DashboardStaticServer.cs
+++ b/src/SysAdminSuite.DashboardHost/DashboardStaticServer.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace SysAdminSuite.DashboardHost;
+
+/// <summary>
+/// Pure path-resolution and MIME logic for the dashboard static surface.
+/// Mirrors the rules in server.py do_GET (lines 562-598) so the .NET host
+/// behaves identically to the Python launcher on /dashboard/* requests.
+/// </summary>
+public static class DashboardStaticServer
+{
+    public const string DashboardPrefix = "/dashboard/";
+    public const string DashboardBare = "/dashboard";
+    public const string DefaultMime = "application/octet-stream";
+
+    public static readonly IReadOnlyDictionary<string, string> MimeTypes =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [".html"] = "text/html; charset=utf-8",
+            [".css"] = "text/css; charset=utf-8",
+            [".js"] = "application/javascript; charset=utf-8",
+            [".json"] = "application/json; charset=utf-8",
+            [".png"] = "image/png",
+            [".svg"] = "image/svg+xml",
+            [".ico"] = "image/x-icon",
+        };
+
+    public enum ResultKind { Redirect, File, NotFound, Forbidden, BadRequest, PassThrough }
+
+    public sealed record ResolveResult(
+        ResultKind Kind,
+        string? FilePath = null,
+        string? MimeType = null,
+        string? RedirectLocation = null);
+
+    public static string GetMimeType(string extension)
+    {
+        if (string.IsNullOrEmpty(extension)) return DefaultMime;
+        return MimeTypes.TryGetValue(extension, out var mime) ? mime : DefaultMime;
+    }
+
+    /// <summary>
+    /// Resolve an incoming URL path against the dashboard root.
+    /// </summary>
+    /// <param name="urlPath">URL path without query string (e.g. "/dashboard/js/app.js").</param>
+    /// <param name="dashboardRoot">Absolute path to the dashboard/ directory.</param>
+    public static ResolveResult Resolve(string urlPath, string dashboardRoot)
+    {
+        if (string.IsNullOrEmpty(urlPath))
+        {
+            return new ResolveResult(ResultKind.BadRequest);
+        }
+        if (string.IsNullOrEmpty(dashboardRoot))
+        {
+            return new ResolveResult(ResultKind.NotFound);
+        }
+
+        if (string.Equals(urlPath, DashboardBare, StringComparison.Ordinal))
+        {
+            return new ResolveResult(ResultKind.Redirect, RedirectLocation: DashboardPrefix);
+        }
+
+        if (string.Equals(urlPath, DashboardPrefix, StringComparison.Ordinal))
+        {
+            var index = Path.Combine(dashboardRoot, "index.html");
+            if (!File.Exists(index))
+            {
+                return new ResolveResult(ResultKind.NotFound);
+            }
+            return new ResolveResult(ResultKind.File, FilePath: index, MimeType: GetMimeType(".html"));
+        }
+
+        if (!urlPath.StartsWith(DashboardPrefix, StringComparison.Ordinal))
+        {
+            return new ResolveResult(ResultKind.PassThrough);
+        }
+
+        var relative = urlPath.Substring(DashboardPrefix.Length);
+        if (string.IsNullOrEmpty(relative))
+        {
+            return new ResolveResult(ResultKind.BadRequest);
+        }
+        if (relative.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+        {
+            return new ResolveResult(ResultKind.BadRequest);
+        }
+
+        string candidate;
+        string rootFull;
+        try
+        {
+            candidate = Path.GetFullPath(Path.Combine(dashboardRoot, relative));
+            rootFull = Path.GetFullPath(dashboardRoot);
+        }
+        catch (Exception)
+        {
+            return new ResolveResult(ResultKind.BadRequest);
+        }
+
+        var rootWithSep = rootFull.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        if (!candidate.StartsWith(rootWithSep, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(candidate, rootFull, StringComparison.OrdinalIgnoreCase))
+        {
+            return new ResolveResult(ResultKind.Forbidden);
+        }
+
+        if (!File.Exists(candidate))
+        {
+            return new ResolveResult(ResultKind.NotFound);
+        }
+
+        var mime = GetMimeType(Path.GetExtension(candidate));
+        return new ResolveResult(ResultKind.File, FilePath: candidate, MimeType: mime);
+    }
+}

--- a/src/SysAdminSuite.DashboardHost/HostOptions.cs
+++ b/src/SysAdminSuite.DashboardHost/HostOptions.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+namespace SysAdminSuite.DashboardHost;
+
+/// <summary>
+/// Parsed command-line options for the dashboard tray host.
+/// Defaults match the existing Launch-SysAdminSuiteDashboard.ps1 behavior:
+/// bind 127.0.0.1:5000, open default browser, show tray icon.
+/// </summary>
+public sealed class HostOptions
+{
+    public const int DefaultPort = 5000;
+    public const string DefaultBindAddress = "127.0.0.1";
+
+    public int Port { get; init; } = DefaultPort;
+    public string BindAddress { get; init; } = DefaultBindAddress;
+    public bool OpenBrowser { get; init; } = true;
+    public bool ShowTray { get; init; } = true;
+    public string? DashboardRootOverride { get; init; }
+
+    public string Url => $"http://{BindAddress}:{Port}/dashboard/";
+
+    public static HostOptions Parse(IReadOnlyList<string> args)
+    {
+        int port = DefaultPort;
+        string bind = DefaultBindAddress;
+        bool openBrowser = true;
+        bool showTray = true;
+        string? rootOverride = null;
+
+        for (int i = 0; i < args.Count; i++)
+        {
+            var a = args[i];
+            switch (a)
+            {
+                case "--port":
+                    if (i + 1 < args.Count && int.TryParse(args[i + 1], out var p) && p > 0 && p < 65536)
+                    {
+                        port = p;
+                        i++;
+                    }
+                    break;
+                case "--bind":
+                    if (i + 1 < args.Count)
+                    {
+                        bind = args[i + 1];
+                        i++;
+                    }
+                    break;
+                case "--no-browser":
+                    openBrowser = false;
+                    break;
+                case "--no-tray":
+                    showTray = false;
+                    break;
+                case "--dashboard-root":
+                    if (i + 1 < args.Count)
+                    {
+                        rootOverride = args[i + 1];
+                        i++;
+                    }
+                    break;
+            }
+        }
+
+        return new HostOptions
+        {
+            Port = port,
+            BindAddress = bind,
+            OpenBrowser = openBrowser,
+            ShowTray = showTray,
+            DashboardRootOverride = rootOverride,
+        };
+    }
+}

--- a/src/SysAdminSuite.DashboardHost/Program.cs
+++ b/src/SysAdminSuite.DashboardHost/Program.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SysAdminSuite.DashboardHost;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        var options = HostOptions.Parse(args);
+
+        var dashboardRoot = options.DashboardRootOverride
+            ?? RepoRootResolver.FindDashboardDirectory();
+
+        if (string.IsNullOrEmpty(dashboardRoot) || !Directory.Exists(dashboardRoot))
+        {
+            ShowFatal("Dashboard folder not found. Expected a 'dashboard' directory next to the host executable or in a parent folder.");
+            return 2;
+        }
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls($"http://{options.BindAddress}:{options.Port}");
+
+        var app = builder.Build();
+
+        app.MapGet("/", (HttpContext ctx) =>
+        {
+            ctx.Response.Redirect(DashboardStaticServer.DashboardPrefix, permanent: false);
+            return Task.CompletedTask;
+        });
+
+        app.Map("/dashboard/{**path}", (HttpContext ctx) => HandleDashboard(ctx, dashboardRoot!));
+        app.Map("/dashboard", (HttpContext ctx) => HandleDashboard(ctx, dashboardRoot!));
+
+        try
+        {
+            app.Start();
+        }
+        catch (Exception ex)
+        {
+            ShowFatal($"Failed to bind {options.BindAddress}:{options.Port}.\n{ex.Message}");
+            return 3;
+        }
+
+        if (!options.ShowTray)
+        {
+            if (options.OpenBrowser) TryOpenBrowser(options.Url);
+            app.WaitForShutdown();
+            return 0;
+        }
+
+        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+
+        var trayCtx = new TrayApplicationContext(
+            url: options.Url,
+            tooltip: $"SysAdminSuite Dashboard ({options.BindAddress}:{options.Port})",
+            stopAsync: () => app.StopAsync());
+
+        if (options.OpenBrowser) TryOpenBrowser(options.Url);
+
+        Application.Run(trayCtx);
+
+        try { app.StopAsync().Wait(TimeSpan.FromSeconds(5)); } catch { }
+        return 0;
+    }
+
+    private static async Task HandleDashboard(HttpContext ctx, string dashboardRoot)
+    {
+        var result = DashboardStaticServer.Resolve(ctx.Request.Path.Value ?? string.Empty, dashboardRoot);
+        switch (result.Kind)
+        {
+            case DashboardStaticServer.ResultKind.Redirect:
+                ctx.Response.StatusCode = 301;
+                ctx.Response.Headers["Location"] = result.RedirectLocation!;
+                return;
+            case DashboardStaticServer.ResultKind.File:
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = result.MimeType ?? DashboardStaticServer.DefaultMime;
+                ctx.Response.Headers["Cache-Control"] = "no-cache";
+                await ctx.Response.SendFileAsync(result.FilePath!);
+                return;
+            case DashboardStaticServer.ResultKind.Forbidden:
+                ctx.Response.StatusCode = 403;
+                await ctx.Response.WriteAsync("Forbidden");
+                return;
+            case DashboardStaticServer.ResultKind.BadRequest:
+                ctx.Response.StatusCode = 400;
+                await ctx.Response.WriteAsync("Bad request");
+                return;
+            case DashboardStaticServer.ResultKind.NotFound:
+            case DashboardStaticServer.ResultKind.PassThrough:
+            default:
+                ctx.Response.StatusCode = 404;
+                await ctx.Response.WriteAsync("Not found");
+                return;
+        }
+    }
+
+    private static void TryOpenBrowser(string url)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+        }
+        catch { /* user can still open from tray */ }
+    }
+
+    private static void ShowFatal(string message)
+    {
+        try
+        {
+            MessageBox.Show(message, "SysAdminSuite Dashboard Host",
+                MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        catch
+        {
+            Console.Error.WriteLine(message);
+        }
+    }
+}

--- a/src/SysAdminSuite.DashboardHost/RepoRootResolver.cs
+++ b/src/SysAdminSuite.DashboardHost/RepoRootResolver.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+
+namespace SysAdminSuite.DashboardHost;
+
+/// <summary>
+/// Locates the dashboard/ directory relative to the executing assembly.
+/// Supports both dev-tree layout (repo\src\SysAdminSuite.DashboardHost\bin\...)
+/// and portable layout (root\app\dashboard plus root\app\bin\... if published in place).
+/// </summary>
+public static class RepoRootResolver
+{
+    public const string DashboardFolderName = "dashboard";
+    public const string DashboardIndex = "index.html";
+
+    public static string? FindDashboardDirectory(string? startDirectory = null)
+    {
+        var start = startDirectory ?? AppContext.BaseDirectory;
+        if (string.IsNullOrEmpty(start)) return null;
+
+        var current = new DirectoryInfo(start);
+        for (int hops = 0; hops < 12 && current != null; hops++)
+        {
+            var candidate = Path.Combine(current.FullName, DashboardFolderName, DashboardIndex);
+            if (File.Exists(candidate))
+            {
+                return Path.Combine(current.FullName, DashboardFolderName);
+            }
+            // Portable layout: when EXE lives alongside an app\ folder.
+            var appCandidate = Path.Combine(current.FullName, "app", DashboardFolderName, DashboardIndex);
+            if (File.Exists(appCandidate))
+            {
+                return Path.Combine(current.FullName, "app", DashboardFolderName);
+            }
+            current = current.Parent;
+        }
+        return null;
+    }
+}

--- a/src/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.csproj
+++ b/src/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>SysAdminSuite.DashboardHost</RootNamespace>
+    <AssemblyName>SysAdminSuite.DashboardHost</AssemblyName>
+    <Description>PS-independent tray host for the SysAdminSuite web dashboard.</Description>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+</Project>

--- a/src/SysAdminSuite.DashboardHost/TrayApplicationContext.cs
+++ b/src/SysAdminSuite.DashboardHost/TrayApplicationContext.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace SysAdminSuite.DashboardHost;
+
+/// <summary>
+/// NotifyIcon-driven application context. Owns the tray icon and provides
+/// menu entries (Open, Copy URL, Stop) that drive the supplied stop callback.
+/// </summary>
+public sealed class TrayApplicationContext : ApplicationContext
+{
+    private readonly NotifyIcon _notifyIcon;
+    private readonly string _url;
+    private readonly Func<Task> _stopAsync;
+    private bool _stopping;
+
+    public TrayApplicationContext(string url, string tooltip, Func<Task> stopAsync)
+    {
+        _url = url;
+        _stopAsync = stopAsync;
+
+        var menu = new ContextMenuStrip();
+        var openItem = new ToolStripMenuItem("Open Dashboard");
+        openItem.Click += (_, _) => OpenBrowser();
+        var copyItem = new ToolStripMenuItem("Copy URL");
+        copyItem.Click += (_, _) => CopyUrl();
+        var stopItem = new ToolStripMenuItem("Stop Dashboard");
+        stopItem.Click += (_, _) => BeginShutdown();
+        menu.Items.Add(openItem);
+        menu.Items.Add(copyItem);
+        menu.Items.Add(new ToolStripSeparator());
+        menu.Items.Add(stopItem);
+
+        _notifyIcon = new NotifyIcon
+        {
+            Icon = CreateTrayIcon(),
+            Text = TruncateForTooltip(tooltip),
+            Visible = true,
+            ContextMenuStrip = menu,
+            BalloonTipTitle = "SysAdminSuite Dashboard",
+            BalloonTipText = "Server is running. Right-click the tray icon to stop.",
+            BalloonTipIcon = ToolTipIcon.Info,
+        };
+        _notifyIcon.DoubleClick += (_, _) => OpenBrowser();
+        _notifyIcon.ShowBalloonTip(4000);
+    }
+
+    public void NotifyError(string title, string message)
+    {
+        if (_notifyIcon.Visible)
+        {
+            _notifyIcon.BalloonTipTitle = title;
+            _notifyIcon.BalloonTipText = message;
+            _notifyIcon.BalloonTipIcon = ToolTipIcon.Error;
+            _notifyIcon.ShowBalloonTip(8000);
+        }
+    }
+
+    private void OpenBrowser()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(_url) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            NotifyError("SysAdminSuite Dashboard", "Could not open browser: " + ex.Message);
+        }
+    }
+
+    private void CopyUrl()
+    {
+        try { Clipboard.SetText(_url); }
+        catch { /* clipboard can race; ignore */ }
+    }
+
+    private void BeginShutdown()
+    {
+        if (_stopping) return;
+        _stopping = true;
+        _ = Task.Run(async () =>
+        {
+            try { await _stopAsync(); }
+            catch { /* swallow - shutdown is best effort */ }
+            finally
+            {
+                try { _notifyIcon.Visible = false; } catch { }
+                try { _notifyIcon.Dispose(); } catch { }
+                Application.Exit();
+            }
+        });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            try { _notifyIcon.Visible = false; } catch { }
+            try { _notifyIcon.Dispose(); } catch { }
+        }
+        base.Dispose(disposing);
+    }
+
+    private static string TruncateForTooltip(string text)
+        => string.IsNullOrEmpty(text) ? "SysAdminSuite Dashboard"
+            : text.Length <= 63 ? text : text.Substring(0, 63);
+
+    private static Icon CreateTrayIcon()
+    {
+        using var bmp = new Bitmap(16, 16);
+        using (var g = Graphics.FromImage(bmp))
+        {
+            g.Clear(Color.SteelBlue);
+        }
+        var hicon = bmp.GetHicon();
+        return Icon.FromHandle(hicon);
+    }
+}

--- a/src/SysAdminSuite.DashboardHost/app.manifest
+++ b/src/SysAdminSuite.DashboardHost/app.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="SysAdminSuite.DashboardHost" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/tools/Test-PortableArtifactSmoke.ps1
+++ b/tools/Test-PortableArtifactSmoke.ps1
@@ -48,6 +48,18 @@ try {
     if (-not $hasRuntime) {
         throw "Archive missing Launch-SysAdminSuite-Runtime.bat at repo root of package."
     }
+    $hasDashboardIndex = $names | Where-Object { $_ -match 'app[/\\]dashboard[/\\]index\.html' }
+    if (-not $hasDashboardIndex) {
+        throw "Archive missing app/dashboard/index.html (required for PS-independent dashboard host)."
+    }
+    $hasHostLauncher = $names | Where-Object { $_ -match 'Launch-SysAdminSuiteDashboard\.Host\.bat' }
+    if (-not $hasHostLauncher) {
+        throw "Archive missing Launch-SysAdminSuiteDashboard.Host.bat at repo root of package."
+    }
+    $hasHostExe = $names | Where-Object { $_ -match 'app[/\\]bin[/\\]SysAdminSuite\.DashboardHost\.exe' }
+    if (-not $hasHostExe) {
+        Write-Warning "Archive missing app/bin/SysAdminSuite.DashboardHost.exe; PS-independent dashboard path will be unavailable until 'dotnet publish' output is staged before packaging."
+    }
 } finally {
     $zip.Dispose()
 }

--- a/tools/build/New-PortableArtifact.ps1
+++ b/tools/build/New-PortableArtifact.ps1
@@ -37,6 +37,7 @@ New-Item -ItemType Directory -Path (Join-Path $stagingRoot 'manifest') -Force | 
 $appTargets = @(
     'ActiveDirectory',
     'Config',
+    'dashboard',
     'DeploymentTracker',
     'EnvSetup',
     'GetInfo',
@@ -48,7 +49,11 @@ $appTargets = @(
     'tools',
     'Utilities',
     'Launch-SysAdminSuite.bat',
-    'Launch-SysAdminSuite-Runtime.bat'
+    'Launch-SysAdminSuite-Runtime.bat',
+    'Launch-SysAdminSuiteDashboard.bat',
+    'Launch-SysAdminSuiteDashboard.ps1',
+    'Launch-SysAdminSuiteDashboard.Host.bat',
+    'server.py'
 )
 
 foreach ($target in $appTargets) {
@@ -60,6 +65,17 @@ foreach ($target in $appTargets) {
 
     $destination = Join-Path (Join-Path $stagingRoot 'app') $target
     Copy-Item -Path $source -Destination $destination -Recurse -Force
+}
+
+$publishSource = Join-Path $repoRoot 'tools\publish\SysAdminSuite.DashboardHost'
+if (Test-Path -LiteralPath $publishSource) {
+    $binDest = Join-Path $stagingRoot 'app\bin'
+    if (-not (Test-Path -LiteralPath $binDest)) {
+        New-Item -ItemType Directory -Path $binDest -Force | Out-Null
+    }
+    Copy-Item -Path (Join-Path $publishSource '*') -Destination $binDest -Recurse -Force
+} else {
+    Write-Warning "DashboardHost publish output not found at $publishSource. Run 'dotnet publish src/SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false -o tools/publish/SysAdminSuite.DashboardHost' before building the portable artifact to include the PS-independent dashboard host."
 }
 
 $manifestSource = Join-Path $repoRoot 'Config\update-manifest.sample.json'


### PR DESCRIPTION
## **User description**
@'
## Summary
- Add SysAdminSuite.DashboardHost (.NET 8 WinExe): Kestrel static server for dashboard/, system-tray host, default-browser launch — no powershell.exe required
- Add Launch-SysAdminSuiteDashboard.Host.bat and Runtime menu option [3] Dashboard (no PowerShell) with PS fallback on [2]
- Package dashboard/ + published host in portable artifact build; document in docs/GUI_HOST_MIGRATION.md
- Extend .gitignore for **/bin/, **/obj/, 	ools/publish/

## Compatibility checklist
- [x] Branch starts from current main (9ec89e4)
- [x] PowerShell preserved — no deletions under GUI/ or Launch-*.ps1
- [x] Bash contracts not impacted
- [x] dotnet test SysAdminSuite.sln -c Release — 26/26 passed locally
- [x] Pester not required (no PS GUI script changes)

## Test plan
- [x] dotnet test SysAdminSuite.sln -c Release
- [ ] dotnet publish src/SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false -o tools/publish/dashboard-host
- [ ] Launch-SysAdminSuiteDashboard.Host.bat → tray + browser at http://127.0.0.1:5000/dashboard/
- [ ] Launch-SysAdminSuite-Runtime.bat option 3
- [ ] Confirm Launch-SysAdminSuiteDashboard.bat (PS path) still works

## Output paths
- Publish: 	ools/publish/dashboard-host/SysAdminSuite.DashboardHost.exe
- Dashboard static root: dashboard/ (served at /dashboard/)
- Docs: docs/GUI_HOST_MIGRATION.md

## Related
- Independent of PR #43 (QR Generator tab). Merge order flexible; no file overlap expected after rebase if main moves.
'@


___

## **CodeAnt-AI Description**
**Add a PowerShell-free dashboard launcher and package it in portable builds**

### What Changed
- Added a new tray-based dashboard host that opens the web dashboard without `powershell.exe` or Python
- The runtime menu now includes a third option for the no-PowerShell dashboard path
- Portable artifact builds now include the dashboard files, the new host launcher, and the host executable when published
- Updated checks and documentation to reflect the new launch path and expected smoke behavior

### Impact
`✅ Dashboard access on locked-down Windows endpoints`
`✅ Fewer failures when PowerShell or Python is unavailable`
`✅ Easier portable package startup for the web dashboard`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
