### PR TITLE
feat(survey): add Cybernet subnet discovery MVP (PowerShell)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ data/updated/*
 *.xls
 *.csv
 *.tsv
+!input/cybernet-serials.example.csv
+!input/site-subnets.example.csv
 *.zip
 !**/.gitkeep
 

--- a/Config/approved-subnets.example.json
+++ b/Config/approved-subnets.example.json
@@ -1,0 +1,16 @@
+{
+  "subnets": [
+    {
+      "site": "SSUH",
+      "cidr": "10.20.30.0/24",
+      "approvedForScan": true,
+      "description": "OR Cybernet VLAN"
+    },
+    {
+      "site": "SSUH",
+      "cidr": "10.20.31.0/24",
+      "approvedForScan": true,
+      "description": "Staging VLAN"
+    }
+  ]
+}

--- a/Config/cybernet-port-profile.json
+++ b/Config/cybernet-port-profile.json
@@ -1,0 +1,14 @@
+{
+  "profiles": {
+    "CybernetWindowsEndpoint": {
+      "ports": [135, 139, 445, 3389, 5985, 5986, 80, 443, 8080, 8443],
+      "defaultRate": 50,
+      "defaultConcurrency": 10,
+      "timeoutMs": 1000,
+      "retries": 1,
+      "requireApprovedSubnet": true,
+      "allowServiceVersionScan": false,
+      "allowFullPortScan": false
+    }
+  }
+}

--- a/Config/cybernet-port-profile.json
+++ b/Config/cybernet-port-profile.json
@@ -1,7 +1,9 @@
 {
+  "_doctrine": "Canonical scan doctrine lives in Config/cybernet-naabu-profiles.json (windows_selected). This profile mirrors that port set and CDN-exclude posture for PowerShell handoff string generation only; PowerShell never executes scans. PowerShell is deprecated for Northwell-targeted workflows; Bash-first AD-export pipelines remain the Northwell-forward path.",
   "profiles": {
     "CybernetWindowsEndpoint": {
-      "ports": [135, 139, 445, 3389, 5985, 5986, 80, 443, 8080, 8443],
+      "ports": [135, 139, 445, 3389, 5985, 5986, 80, 443],
+      "excludeCdn": true,
       "defaultRate": 50,
       "defaultConcurrency": 10,
       "timeoutMs": 1000,

--- a/Config/cybernet-subnet-rules.json
+++ b/Config/cybernet-subnet-rules.json
@@ -1,0 +1,39 @@
+{
+  "subnetInference": {
+    "requireApprovedSubnet": true,
+    "allowDnsOnlyIpCandidate": true,
+    "allowRouteTableCandidate": false,
+    "allowDhcpScopeCandidate": false,
+    "allowArpCandidate": false,
+    "defaultPrefixLengthWhenUnknown": 24,
+    "neverAssumePrefixWithoutEvidence": true
+  },
+  "confidenceRules": {
+    "confirmed": [
+      "SerialMatched",
+      "HostnameMatchedOrMacMatched",
+      "IpResolved",
+      "SubnetApproved"
+    ],
+    "high": [
+      "HostnameMatched",
+      "IpResolved",
+      "SubnetApproved"
+    ],
+    "medium": [
+      "MacMatchedOrIpObserved",
+      "SubnetApproved"
+    ],
+    "weak": [
+      "IpObserved",
+      "SubnetInferred"
+    ],
+    "blocked": [
+      "IpOrSubnetFound",
+      "SubnetNotApproved"
+    ],
+    "missing": [
+      "SerialOnlyNoIdentityBridge"
+    ]
+  }
+}

--- a/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
+++ b/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
@@ -1,0 +1,270 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0' }
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:moduleRoot = Join-Path $script:repoRoot 'modules\CybernetSubnetDiscovery'
+    $script:surveyRoot = Join-Path $script:repoRoot 'modules\CybernetSurvey'
+
+    . (Join-Path $script:moduleRoot 'Import-CybernetSerialInventory.ps1')
+    . (Join-Path $script:moduleRoot 'Convert-IpToSubnetCandidate.ps1')
+    . (Join-Path $script:moduleRoot 'Resolve-CybernetDnsIdentity.ps1')
+    . (Join-Path $script:moduleRoot 'New-CybernetSubnetDiscoveryReport.ps1')
+    . (Join-Path $script:surveyRoot 'New-CybernetScannerCommand.ps1')
+}
+
+Describe 'Normalize-CybernetSerial' {
+    It 'Uppercases and removes whitespace' {
+        Normalize-CybernetSerial -Value ' cn12345678 ' | Should -Be 'CN12345678'
+    }
+
+    It 'Returns empty for blank input' {
+        Normalize-CybernetSerial -Value '   ' | Should -Be ''
+    }
+}
+
+Describe 'Normalize-CybernetMac' {
+    It 'Normalizes dash-separated MAC' {
+        Normalize-CybernetMac -Value '00-11-22-33-44-55' | Should -Be '00:11:22:33:44:55'
+    }
+
+    It 'Normalizes colon-separated MAC' {
+        Normalize-CybernetMac -Value 'aa:bb:cc:dd:ee:ff' | Should -Be 'AA:BB:CC:DD:EE:FF'
+    }
+
+    It 'Normalizes bare hex MAC' {
+        Normalize-CybernetMac -Value '001122334455' | Should -Be '00:11:22:33:44:55'
+    }
+}
+
+Describe 'Import-CybernetSerialInventory' {
+    It 'Imports manifest with blank optional fields' {
+        $csv = Join-Path $TestDrive 'serials.csv'
+        @'
+Site,Serial,ExpectedHostname,ExpectedMAC,ExpectedRoom,ExpectedStatus,Notes
+SSUH,CN12345678,WNH269OPR009,00-11-22-33-44-55,OR-2,Configured,
+SSUH,CN87654321,,,,Configured,Serial known only
+'@ | Set-Content -LiteralPath $csv -Encoding UTF8
+
+        $result = Import-CybernetSerialInventory -Path $csv -Site 'SSUH'
+        $result.Rows.Count | Should -Be 2
+        $result.Rows[1].ExpectedHostname | Should -Be ''
+        $result.Rows[1].ExpectedMAC | Should -Be ''
+    }
+
+    It 'Detects duplicate serials' {
+        $csv = Join-Path $TestDrive 'dupes.csv'
+        @'
+Site,Serial,ExpectedHostname,ExpectedMAC,ExpectedRoom,ExpectedStatus,Notes
+SSUH,CN11111111,H1,,,, 
+SSUH,CN11111111,H2,,,, 
+'@ | Set-Content -LiteralPath $csv -Encoding UTF8
+
+        $result = Import-CybernetSerialInventory -Path $csv -Site 'SSUH'
+        $result.DuplicateSerials | Should -Contain 'CN11111111'
+    }
+}
+
+Describe 'Import-CybernetSiteSubnets' {
+    It 'Parses ApprovedForScan values' {
+        $csv = Join-Path $TestDrive 'subnets.csv'
+        @'
+Site,Subnet,Description,ApprovedForScan
+SSUH,10.20.30.0/24,OR Cybernet VLAN,true
+SSUH,10.20.99.0/24,Disabled VLAN,false
+'@ | Set-Content -LiteralPath $csv -Encoding UTF8
+
+        $rows = Import-CybernetSiteSubnets -Path $csv -Site 'SSUH'
+        $rows.Count | Should -Be 2
+        ($rows | Where-Object { $_.Subnet -eq '10.20.30.0/24' }).ApprovedForScan | Should -Be $true
+        ($rows | Where-Object { $_.Subnet -eq '10.20.99.0/24' }).ApprovedForScan | Should -Be $false
+    }
+}
+
+Describe 'Convert-IpToSubnetCandidate' {
+    It 'Maps IP to approved subnet' {
+        $subnets = @(
+            [pscustomobject]@{ Site = 'SSUH'; Subnet = '10.20.30.0/24'; Description = 'OR'; ApprovedForScan = $true; Source = 'SiteSubnets' }
+        )
+        $match = Convert-IpToSubnetCandidate -IPv4 '10.20.30.42' -ApprovedSubnets $subnets
+        $match.SubnetCandidate | Should -Be '10.20.30.0/24'
+        $match.ApprovedForScan | Should -Be $true
+    }
+
+    It 'Rejects public IP addresses' {
+        $subnets = @(
+            [pscustomobject]@{ Site = 'SSUH'; Subnet = '10.20.30.0/24'; Description = 'OR'; ApprovedForScan = $true; Source = 'SiteSubnets' }
+        )
+        $match = Convert-IpToSubnetCandidate -IPv4 '8.8.8.8' -ApprovedSubnets $subnets
+        $match.IsPublic | Should -Be $true
+        $match.Matched | Should -Be $false
+    }
+
+    It 'Rejects unapproved subnet matches' {
+        $rows = @(
+            [pscustomobject]@{ Site = 'SSUH'; Subnet = '10.20.30.0/24'; Description = 'OR'; ApprovedForScan = $false; Source = 'SiteSubnets' }
+        )
+        $match = Convert-IpToSubnetCandidate -IPv4 '10.20.30.42' -ApprovedSubnets $rows -RequireApprovedSubnet $true
+        $match.Matched | Should -Be $true
+        $match.ApprovedForScan | Should -Be $false
+    }
+
+    It 'Blocks documentation-range IPs as public' {
+        $subnets = @(
+            [pscustomobject]@{ Site = 'SSUH'; Subnet = '10.20.30.0/24'; Description = 'OR'; ApprovedForScan = $true; Source = 'SiteSubnets' }
+        )
+        $match = Convert-IpToSubnetCandidate -IPv4 '203.0.113.1' -ApprovedSubnets $subnets
+        $match.IsPublic | Should -Be $true
+    }
+}
+
+Describe 'Resolve-CybernetDnsIdentity' {
+    It 'Parses mocked Resolve-DnsName output' {
+        $mockResolver = {
+            param($Name)
+            @([pscustomobject]@{ Name = $Name; Type = 'A'; IPAddress = '10.20.30.88' })
+        }
+
+        $records = Resolve-CybernetDnsForward -Hostname 'WNH269OPR014' -DnsResolver $mockResolver
+        @($records).Count | Should -Be 1
+        $records[0].IP | Should -Be '10.20.30.88'
+    }
+
+    It 'Applies DNS results to inventory rows' {
+        $mockResolver = {
+            param($Name)
+            @([pscustomobject]@{ Name = $Name; Type = 'A'; IPAddress = '10.20.30.42' })
+        }
+
+        $rows = @([pscustomobject]@{
+            Site = 'SSUH'; Serial = 'CN12345678'; ExpectedHostname = 'WNH269OPR009'
+            ExpectedMAC = '00:11:22:33:44:55'; ExpectedRoom = ''; ExpectedStatus = ''
+            Notes = ''; IP = ''; SubnetCandidate = ''; SubnetSource = ''
+            Confidence = 'Missing'; Evidence = ''
+        })
+
+        $updated = Apply-CybernetDnsToInventory -InventoryRows $rows -DnsResolver $mockResolver
+        $updated[0].IP | Should -Be '10.20.30.42'
+    }
+}
+
+Describe 'New-CybernetSubnetDiscoveryReport' {
+    It 'Generates target IPs only for approved scope' {
+        $subnets = @(
+            [pscustomobject]@{ Site = 'SSUH'; Subnet = '10.20.30.0/24'; Description = 'OR'; ApprovedForScan = $true; Source = 'SiteSubnets' }
+        )
+        $inventory = @(
+            [pscustomobject]@{ Site='SSUH'; Serial='CN1'; ExpectedHostname='H1'; ExpectedMAC=''; IP='10.20.30.10'; Evidence='' }
+            [pscustomobject]@{ Site='SSUH'; Serial='CN2'; ExpectedHostname='H2'; ExpectedMAC=''; IP='8.8.8.8'; Evidence='' }
+            [pscustomobject]@{ Site='SSUH'; Serial='CN3'; ExpectedHostname=''; ExpectedMAC=''; IP=''; Evidence='' }
+        )
+
+        $matches = foreach ($row in $inventory) {
+            Convert-IpToSubnetCandidate -IPv4 $row.IP -ApprovedSubnets $subnets
+        }
+
+        $identity = New-CybernetIdentityMapRows -InventoryRows $inventory -SubnetMatches $matches
+        $targets = New-CybernetTargetIpList -IdentityMapRows $identity
+        $targets | Should -Contain '10.20.30.10'
+        $targets | Should -Not -Contain '8.8.8.8'
+        @($targets).Count | Should -Be 1
+    }
+
+    It 'Generates action items for Missing records' {
+        $identity = @(
+            [pscustomobject]@{
+                Site='SSUH'; Serial='CN87654321'; Hostname=''; MAC=''; IP=''
+                SubnetCandidate=''; SubnetSource=''; Confidence='Missing'
+                Evidence='Serial has no hostname, MAC, IP, or subnet bridge'
+            }
+        )
+        $md = New-CybernetActionItemsMarkdown -IdentityMapRows $identity -DuplicateSerials @()
+        $md | Should -Match 'Missing bridge'
+        $md | Should -Match 'CN87654321'
+    }
+
+    It 'Classifies unapproved subnet as Blocked' {
+        $row = [pscustomobject]@{
+            Site='SSUH'; Serial='CN9'; ExpectedHostname='H9'; ExpectedMAC=''; IP='10.20.30.50'; Evidence=''
+        }
+        $match = Convert-IpToSubnetCandidate -IPv4 $row.IP -ApprovedSubnets @(
+            [pscustomobject]@{ Site='SSUH'; Subnet='10.20.30.0/24'; ApprovedForScan=$false; Source='SiteSubnets' }
+        )
+        $identity = New-CybernetIdentityMapRows -InventoryRows @($row) -SubnetMatches @($match)
+        $identity[0].Confidence | Should -Be 'Blocked'
+    }
+
+    It 'Generates summary JSON with confidence counts' {
+        $identity = @(
+            [pscustomobject]@{ Site='SSUH'; Serial='CN1'; Hostname='H1'; MAC=''; IP='10.20.30.10'; SubnetCandidate='10.20.30.0/24'; SubnetSource='SiteSubnets'; Confidence='High'; Evidence='' }
+            [pscustomobject]@{ Site='SSUH'; Serial='CN2'; Hostname=''; MAC=''; IP=''; SubnetCandidate=''; SubnetSource=''; Confidence='Missing'; Evidence='' }
+        )
+        $summary = New-CybernetDiscoverySummary -Site 'SSUH' -IdentityMapRows $identity -TargetIps @('10.20.30.10') -DuplicateSerials @() -DnsResolvedCount 1
+        $summary.site | Should -Be 'SSUH'
+        $summary.confidenceCounts.High | Should -Be 1
+        $summary.confidenceCounts.Missing | Should -Be 1
+        ($summary | ConvertTo-Json) | Should -Match 'confidenceCounts'
+    }
+}
+
+Describe 'New-CybernetScannerCommand' {
+    It 'Generates deterministic Naabu command' {
+        $profilePath = Join-Path $script:repoRoot 'config\cybernet-port-profile.json'
+        $profile = Get-CybernetPortProfile -ProfilePath $profilePath
+        $cmd = New-CybernetNaabuCommand -TargetFile '.\targets.txt' -OutputFile '.\out.jsonl' -Profile $profile
+        $cmd.Command | Should -Be 'naabu -list .\targets.txt -p 135,139,445,3389,5985,5986,80,443,8080,8443 -rate 50 -c 10 -retries 1 -timeout 1000 -json -silent -duc -o .\out.jsonl'
+    }
+
+    It 'Generates deterministic Nmap host discovery command' {
+        $cmd = New-CybernetNmapHostDiscoveryCommand -TargetFile '.\targets.txt' -OutputFile '.\out.xml'
+        $cmd.Command | Should -Be 'nmap -sn -iL .\targets.txt -oX .\out.xml'
+    }
+
+    It 'Generates deterministic Nmap selected-port command' {
+        $profilePath = Join-Path $script:repoRoot 'config\cybernet-port-profile.json'
+        $profile = Get-CybernetPortProfile -ProfilePath $profilePath
+        $cmd = New-CybernetNmapSelectedPortCommand -TargetFile '.\targets.txt' -OutputFile '.\out.xml' -Profile $profile
+        $cmd.Command | Should -Be 'nmap -p 135,139,445,3389,5985,5986,80,443,8080,8443 --open -iL .\targets.txt -oX .\out.xml'
+    }
+}
+
+Describe 'Invoke-SASCybernetSubnetDiscovery.ps1 integration' {
+    It 'Runs end-to-end without executing scanners' {
+        $outDir = Join-Path $TestDrive 'discovery'
+        $invokePath = Join-Path $script:moduleRoot 'Invoke-SASCybernetSubnetDiscovery.ps1'
+        $serials = Join-Path $script:repoRoot 'input\cybernet-serials.example.csv'
+        $subnets = Join-Path $script:repoRoot 'input\site-subnets.example.csv'
+
+        $knownHosts = Join-Path $TestDrive 'known.csv'
+        @(
+            [pscustomobject]@{ Serial = 'CN12345678'; ExpectedHostname = 'WNH269OPR009'; IP = '10.20.30.42' }
+        ) | Export-Csv -LiteralPath $knownHosts -NoTypeInformation
+
+        & $invokePath `
+            -Site 'SSUH' `
+            -SerialInventoryPath $serials `
+            -SiteSubnetsPath $subnets `
+            -KnownHostsPath $knownHosts `
+            -OutDir $outDir `
+            -GenerateSurveyTargets
+
+        @(
+            'CybernetSubnetDiscovery_NormalizedSerials.csv',
+            'CybernetSubnetDiscovery_IdentityMap.csv',
+            'CybernetSubnetDiscovery_SubnetsToSurvey.csv',
+            'CybernetSubnetDiscovery_TargetIPs.txt',
+            'CybernetSubnetDiscovery_Summary.json',
+            'CybernetSubnetDiscovery_ActionItems.md',
+            'CybernetSubnetDiscovery_EvidenceLog.jsonl'
+        ) | ForEach-Object {
+            Join-Path $outDir $_ | Should -Exist
+        }
+
+        $log = Get-Content -LiteralPath (Join-Path $outDir 'CybernetSubnetDiscovery_EvidenceLog.jsonl') -Raw
+        $log | Should -Match 'naabu -list'
+        $log | Should -Match 'nmap -sn'
+        $log | Should -Match 'not executed'
+
+        $targets = Get-Content -LiteralPath (Join-Path $outDir 'CybernetSubnetDiscovery_TargetIPs.txt')
+        $targets | Should -Contain '10.20.30.42'
+    }
+}

--- a/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
+++ b/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
@@ -211,7 +211,7 @@ Describe 'New-CybernetScannerCommand' {
         $profilePath = Join-Path $script:repoRoot 'Config\cybernet-port-profile.json'
         $profile = Get-CybernetPortProfile -ProfilePath $profilePath
         $cmd = New-CybernetNaabuCommand -TargetFile '.\targets.txt' -OutputFile '.\out.jsonl' -Profile $profile
-        $cmd.Command | Should -Be 'naabu -list .\targets.txt -p 135,139,445,3389,5985,5986,80,443,8080,8443 -rate 50 -c 10 -retries 1 -timeout 1000 -json -silent -duc -o .\out.jsonl'
+        $cmd.Command | Should -Be 'naabu -list .\targets.txt -p 135,139,445,3389,5985,5986,80,443 -rate 50 -c 10 -retries 1 -timeout 1000 -ec -json -silent -duc -o .\out.jsonl'
     }
 
     It 'Generates deterministic Nmap host discovery command' {
@@ -223,7 +223,7 @@ Describe 'New-CybernetScannerCommand' {
         $profilePath = Join-Path $script:repoRoot 'Config\cybernet-port-profile.json'
         $profile = Get-CybernetPortProfile -ProfilePath $profilePath
         $cmd = New-CybernetNmapSelectedPortCommand -TargetFile '.\targets.txt' -OutputFile '.\out.xml' -Profile $profile
-        $cmd.Command | Should -Be 'nmap -p 135,139,445,3389,5985,5986,80,443,8080,8443 --open -iL .\targets.txt -oX .\out.xml'
+        $cmd.Command | Should -Be 'nmap -p 135,139,445,3389,5985,5986,80,443 --open -iL .\targets.txt -oX .\out.xml'
     }
 }
 

--- a/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
+++ b/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
@@ -208,7 +208,7 @@ Describe 'New-CybernetSubnetDiscoveryReport' {
 
 Describe 'New-CybernetScannerCommand' {
     It 'Generates deterministic Naabu command' {
-        $profilePath = Join-Path $script:repoRoot 'config\cybernet-port-profile.json'
+        $profilePath = Join-Path $script:repoRoot 'Config\cybernet-port-profile.json'
         $profile = Get-CybernetPortProfile -ProfilePath $profilePath
         $cmd = New-CybernetNaabuCommand -TargetFile '.\targets.txt' -OutputFile '.\out.jsonl' -Profile $profile
         $cmd.Command | Should -Be 'naabu -list .\targets.txt -p 135,139,445,3389,5985,5986,80,443,8080,8443 -rate 50 -c 10 -retries 1 -timeout 1000 -json -silent -duc -o .\out.jsonl'
@@ -220,7 +220,7 @@ Describe 'New-CybernetScannerCommand' {
     }
 
     It 'Generates deterministic Nmap selected-port command' {
-        $profilePath = Join-Path $script:repoRoot 'config\cybernet-port-profile.json'
+        $profilePath = Join-Path $script:repoRoot 'Config\cybernet-port-profile.json'
         $profile = Get-CybernetPortProfile -ProfilePath $profilePath
         $cmd = New-CybernetNmapSelectedPortCommand -TargetFile '.\targets.txt' -OutputFile '.\out.xml' -Profile $profile
         $cmd.Command | Should -Be 'nmap -p 135,139,445,3389,5985,5986,80,443,8080,8443 --open -iL .\targets.txt -oX .\out.xml'

--- a/docs/NAABU_CYBERNET_PROFILES.md
+++ b/docs/NAABU_CYBERNET_PROFILES.md
@@ -127,3 +127,14 @@ Optional Go normalizer: `probe/packet-expenditure/` (`sas-naabu-normalize`).
 bash Tests/bash/test_naabu_pipeline_contracts.sh
 bash Tests/bash/test_naabu_package_contracts.sh
 ```
+
+## Legacy / PowerShell-enabled environments
+
+PowerShell support is retained for PowerShell-enabled environments and as a reference implementation.
+For Northwell-targeted workflows, PowerShell is deprecated. Prefer Bash-first workflows that consume approved AD exports and write local evidence only.
+
+`Invoke-SASCybernetSubnetDiscovery` (PR #49 module under `modules/CybernetSubnetDiscovery/`) may emit
+`evidence/CybernetSubnetDiscovery/<site>/CybernetSubnetDiscovery_TargetIPs.txt` for optional handoff.
+That output is not required for Northwell WAB Phase 2b or Bash orchestrator workflows.
+PS-generated Naabu/Nmap strings are record-only reference commands; execute scans through Bash
+(`survey/sas-run-naabu-pipeline.sh`, `survey/sas-cybernet-subnet-survey.sh`) instead.

--- a/input/cybernet-serials.example.csv
+++ b/input/cybernet-serials.example.csv
@@ -1,0 +1,3 @@
+Site,Serial,ExpectedHostname,ExpectedMAC,ExpectedRoom,ExpectedStatus,Notes
+SSUH,CN12345678,WNH269OPR009,00-11-22-33-44-55,OR-2,Configured,
+SSUH,CN87654321,,,,Configured,Serial known only

--- a/input/site-subnets.example.csv
+++ b/input/site-subnets.example.csv
@@ -1,0 +1,3 @@
+Site,Subnet,Description,ApprovedForScan
+SSUH,10.20.30.0/24,OR Cybernet VLAN,true
+SSUH,10.20.31.0/24,Staging VLAN,true

--- a/modules/CybernetSubnetDiscovery/Convert-IpToSubnetCandidate.ps1
+++ b/modules/CybernetSubnetDiscovery/Convert-IpToSubnetCandidate.ps1
@@ -1,0 +1,173 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+function ConvertTo-IPv4Int {
+    param([string]$IPv4)
+    try {
+        $bytes = [System.Net.IPAddress]::Parse($IPv4).GetAddressBytes()
+        [array]::Reverse($bytes)
+        return [BitConverter]::ToUInt32($bytes, 0)
+    } catch {
+        return $null
+    }
+}
+
+function Split-Cidr {
+    param([string]$Cidr)
+    if ($Cidr -notmatch '^(\d{1,3}(?:\.\d{1,3}){3})/(\d{1,2})$') {
+        throw "Invalid CIDR format: $Cidr"
+    }
+    return @{
+        Network      = $Matches[1]
+        PrefixLength = [int]$Matches[2]
+    }
+}
+
+function Test-IpInSubnet {
+    param(
+        [string]$IPv4,
+        [string]$Cidr
+    )
+    $parts = Split-Cidr -Cidr $Cidr
+    $prefixLength = $parts.PrefixLength
+    if ($prefixLength -lt 0 -or $prefixLength -gt 32) { return $false }
+    if ($prefixLength -eq 0) { return $true }
+
+    $ipBytes = [System.Net.IPAddress]::Parse($IPv4).GetAddressBytes()
+    $netBytes = [System.Net.IPAddress]::Parse($parts.Network).GetAddressBytes()
+
+    $fullBytes = [math]::Floor($prefixLength / 8)
+    $remainder = $prefixLength % 8
+
+    for ($i = 0; $i -lt $fullBytes; $i++) {
+        if ($ipBytes[$i] -ne $netBytes[$i]) { return $false }
+    }
+
+    if ($remainder -gt 0) {
+        $mask = [byte](255 -band (255 -shl (8 - $remainder)))
+        if (($ipBytes[$fullBytes] -band $mask) -ne ($netBytes[$fullBytes] -band $mask)) { return $false }
+    }
+
+    return $true
+}
+
+function Test-IsPublicIPv4 {
+    param([string]$IPv4)
+    if ([string]::IsNullOrWhiteSpace($IPv4)) { return $false }
+    try {
+        $ip = [System.Net.IPAddress]::Parse($IPv4)
+    } catch {
+        return $true
+    }
+
+    if ($ip.AddressFamily -ne [System.Net.Sockets.AddressFamily]::InterNetwork) {
+        return $true
+    }
+
+    $privateRanges = @(
+        '10.0.0.0/8',
+        '172.16.0.0/12',
+        '192.168.0.0/16',
+        '100.64.0.0/10',
+        '169.254.0.0/16',
+        '127.0.0.0/8'
+    )
+
+    foreach ($range in $privateRanges) {
+        if (Test-IpInSubnet -IPv4 $IPv4 -Cidr $range) {
+            return $false
+        }
+    }
+
+    $documentationRanges = @(
+        '192.0.2.0/24',
+        '198.51.100.0/24',
+        '203.0.113.0/24'
+    )
+
+    foreach ($range in $documentationRanges) {
+        if (Test-IpInSubnet -IPv4 $IPv4 -Cidr $range) {
+            return $true
+        }
+    }
+
+    $firstOctet = [int]($IPv4.Split('.')[0])
+    if ($firstOctet -ge 224) { return $true }
+
+    return $true
+}
+
+function Test-SubnetApprovedForScan {
+    param(
+        [object]$SubnetRow,
+        [bool]$RequireApprovedSubnet = $true
+    )
+    if (-not $RequireApprovedSubnet) { return $true }
+    return [bool]$SubnetRow.ApprovedForScan
+}
+
+function Convert-IpToSubnetCandidate {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$IPv4,
+
+        [Parameter(Mandatory = $true)]
+        [object[]]$ApprovedSubnets,
+
+        [bool]$RequireApprovedSubnet = $true
+    )
+
+    if ([string]::IsNullOrWhiteSpace($IPv4)) {
+        return [pscustomobject]@{
+            IP              = ''
+            SubnetCandidate = ''
+            SubnetSource    = ''
+            ApprovedForScan = $false
+            IsPublic        = $false
+            Matched         = $false
+        }
+    }
+
+    $isPublic = Test-IsPublicIPv4 -IPv4 $IPv4
+    if ($isPublic) {
+        return [pscustomobject]@{
+            IP              = $IPv4
+            SubnetCandidate = ''
+            SubnetSource    = ''
+            ApprovedForScan = $false
+            IsPublic        = $true
+            Matched         = $false
+        }
+    }
+
+    $matches = @()
+    foreach ($subnet in $ApprovedSubnets) {
+        if (Test-IpInSubnet -IPv4 $IPv4 -Cidr $subnet.Subnet) {
+            $matches += $subnet
+        }
+    }
+
+    if (@($matches).Count -eq 0) {
+        return [pscustomobject]@{
+            IP              = $IPv4
+            SubnetCandidate = ''
+            SubnetSource    = ''
+            ApprovedForScan = $false
+            IsPublic        = $false
+            Matched         = $false
+        }
+    }
+
+    $best = $matches | Sort-Object -Property Subnet | Select-Object -First 1
+    $approved = Test-SubnetApprovedForScan -SubnetRow $best -RequireApprovedSubnet $RequireApprovedSubnet
+
+    return [pscustomobject]@{
+        IP              = $IPv4
+        SubnetCandidate = $best.Subnet
+        SubnetSource    = [string]$best.Source
+        ApprovedForScan = $approved
+        IsPublic        = $false
+        Matched         = $true
+    }
+}

--- a/modules/CybernetSubnetDiscovery/Import-CybernetSerialInventory.ps1
+++ b/modules/CybernetSubnetDiscovery/Import-CybernetSerialInventory.ps1
@@ -1,0 +1,240 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+function Normalize-CybernetSerial {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+    $clean = ($Value.Trim().ToUpperInvariant() -replace '\s+', '')
+    return $clean
+}
+
+function Normalize-CybernetMac {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+    $clean = ($Value.ToUpperInvariant().ToCharArray() | Where-Object { $_ -match '[0-9A-F]' }) -join ''
+    if ($clean.Length -ne 12) { return $clean }
+    $pairs = for ($i = 0; $i -lt 12; $i += 2) { $clean.Substring($i, 2) }
+    return ($pairs -join ':')
+}
+
+function Normalize-CybernetHostname {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+    $trimmed = $Value.Trim()
+    if ($trimmed -match '\.') { return $trimmed }
+    return $trimmed.ToUpperInvariant()
+}
+
+function ConvertTo-BooleanLike {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+    switch -Regex ($Value.Trim()) {
+        '^(?i)(true|yes|y|1)$' { return $true }
+        default { return $false }
+    }
+}
+
+function Get-CsvPropertyValue {
+    param(
+        [object]$Row,
+        [string[]]$Names
+    )
+    foreach ($name in $Names) {
+        $prop = $Row.PSObject.Properties[$name]
+        if ($prop -and -not [string]::IsNullOrWhiteSpace([string]$prop.Value)) {
+            return ([string]$prop.Value).Trim()
+        }
+    }
+    return ''
+}
+
+function Import-CybernetSerialInventory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Site
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Serial inventory file not found: $Path"
+    }
+
+    $rawRows = @(Import-Csv -LiteralPath $Path)
+    $normalized = New-Object System.Collections.Generic.List[object]
+    $duplicateSerials = New-Object System.Collections.Generic.List[string]
+
+    foreach ($row in $rawRows) {
+        $rowSite = Get-CsvPropertyValue -Row $row -Names @('Site')
+        if ($rowSite -and $rowSite -ne $Site) { continue }
+
+        $serial = Normalize-CybernetSerial -Value (Get-CsvPropertyValue -Row $row -Names @('Serial'))
+        if ([string]::IsNullOrWhiteSpace($serial)) { continue }
+
+        $normalized.Add([pscustomobject]@{
+            Site             = $Site
+            Serial           = $serial
+            ExpectedHostname = Normalize-CybernetHostname -Value (Get-CsvPropertyValue -Row $row -Names @('ExpectedHostname', 'Hostname'))
+            ExpectedMAC      = Normalize-CybernetMac -Value (Get-CsvPropertyValue -Row $row -Names @('ExpectedMAC', 'MAC'))
+            ExpectedRoom     = Get-CsvPropertyValue -Row $row -Names @('ExpectedRoom', 'Room')
+            ExpectedStatus   = Get-CsvPropertyValue -Row $row -Names @('ExpectedStatus', 'Status')
+            Notes            = Get-CsvPropertyValue -Row $row -Names @('Notes')
+            IP               = ''
+            SubnetCandidate  = ''
+            SubnetSource     = ''
+            Confidence       = 'Missing'
+            Evidence         = ''
+        }) | Out-Null
+    }
+
+    $groups = $normalized | Group-Object -Property Serial
+    foreach ($group in $groups) {
+        if ($group.Count -gt 1) {
+            $duplicateSerials.Add($group.Name) | Out-Null
+        }
+    }
+
+    return [pscustomobject]@{
+        Rows             = $normalized.ToArray()
+        DuplicateSerials = $duplicateSerials.ToArray()
+    }
+}
+
+function Import-CybernetSiteSubnets {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Site
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Site subnet file not found: $Path"
+    }
+
+    $rows = @(Import-Csv -LiteralPath $Path)
+    $subnets = New-Object System.Collections.Generic.List[object]
+
+    foreach ($row in $rows) {
+        $rowSite = Get-CsvPropertyValue -Row $row -Names @('Site', 'site_code', 'site')
+        if ($rowSite -and $rowSite -ne $Site) { continue }
+
+        $cidr = Get-CsvPropertyValue -Row $row -Names @('Subnet', 'subnet_cidr', 'cidr')
+        if ([string]::IsNullOrWhiteSpace($cidr)) { continue }
+
+        $subnets.Add([pscustomobject]@{
+            Site             = $Site
+            Subnet           = $cidr.Trim()
+            Description      = Get-CsvPropertyValue -Row $row -Names @('Description', 'notes', 'Notes')
+            ApprovedForScan  = ConvertTo-BooleanLike -Value (Get-CsvPropertyValue -Row $row -Names @('ApprovedForScan', 'enabled', 'Enabled'))
+            Source           = 'SiteSubnets'
+        }) | Out-Null
+    }
+
+    return $subnets.ToArray()
+}
+
+function Import-CybernetApprovedSubnetsJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Site
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Approved subnets JSON file not found: $Path"
+    }
+
+    $json = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    $subnets = New-Object System.Collections.Generic.List[object]
+
+    foreach ($entry in @($json.subnets)) {
+        $entrySite = [string]$entry.site
+        if ($entrySite -and $entrySite -ne $Site) { continue }
+
+        $cidr = [string]$entry.cidr
+        if ([string]::IsNullOrWhiteSpace($cidr)) { continue }
+
+        $subnets.Add([pscustomobject]@{
+            Site             = $Site
+            Subnet           = $cidr.Trim()
+            Description      = [string]$entry.description
+            ApprovedForScan  = [bool]$entry.approvedForScan
+            Source           = 'ApprovedSubnets'
+        }) | Out-Null
+    }
+
+    return $subnets.ToArray()
+}
+
+function Merge-CybernetKnownData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$InventoryRows,
+
+        [string]$KnownHostsPath,
+        [string]$KnownMacsPath
+    )
+
+    $hostMap = @{}
+    $macMap = @{}
+
+    if ($KnownHostsPath -and (Test-Path -LiteralPath $KnownHostsPath)) {
+        foreach ($row in @(Import-Csv -LiteralPath $KnownHostsPath)) {
+            $serial = Normalize-CybernetSerial -Value (Get-CsvPropertyValue -Row $row -Names @('Serial'))
+            $hostname = Normalize-CybernetHostname -Value (Get-CsvPropertyValue -Row $row -Names @('ExpectedHostname', 'Hostname'))
+            $ip = Get-CsvPropertyValue -Row $row -Names @('IP', 'IPAddress')
+            if ($serial) { $hostMap[$serial] = @{ Hostname = $hostname; IP = $ip } }
+        }
+    }
+
+    if ($KnownMacsPath -and (Test-Path -LiteralPath $KnownMacsPath)) {
+        foreach ($row in @(Import-Csv -LiteralPath $KnownMacsPath)) {
+            $serial = Normalize-CybernetSerial -Value (Get-CsvPropertyValue -Row $row -Names @('Serial'))
+            $mac = Normalize-CybernetMac -Value (Get-CsvPropertyValue -Row $row -Names @('ExpectedMAC', 'MAC'))
+            if ($serial) { $macMap[$serial] = $mac }
+        }
+    }
+
+    $merged = foreach ($row in $InventoryRows) {
+        $copy = [pscustomobject]@{
+            Site             = $row.Site
+            Serial           = $row.Serial
+            ExpectedHostname = $row.ExpectedHostname
+            ExpectedMAC      = $row.ExpectedMAC
+            ExpectedRoom     = $row.ExpectedRoom
+            ExpectedStatus   = $row.ExpectedStatus
+            Notes            = $row.Notes
+            IP               = $row.IP
+            SubnetCandidate  = $row.SubnetCandidate
+            SubnetSource     = $row.SubnetSource
+            Confidence       = $row.Confidence
+            Evidence         = $row.Evidence
+        }
+
+        if ($hostMap.ContainsKey($row.Serial)) {
+            if ([string]::IsNullOrWhiteSpace($copy.ExpectedHostname)) {
+                $copy.ExpectedHostname = $hostMap[$row.Serial].Hostname
+            }
+            if ([string]::IsNullOrWhiteSpace($copy.IP)) {
+                $copy.IP = $hostMap[$row.Serial].IP
+            }
+        }
+
+        if ($macMap.ContainsKey($row.Serial) -and [string]::IsNullOrWhiteSpace($copy.ExpectedMAC)) {
+            $copy.ExpectedMAC = $macMap[$row.Serial]
+        }
+
+        $copy
+    }
+
+    return @($merged)
+}

--- a/modules/CybernetSubnetDiscovery/Invoke-SASCybernetSubnetDiscovery.ps1
+++ b/modules/CybernetSubnetDiscovery/Invoke-SASCybernetSubnetDiscovery.ps1
@@ -1,0 +1,144 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Cybernet subnet discovery — serial inventory to approved scanner scope.
+
+.DESCRIPTION
+  Imports Cybernet serial inventory, normalizes identity fields, optionally resolves DNS,
+  maps IPs to approved site subnets, and emits technician-readable artifacts plus
+  deterministic Naabu/Nmap command strings (recorded only, never executed).
+
+.EXAMPLE
+  .\Invoke-SASCybernetSubnetDiscovery.ps1 `
+    -Site "SSUH" `
+    -SerialInventoryPath ".\input\cybernet-serials.example.csv" `
+    -SiteSubnetsPath ".\input\site-subnets.example.csv" `
+    -UseDns `
+    -GenerateSurveyTargets `
+    -OutDir ".\evidence\CybernetSubnetDiscovery\SSUH"
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Site,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SerialInventoryPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SiteSubnetsPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutDir,
+
+    [string]$KnownHostsPath,
+    [string]$KnownMacsPath,
+    [string]$ApprovedSubnetsPath,
+    [string]$DnsSuffix,
+
+    [switch]$UseDns,
+    [switch]$GenerateSurveyTargets
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$moduleRoot = $PSScriptRoot
+$repoRoot = Split-Path -Parent (Split-Path -Parent $moduleRoot)
+
+. (Join-Path $moduleRoot 'Import-CybernetSerialInventory.ps1')
+. (Join-Path $moduleRoot 'Convert-IpToSubnetCandidate.ps1')
+. (Join-Path $moduleRoot 'Resolve-CybernetDnsIdentity.ps1')
+. (Join-Path $moduleRoot 'New-CybernetSubnetDiscoveryReport.ps1')
+
+$rulesPath = Join-Path $repoRoot 'config/cybernet-subnet-rules.json'
+$portProfilePath = Join-Path $repoRoot 'config/cybernet-port-profile.json'
+$rules = Get-Content -LiteralPath $rulesPath -Raw | ConvertFrom-Json
+$requireApprovedSubnet = [bool]$rules.subnetInference.requireApprovedSubnet
+$whatIfMode = [bool]$WhatIfPreference
+
+$evidenceLog = New-Object System.Collections.Generic.List[string]
+Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'Start' -Action 'InvokeDiscovery' -Detail "Site=$Site OutDir=$OutDir"
+
+$importResult = Import-CybernetSerialInventory -Path $SerialInventoryPath -Site $Site
+$inventory = @($importResult.Rows)
+Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'Import' -Action 'SerialInventory' -Detail "Imported $(@($inventory).Count) row(s); duplicates=$(@($importResult.DuplicateSerials).Count)"
+
+$inventory = Merge-CybernetKnownData -InventoryRows $inventory -KnownHostsPath $KnownHostsPath -KnownMacsPath $KnownMacsPath
+
+$siteSubnets = Import-CybernetSiteSubnets -Path $SiteSubnetsPath -Site $Site
+if ($ApprovedSubnetsPath) {
+    $jsonSubnets = Import-CybernetApprovedSubnetsJson -Path $ApprovedSubnetsPath -Site $Site
+    $siteSubnets = @($siteSubnets + $jsonSubnets)
+}
+Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'Import' -Action 'SiteSubnets' -Detail "Loaded $(@($siteSubnets).Count) subnet row(s)"
+
+$dnsResolvedCount = 0
+if ($UseDns) {
+    $beforeIps = @($inventory | Where-Object { $_.IP } | Measure-Object).Count
+    $inventory = Apply-CybernetDnsToInventory -InventoryRows $inventory -DnsSuffix $DnsSuffix
+    $afterIps = @($inventory | Where-Object { $_.IP } | Measure-Object).Count
+    $dnsResolvedCount = $afterIps - $beforeIps
+    Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'DNS' -Action 'ForwardResolve' -Detail "Resolved $dnsResolvedCount new IP(s)"
+}
+
+$subnetMatches = New-Object System.Collections.Generic.List[object]
+foreach ($row in $inventory) {
+    $match = Convert-IpToSubnetCandidate -IPv4 $row.IP -ApprovedSubnets $siteSubnets -RequireApprovedSubnet $requireApprovedSubnet
+    $subnetMatches.Add($match) | Out-Null
+
+    if ($match.IsPublic) {
+        Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'Safety' -Action 'RejectPublicIp' -Detail "Serial=$($row.Serial) IP=$($row.IP)"
+    } elseif ($match.Matched -and -not $match.ApprovedForScan) {
+        Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'Safety' -Action 'RejectUnapprovedSubnet' -Detail "Serial=$($row.Serial) IP=$($row.IP) Subnet=$($match.SubnetCandidate)"
+    }
+}
+
+$identityMap = New-CybernetIdentityMapRows -InventoryRows $inventory -SubnetMatches $subnetMatches.ToArray()
+$subnetsToSurvey = New-CybernetSubnetsToSurveyRows -IdentityMapRows $identityMap
+$targetIps = New-CybernetTargetIpList -IdentityMapRows $identityMap
+$actionItems = New-CybernetActionItemsMarkdown -IdentityMapRows $identityMap -DuplicateSerials $importResult.DuplicateSerials
+
+$scannerCommands = @()
+if ($GenerateSurveyTargets -and @($targetIps).Count -gt 0) {
+    . (Join-Path $repoRoot 'modules/CybernetSurvey/New-CybernetScannerCommand.ps1')
+    $targetFile = Join-Path $OutDir 'CybernetSubnetDiscovery_TargetIPs.txt'
+    $surveyOutDir = Join-Path (Join-Path (Split-Path -Parent (Split-Path -Parent $OutDir)) 'CybernetSurvey') $Site
+    $scannerCommands = New-CybernetScannerCommands -TargetFile $targetFile -SurveyOutDir $surveyOutDir -PortProfilePath $portProfilePath
+    foreach ($cmd in $scannerCommands) {
+        Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'ScannerHandoff' -Action 'GenerateCommand' -Detail "$($cmd.Scanner) command prepared (not executed)" -Command $cmd.Command
+    }
+}
+
+$summary = New-CybernetDiscoverySummary -Site $Site -IdentityMapRows $identityMap -TargetIps $targetIps -DuplicateSerials $importResult.DuplicateSerials -DnsResolvedCount $dnsResolvedCount -Extra @{
+    scannerCommandsGenerated = @($scannerCommands).Count
+    whatIf                   = $whatIfMode
+}
+
+$normalizedSerials = foreach ($row in $identityMap) {
+    [pscustomobject]@{
+        Site             = $row.Site
+        Serial           = $row.Serial
+        ExpectedHostname = $row.Hostname
+        ExpectedMAC      = $row.MAC
+        IP               = $row.IP
+        SubnetCandidate  = $row.SubnetCandidate
+        Confidence       = $row.Confidence
+    }
+}
+
+Write-CybernetEvidenceLogEntry -LogEntries $evidenceLog -Stage 'Complete' -Action 'ExportArtifacts' -Detail "WhatIf=$whatIfMode"
+
+$result = Export-CybernetSubnetDiscoveryArtifacts `
+    -OutDir $OutDir `
+    -NormalizedSerials @($normalizedSerials) `
+    -IdentityMapRows $identityMap `
+    -SubnetsToSurveyRows $subnetsToSurvey `
+    -TargetIps $targetIps `
+    -Summary $summary `
+    -ActionItemsMarkdown $actionItems `
+    -EvidenceLogEntries $evidenceLog.ToArray() `
+    -WhatIf:$whatIfMode
+
+Write-Output $summary
+return $result

--- a/modules/CybernetSubnetDiscovery/Invoke-SASCybernetSubnetDiscovery.ps1
+++ b/modules/CybernetSubnetDiscovery/Invoke-SASCybernetSubnetDiscovery.ps1
@@ -51,8 +51,8 @@ $repoRoot = Split-Path -Parent (Split-Path -Parent $moduleRoot)
 . (Join-Path $moduleRoot 'Resolve-CybernetDnsIdentity.ps1')
 . (Join-Path $moduleRoot 'New-CybernetSubnetDiscoveryReport.ps1')
 
-$rulesPath = Join-Path $repoRoot 'config/cybernet-subnet-rules.json'
-$portProfilePath = Join-Path $repoRoot 'config/cybernet-port-profile.json'
+$rulesPath = Join-Path $repoRoot 'Config/cybernet-subnet-rules.json'
+$portProfilePath = Join-Path $repoRoot 'Config/cybernet-port-profile.json'
 $rules = Get-Content -LiteralPath $rulesPath -Raw | ConvertFrom-Json
 $requireApprovedSubnet = [bool]$rules.subnetInference.requireApprovedSubnet
 $whatIfMode = [bool]$WhatIfPreference

--- a/modules/CybernetSubnetDiscovery/Invoke-SASCybernetSubnetDiscovery.ps1
+++ b/modules/CybernetSubnetDiscovery/Invoke-SASCybernetSubnetDiscovery.ps1
@@ -8,6 +8,13 @@
   maps IPs to approved site subnets, and emits technician-readable artifacts plus
   deterministic Naabu/Nmap command strings (recorded only, never executed).
 
+  PowerShell support is retained for PowerShell-enabled environments and as a reference
+  implementation. For Northwell-targeted workflows, PowerShell is deprecated. Prefer
+  Bash-first workflows that consume approved AD exports and write local evidence only.
+
+  Scanner handoff strings are reference only. Bash survey orchestration and Naabu/Nmap
+  pipelines remain the execution authority for Northwell field work.
+
 .EXAMPLE
   .\Invoke-SASCybernetSubnetDiscovery.ps1 `
     -Site "SSUH" `

--- a/modules/CybernetSubnetDiscovery/New-CybernetSubnetDiscoveryReport.ps1
+++ b/modules/CybernetSubnetDiscovery/New-CybernetSubnetDiscoveryReport.ps1
@@ -1,0 +1,277 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+function Get-CybernetIdentityConfidence {
+    param(
+        [object]$Row,
+        [object]$SubnetMatch
+    )
+
+    $hasSerial = -not [string]::IsNullOrWhiteSpace($Row.Serial)
+    $hasHostname = -not [string]::IsNullOrWhiteSpace($Row.ExpectedHostname)
+    $hasMac = -not [string]::IsNullOrWhiteSpace($Row.ExpectedMAC)
+    $hasIp = -not [string]::IsNullOrWhiteSpace($Row.IP)
+    $subnetApproved = $SubnetMatch -and $SubnetMatch.Matched -and $SubnetMatch.ApprovedForScan
+    $subnetMatched = $SubnetMatch -and $SubnetMatch.Matched
+    $isPublic = $SubnetMatch -and $SubnetMatch.IsPublic
+
+    if ($isPublic -or ($hasIp -and $subnetMatched -and -not $subnetApproved)) {
+        return 'Blocked'
+    }
+
+    if ($hasSerial -and ($hasHostname -or $hasMac) -and $hasIp -and $subnetApproved) {
+        return 'Confirmed'
+    }
+
+    if ($hasHostname -and $hasIp -and $subnetApproved) {
+        return 'High'
+    }
+
+    if (($hasMac -or $hasIp) -and $subnetApproved) {
+        return 'Medium'
+    }
+
+    if ($hasIp -and -not $subnetApproved) {
+        return 'Weak'
+    }
+
+    if ($hasSerial -and -not $hasHostname -and -not $hasMac -and -not $hasIp) {
+        return 'Missing'
+    }
+
+    if (-not $hasIp -and -not $hasHostname -and -not $hasMac) {
+        return 'Missing'
+    }
+
+    return 'Missing'
+}
+
+function New-CybernetIdentityMapRows {
+    param(
+        [object[]]$InventoryRows,
+        [object[]]$SubnetMatches
+    )
+
+    $rows = New-Object System.Collections.Generic.List[object]
+    for ($i = 0; $i -lt @($InventoryRows).Count; $i++) {
+        $row = $InventoryRows[$i]
+        $match = $SubnetMatches[$i]
+        $confidence = Get-CybernetIdentityConfidence -Row $row -SubnetMatch $match
+
+        $evidence = $row.Evidence
+        if ($match.IsPublic) {
+            $evidence = 'Public IP rejected by default'
+        } elseif ($match.Matched -and -not $match.ApprovedForScan) {
+            $evidence = 'Subnet found but not approved for scan'
+        } elseif ($confidence -eq 'Missing') {
+            $evidence = 'Serial has no hostname, MAC, IP, or subnet bridge'
+        } elseif ([string]::IsNullOrWhiteSpace($evidence)) {
+            $evidence = "Classified as $confidence"
+        }
+
+        $rows.Add([pscustomobject]@{
+            Site             = $row.Site
+            Serial           = $row.Serial
+            Hostname         = $row.ExpectedHostname
+            MAC              = $row.ExpectedMAC
+            IP               = $row.IP
+            SubnetCandidate  = $match.SubnetCandidate
+            SubnetSource     = $match.SubnetSource
+            Confidence       = $confidence
+            Evidence         = $evidence
+        }) | Out-Null
+    }
+
+    return $rows.ToArray()
+}
+
+function New-CybernetSubnetsToSurveyRows {
+    param([object[]]$IdentityMapRows)
+
+    $grouped = $IdentityMapRows |
+        Where-Object { $_.SubnetCandidate -and $_.Confidence -in @('Confirmed', 'High', 'Medium') } |
+        Group-Object -Property SubnetCandidate
+
+    $output = New-Object System.Collections.Generic.List[object]
+    foreach ($group in @($grouped)) {
+        $bestConfidence = ($group.Group.Confidence | Sort-Object -Unique)[0]
+        $output.Add([pscustomobject]@{
+            Site             = ($group.Group | Select-Object -First 1).Site
+            Subnet           = $group.Name
+            Reason           = "Matched known Cybernet DNS/IP evidence $(@($group.Group).Count) record(s)"
+            Confidence       = $bestConfidence
+            ApprovedForScan  = 'true'
+        }) | Out-Null
+    }
+
+    return @($output.ToArray() | Sort-Object Subnet)
+}
+
+function New-CybernetTargetIpList {
+    param([object[]]$IdentityMapRows)
+
+    $ips = @($IdentityMapRows |
+        Where-Object { $_.IP -and $_.Confidence -in @('Confirmed', 'High', 'Medium') } |
+        Select-Object -ExpandProperty IP -Unique |
+        Sort-Object)
+
+    if (@($ips).Count -eq 0) {
+        return @()
+    }
+
+    return [string[]]$ips
+}
+
+function New-CybernetActionItemsMarkdown {
+    param(
+        [object[]]$IdentityMapRows,
+        [string[]]$DuplicateSerials
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    $lines.Add('# Cybernet Subnet Discovery Action Items') | Out-Null
+    $lines.Add('') | Out-Null
+
+    foreach ($serial in @($DuplicateSerials)) {
+        $lines.Add("- **Duplicate serial**: Review inventory for serial '$serial' - multiple rows share this identity anchor.") | Out-Null
+    }
+
+    foreach ($row in $IdentityMapRows) {
+        if ($row.Confidence -eq 'Missing') {
+            $lines.Add("- **Missing bridge** [$($row.Serial)]: Add hostname, MAC, or infrastructure export to connect serial to approved subnet scope.") | Out-Null
+        }
+        if ($row.Confidence -eq 'Blocked') {
+            $lines.Add("- **Blocked scope** [$($row.Serial)]: $($row.Evidence). Do not scan until subnet is approved or IP is corrected.") | Out-Null
+        }
+    }
+
+    if ($lines.Count -le 2) {
+        $lines.Add('- No action items. Approved scope is ready for technician review.') | Out-Null
+    }
+
+    return ($lines -join [Environment]::NewLine)
+}
+
+function New-CybernetDiscoverySummary {
+    param(
+        [string]$Site,
+        [object[]]$IdentityMapRows,
+        [object[]]$TargetIps,
+        [string[]]$DuplicateSerials,
+        [int]$DnsResolvedCount,
+        [hashtable]$Extra = @{}
+    )
+
+    $IdentityMapRows = @($IdentityMapRows)
+    $TargetIps = @($TargetIps)
+    $DuplicateSerials = @($DuplicateSerials)
+
+    $confidenceCounts = @{}
+    foreach ($level in @('Confirmed', 'High', 'Medium', 'Weak', 'Blocked', 'Missing')) {
+        $confidenceCounts[$level] = ($IdentityMapRows | Where-Object { $_.Confidence -eq $level } | Measure-Object).Count
+    }
+
+    $summary = [ordered]@{
+        site               = $Site
+        generatedAtUtc     = (Get-Date).ToUniversalTime().ToString('o')
+        recordCount        = ($IdentityMapRows | Measure-Object).Count
+        targetIpCount      = ($TargetIps | Measure-Object).Count
+        duplicateSerials   = @($DuplicateSerials)
+        dnsResolvedCount   = $DnsResolvedCount
+        confidenceCounts   = $confidenceCounts
+        blockedPublicCount = ($IdentityMapRows | Where-Object { $_.Evidence -like '*Public IP*' } | Measure-Object).Count
+        blockedSubnetCount = ($IdentityMapRows | Where-Object { $_.Evidence -like '*not approved*' } | Measure-Object).Count
+    }
+
+    foreach ($key in $Extra.Keys) {
+        $summary[$key] = $Extra[$key]
+    }
+
+    return [pscustomobject]$summary
+}
+
+function Write-CybernetEvidenceLogEntry {
+    param(
+        [AllowEmptyCollection()]
+        [System.Collections.Generic.List[string]]$LogEntries,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Stage,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Action,
+
+        [string]$Detail,
+        [string]$Command
+    )
+
+    $entry = [ordered]@{
+        timestamp = (Get-Date).ToUniversalTime().ToString('o')
+        stage     = $Stage
+        action    = $Action
+        detail    = $Detail
+    }
+    if ($Command) { $entry.command = $Command }
+
+    $LogEntries.Add(($entry | ConvertTo-Json -Compress)) | Out-Null
+}
+
+function Export-CybernetSubnetDiscoveryArtifacts {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OutDir,
+
+        [object[]]$NormalizedSerials,
+        [object[]]$IdentityMapRows,
+        [object[]]$SubnetsToSurveyRows,
+        [string[]]$TargetIps,
+        [object]$Summary,
+        [string]$ActionItemsMarkdown,
+        [string[]]$EvidenceLogEntries,
+
+        [switch]$WhatIf
+    )
+
+    $files = @{
+        NormalizedSerials = Join-Path $OutDir 'CybernetSubnetDiscovery_NormalizedSerials.csv'
+        IdentityMap       = Join-Path $OutDir 'CybernetSubnetDiscovery_IdentityMap.csv'
+        SubnetsToSurvey   = Join-Path $OutDir 'CybernetSubnetDiscovery_SubnetsToSurvey.csv'
+        TargetIPs         = Join-Path $OutDir 'CybernetSubnetDiscovery_TargetIPs.txt'
+        Summary           = Join-Path $OutDir 'CybernetSubnetDiscovery_Summary.json'
+        ActionItems       = Join-Path $OutDir 'CybernetSubnetDiscovery_ActionItems.md'
+        EvidenceLog       = Join-Path $OutDir 'CybernetSubnetDiscovery_EvidenceLog.jsonl'
+    }
+
+    if ($WhatIf) {
+        return [pscustomobject]@{
+            OutDir = $OutDir
+            Files  = $files
+            WhatIf = $true
+        }
+    }
+
+    New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+    @($NormalizedSerials) | Export-Csv -LiteralPath $files.NormalizedSerials -NoTypeInformation
+    @($IdentityMapRows) | Export-Csv -LiteralPath $files.IdentityMap -NoTypeInformation
+    if (($SubnetsToSurveyRows | Measure-Object).Count -gt 0) {
+        @($SubnetsToSurveyRows) | Export-Csv -LiteralPath $files.SubnetsToSurvey -NoTypeInformation
+    } else {
+        'Site,Subnet,Reason,Confidence,ApprovedForScan' | Set-Content -LiteralPath $files.SubnetsToSurvey -Encoding UTF8
+    }
+    if (($TargetIps | Measure-Object).Count -gt 0) {
+        @($TargetIps) | Set-Content -LiteralPath $files.TargetIPs -Encoding UTF8
+    } else {
+        '' | Set-Content -LiteralPath $files.TargetIPs -Encoding UTF8
+    }
+    ($Summary | ConvertTo-Json -Depth 6) | Set-Content -LiteralPath $files.Summary -Encoding UTF8
+    $ActionItemsMarkdown | Set-Content -LiteralPath $files.ActionItems -Encoding UTF8
+    @($EvidenceLogEntries) | Set-Content -LiteralPath $files.EvidenceLog -Encoding UTF8
+
+    return [pscustomobject]@{
+        OutDir = $OutDir
+        Files  = $files
+        WhatIf = $false
+    }
+}

--- a/modules/CybernetSubnetDiscovery/Resolve-CybernetDnsIdentity.ps1
+++ b/modules/CybernetSubnetDiscovery/Resolve-CybernetDnsIdentity.ps1
@@ -1,0 +1,169 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+function ConvertFrom-DnsResolutionResult {
+    param(
+        [string]$QueryName,
+        [object[]]$DnsResults,
+        [string]$Source = 'DNS'
+    )
+
+    $records = New-Object System.Collections.Generic.List[object]
+    foreach ($result in @($DnsResults)) {
+        if ($null -eq $result) { continue }
+
+        $recordType = ''
+        if ($result.PSObject.Properties['Type']) {
+            $recordType = [string]$result.Type
+        }
+
+        $ip = ''
+        if ($result.PSObject.Properties['IPAddress']) {
+            $ip = [string]$result.IPAddress
+        }
+
+        if ([string]::IsNullOrWhiteSpace($ip) -and $recordType -eq 'A' -and $result.PSObject.Properties['NameHost']) {
+            continue
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($ip)) {
+            $records.Add([pscustomobject]@{
+                Hostname   = $QueryName
+                IP         = $ip
+                RecordType = if ($recordType) { $recordType } else { 'A' }
+                Source     = $Source
+            }) | Out-Null
+        }
+    }
+
+    return $records.ToArray()
+}
+
+function Resolve-CybernetDnsForward {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Hostname,
+
+        [string]$DnsSuffix,
+        [scriptblock]$DnsResolver
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Hostname)) {
+        return @()
+    }
+
+    if (-not $DnsResolver) {
+        $DnsResolver = {
+            param($Name)
+            Resolve-DnsName -Name $Name -Type A -ErrorAction Stop
+        }
+    }
+
+    $namesToTry = New-Object System.Collections.Generic.List[string]
+    $namesToTry.Add($Hostname) | Out-Null
+    if ($DnsSuffix -and $Hostname -notmatch '\.') {
+        $namesToTry.Add("$Hostname.$DnsSuffix") | Out-Null
+    }
+
+    $allRecords = New-Object System.Collections.Generic.List[object]
+    foreach ($name in $namesToTry) {
+        try {
+            $results = & $DnsResolver $name
+            $parsed = @(ConvertFrom-DnsResolutionResult -QueryName $name -DnsResults @($results) -Source 'DNS-Forward')
+            foreach ($record in $parsed) {
+                $allRecords.Add($record) | Out-Null
+            }
+            if (@($parsed).Count -gt 0) { break }
+        } catch {
+            continue
+        }
+    }
+
+    return $allRecords.ToArray()
+}
+
+function Resolve-CybernetDnsReverse {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$IPv4,
+
+        [scriptblock]$DnsResolver
+    )
+
+    if ([string]::IsNullOrWhiteSpace($IPv4)) {
+        return @()
+    }
+
+    if (-not $DnsResolver) {
+        $DnsResolver = {
+            param($Name)
+            Resolve-DnsName -Name $Name -Type PTR -ErrorAction Stop
+        }
+    }
+
+    try {
+        $results = & $DnsResolver $IPv4
+        $hostname = ''
+        foreach ($result in @($results)) {
+            if ($result.PSObject.Properties['NameHost'] -and $result.NameHost) {
+                $hostname = [string]$result.NameHost
+                break
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($hostname)) {
+            return @()
+        }
+
+        return @([pscustomobject]@{
+            Hostname   = $hostname.TrimEnd('.')
+            IP         = $IPv4
+            RecordType = 'PTR'
+            Source     = 'DNS-Reverse'
+        })
+    } catch {
+        return @()
+    }
+}
+
+function Apply-CybernetDnsToInventory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$InventoryRows,
+
+        [string]$DnsSuffix,
+        [scriptblock]$DnsResolver
+    )
+
+    $updated = foreach ($row in $InventoryRows) {
+        $copy = [pscustomobject]@{
+            Site             = $row.Site
+            Serial           = $row.Serial
+            ExpectedHostname = $row.ExpectedHostname
+            ExpectedMAC      = $row.ExpectedMAC
+            ExpectedRoom     = $row.ExpectedRoom
+            ExpectedStatus   = $row.ExpectedStatus
+            Notes            = $row.Notes
+            IP               = $row.IP
+            SubnetCandidate  = $row.SubnetCandidate
+            SubnetSource     = $row.SubnetSource
+            Confidence       = $row.Confidence
+            Evidence         = $row.Evidence
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($copy.ExpectedHostname) -and [string]::IsNullOrWhiteSpace($copy.IP)) {
+            $records = Resolve-CybernetDnsForward -Hostname $copy.ExpectedHostname -DnsSuffix $DnsSuffix -DnsResolver $DnsResolver
+            if (@($records).Count -gt 0) {
+                $copy.IP = $records[0].IP
+                $copy.Evidence = "DNS forward resolved $($copy.ExpectedHostname) to $($copy.IP)"
+            }
+        }
+
+        $copy
+    }
+
+    return @($updated)
+}

--- a/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
+++ b/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
@@ -1,0 +1,111 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+function Get-CybernetPortProfile {
+    param([string]$ProfilePath)
+
+    if (-not (Test-Path -LiteralPath $ProfilePath)) {
+        throw "Port profile not found: $ProfilePath"
+    }
+
+    $json = Get-Content -LiteralPath $ProfilePath -Raw | ConvertFrom-Json
+    $profile = $json.profiles.CybernetWindowsEndpoint
+    if (-not $profile) {
+        throw 'CybernetWindowsEndpoint profile missing from port profile JSON'
+    }
+
+    return $profile
+}
+
+function New-CybernetNaabuCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TargetFile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputFile,
+
+        [object]$Profile
+    )
+
+    $ports = ($Profile.ports | ForEach-Object { [string]$_ }) -join ','
+    $command = "naabu -list $TargetFile -p $ports -rate $($Profile.defaultRate) -c $($Profile.defaultConcurrency) -retries $($Profile.retries) -timeout $($Profile.timeoutMs) -json -silent -duc -o $OutputFile"
+
+    return [pscustomobject]@{
+        Scanner    = 'Naabu'
+        Command    = $command
+        TargetFile = $TargetFile
+        OutputFile = $OutputFile
+    }
+}
+
+function New-CybernetNmapHostDiscoveryCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TargetFile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputFile
+    )
+
+    $command = "nmap -sn -iL $TargetFile -oX $OutputFile"
+
+    return [pscustomobject]@{
+        Scanner    = 'Nmap'
+        Command    = $command
+        TargetFile = $TargetFile
+        OutputFile = $OutputFile
+    }
+}
+
+function New-CybernetNmapSelectedPortCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TargetFile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputFile,
+
+        [object]$Profile
+    )
+
+    $ports = ($Profile.ports | ForEach-Object { [string]$_ }) -join ','
+    $command = "nmap -p $ports --open -iL $TargetFile -oX $OutputFile"
+
+    return [pscustomobject]@{
+        Scanner    = 'Nmap'
+        Command    = $command
+        TargetFile = $TargetFile
+        OutputFile = $OutputFile
+    }
+}
+
+function New-CybernetScannerCommands {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TargetFile,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SurveyOutDir,
+
+        [string]$PortProfilePath
+    )
+
+    if (-not $PortProfilePath) {
+        $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        $PortProfilePath = Join-Path $repoRoot 'config/cybernet-port-profile.json'
+    }
+
+    $profile = Get-CybernetPortProfile -ProfilePath $PortProfilePath
+
+    $naabuOut = Join-Path $SurveyOutDir 'CybernetSurvey_Naabu.jsonl'
+    $nmapSnOut = Join-Path $SurveyOutDir 'CybernetSurvey_NmapHostDiscovery.xml'
+    $nmapPortOut = Join-Path $SurveyOutDir 'CybernetSurvey_NmapPorts.xml'
+
+    return @(
+        (New-CybernetNaabuCommand -TargetFile $TargetFile -OutputFile $naabuOut -Profile $profile)
+        (New-CybernetNmapHostDiscoveryCommand -TargetFile $TargetFile -OutputFile $nmapSnOut)
+        (New-CybernetNmapSelectedPortCommand -TargetFile $TargetFile -OutputFile $nmapPortOut -Profile $profile)
+    )
+}

--- a/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
+++ b/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
@@ -94,7 +94,7 @@ function New-CybernetScannerCommands {
 
     if (-not $PortProfilePath) {
         $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-        $PortProfilePath = Join-Path $repoRoot 'config/cybernet-port-profile.json'
+        $PortProfilePath = Join-Path $repoRoot 'Config/cybernet-port-profile.json'
     }
 
     $profile = Get-CybernetPortProfile -ProfilePath $PortProfilePath

--- a/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
+++ b/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
@@ -29,7 +29,16 @@ function New-CybernetNaabuCommand {
     )
 
     $ports = ($Profile.ports | ForEach-Object { [string]$_ }) -join ','
-    $command = "naabu -list $TargetFile -p $ports -rate $($Profile.defaultRate) -c $($Profile.defaultConcurrency) -retries $($Profile.retries) -timeout $($Profile.timeoutMs) -json -silent -duc -o $OutputFile"
+
+    # CDN exclusion (-ec) mirrors Config/cybernet-naabu-profiles.json windows_selected doctrine:
+    # it caps CDN/cloud-edge hosts to avoid wasteful probing. Record-only; never executed here.
+    $excludeCdn = $false
+    if ($Profile.PSObject.Properties.Name -contains 'excludeCdn') {
+        $excludeCdn = [bool]$Profile.excludeCdn
+    }
+    $ecFlag = if ($excludeCdn) { ' -ec' } else { '' }
+
+    $command = "naabu -list $TargetFile -p $ports -rate $($Profile.defaultRate) -c $($Profile.defaultConcurrency) -retries $($Profile.retries) -timeout $($Profile.timeoutMs)$ecFlag -json -silent -duc -o $OutputFile"
 
     return [pscustomobject]@{
         Scanner    = 'Naabu'


### PR DESCRIPTION
## **User description**
## Summary

This PR preserves a PowerShell-enabled discovery MVP for environments where PowerShell is approved. It is not the Northwell-forward path. For Northwell, use Bash-first workflows, approved AD exports, logs/targets, Naabu/Nmap reachability validation, and local evidence packaging.

PowerShell support is retained for PowerShell-enabled environments and as a reference implementation. For Northwell-targeted workflows, PowerShell is deprecated. Prefer Bash-first workflows that consume approved AD exports and write local evidence only.

### What this adds (legacy / PS-enabled lane)

- `modules/CybernetSubnetDiscovery/` — serial inventory import, DNS identity resolution, approved subnet matching, confidence scoring, artifact export
- `modules/CybernetSurvey/New-CybernetScannerCommand.ps1` — deterministic Naabu/Nmap **handoff strings only** (recorded, never executed)
- `Config/cybernet-subnet-rules.json`, `Config/cybernet-port-profile.json`, `Config/approved-subnets.example.json`
- `Tests/Pester/CybernetSubnetDiscovery.Tests.ps1` — 22 contract tests
- Example inputs under `input/`

### Lane separation

| Lane | Role |
|------|------|
| **PowerShell (this PR)** | Serial-led scope definition and artifact export for PS-enabled orgs |
| **Bash (main)** | Survey orchestration, Naabu/Nmap execution, evidence packaging |
| **AD exports** | Population and identity context authority |
| **Naabu/Nmap** | Reachability validation only |

PS-generated scanner commands are **handoff/reference strings only**, not execution authority. PS does not execute Naabu/Nmap. PS is **not required** for WAB Phase 2b.

### Rebase and integration (Agent E2)

- **Base:** `main` (rebased from stale `docs/cybernet-neuron-survey-tutorial`)
- **`.gitignore`:** Preserved `bin/*`, `logs/network_context/*`, `logs/nmap/*`, `evidence/*`, and input CSV exceptions
- **CDN/low-noise alignment:** PS Naabu handoff strings mirror `windows_selected` doctrine — ports `135,139,445,3389,5985,5986,80,443` with `-ec`; no 8080/8443

### Test results

| Suite | Result |
|-------|--------|
| Targeted Pester (`CybernetSubnetDiscovery.Tests.ps1`) | **22/22 PASS** |
| Full Pester (`Test-Pester5Suite.ps1`) | **374 pass / 46 fail** — failures are **pre-existing** (missing Neuron/DeploymentTracker fixture files on main; unrelated to this PR) |
| Bash `test_naabu_pipeline_contracts.sh` | **PASS** |
| Bash `test_naabu_package_contracts.sh` | **PASS** |
| Bash `test-cybernet-subnet-survey-contracts.sh` | **PASS** |

### Test plan

```powershell
Invoke-Pester Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
Import-Module ./modules/CybernetSubnetDiscovery -ErrorAction SilentlyContinue
.\modules\CybernetSubnetDiscovery\Invoke-SASCybernetSubnetDiscovery.ps1 -Site SSUH -WhatIf `
  -SerialInventoryPath .\input\cybernet-serials.example.csv `
  -SiteSubnetsPath .\input\site-subnets.example.csv `
  -OutDir .\evidence\CybernetSubnetDiscovery\SSUH
```

Verify `evidence/` stays gitignored after run.


___

## **CodeAnt-AI Description**
**Add PowerShell-based Cybernet subnet discovery with approved-scope checks and exportable evidence**

### What Changed
- Adds a PowerShell discovery flow that imports Cybernet serial inventories, fills in known host and MAC details, and optionally resolves hostnames to IPs
- Matches discovered IPs only to approved site subnets, blocks public or unapproved addresses, and labels each record by confidence
- Exports reviewable artifacts for the site, including target IPs, subnet mappings, action items, summary JSON, and an evidence log
- Generates record-only Naabu and Nmap command strings for handoff without running any scans
- Updates the discovery rules, port profile, and docs to reflect the legacy PowerShell lane and the Northwell Bash-first path
- Fixes config path handling for case-sensitive filesystems

### Impact
`✅ Fewer scans against unapproved subnets`
`✅ Clearer discovery handoff for technicians`
`✅ Faster review of missing or blocked records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
