### PR TITLE
feat(survey): harden naabu pipeline and parser preflight

### DIFF
--- a/survey/sas-cybernet-subnet-survey.sh
+++ b/survey/sas-cybernet-subnet-survey.sh
@@ -1,592 +1,109 @@
 #!/usr/bin/env bash
 # SysAdminSuite Cybernet serial-led subnet survey orchestrator.
 # Authorized internal asset discovery only. Read-only. Local output only.
-
 set -euo pipefail
 
-VERSION="0.1.0"
-SITE=""
-MODE=""
-RUN_ID="$(date +%Y%m%d_%H%M%S)"
-OUTPUT_ROOT="survey/output/cybernet_subnet_survey"
-LOGS_ROOT="logs/nmap"
-NETWORK_CTX_ROOT="logs/network_context"
-MANIFEST=""
-SUBNET_FILE=""
-HOST_FILE=""
-NMAP_XML=""
-RESOLVER_OUTPUT=""
-RESOLVER_DASHBOARD=""
-CONFIRM_TOOL="nmap"
-PORTS="135,445,3389"
-RATE="50"
-NAABU_PROFILE="keyports_cdn_json"
-PIPE_FOLLOWUP=0
-ALLOW_FULL_PORTS=0
-NAABU_HOST=""
-CIDRS=()
-ALLOW_WIDE=0
-ALLOW_PUBLIC=0
-DRY_RUN=0
-VERBOSE=0
-MAX_HOSTS=256
+VERSION="0.1.1"
+SITE=""; MODE=""; RUN_ID="$(date +%Y%m%d_%H%M%S)"
+OUTPUT_ROOT="survey/output/cybernet_subnet_survey"; LOGS_ROOT="logs/nmap"; NETWORK_CTX_ROOT="logs/network_context"
+MANIFEST=""; SUBNET_FILE=""; HOST_FILE=""; NMAP_XML=""; RESOLVER_OUTPUT=""; RESOLVER_DASHBOARD=""
+CONFIRM_TOOL="nmap"; PORTS="135,445,3389"; RATE="50"; NAABU_PROFILE="keyports_cdn_json"
+PIPE_FOLLOWUP=0; ALLOW_FULL_PORTS=0; NAABU_HOST=""; CIDRS=(); ALLOW_WIDE=0; ALLOW_PUBLIC=0; DRY_RUN=0; VERBOSE=0; MAX_HOSTS=256
+RUN_DIR=""; HOSTS_DIR=""; RESOLVER_DIR=""; PLANNED_FILE=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-usage() {
-  cat <<'USAGE'
+usage(){ cat <<'USAGE'
 SysAdminSuite Cybernet Subnet Survey Runner
 
-Authorized internal asset discovery only.
-Read-only. No endpoint mutation.
-No evasion, spoofing, decoys, NSE/vuln scripts, brute force, credential attacks, or version detection in discovery modes.
+Authorized internal asset discovery only. Read-only. No endpoint mutation.
+Modes: local-context-only, dns-list-only, discover, confirm-windows, resolve-only, parse-naabu-only, package-only
 
 Usage:
   bash survey/sas-cybernet-subnet-survey.sh --site SITE --mode MODE [options]
 
-Modes:
-  local-context-only   Run local subnet finder and copy network context
-  dns-list-only        Nmap -sL list/DNS sanity check per CIDR (not host proof)
-  discover             Nmap -sn discovery (no-DNS + system-DNS) per CIDR
-  confirm-windows      Narrow Windows port confirmation against a host file only
-  resolve-only         Resolve manifest against existing Nmap XML evidence
-  parse-naabu-only     Parse existing naabu JSON/txt + followup into resolver CSV
-  package-only         Package run outputs into survey/artifacts/
-
-Required:
-  --site SITE          Site/run label (alphanumeric, dash, underscore)
-
-Options:
-  --mode MODE          One of the modes above (required)
-  --manifest PATH      Target manifest CSV (resolve-only, package-only)
-  --cidr CIDR          Approved IPv4 CIDR. Repeatable
-  --subnet-file PATH   Plain-text CIDR list (e.g. subnet_candidates.txt)
-  --host-file PATH     Host list for confirm-windows (required for that mode)
-  --output-root DIR    Default: survey/output/cybernet_subnet_survey
-  --logs-root DIR      Default: logs/nmap
-  --run-id ID          Correlate multi-step runs. Default: timestamp
-  --confirm-tool TOOL  nmap or naabu. Default: nmap
-  --naabu-profile NAME Naabu profile when --confirm-tool naabu. Default: keyports_cdn_json
-  --pipe-followup      Pipe naabu silent stdout into sas-cybernet-packet-followup.sh
-  --udp-services       Use udp_infrastructure profile (DNS/SNMP UDP)
-  --allow-full-ports   Permit naabu full_ports_cdn_guarded profile (-p - -ec)
-  --host URL           Hostname/URL for naabu -sa scans (hostname_all_ips profile)
-  --ports PORTS        Default: 135,445,3389 (nmap confirm only)
-  --rate N             Naabu rate. Default: 50
-  --nmap-xml PATH      Override Nmap XML for resolve-only
-  --resolver-output PATH
-  --resolver-dashboard PATH
-  --allow-wide         Permit CIDRs broader than /24
-  --allow-public       Permit non-RFC1918/public CIDRs
-  --dry-run            Print planned commands; do not execute nmap/naabu/finder
-  --verbose            Echo commands before execution
-  -h, --help           Show help
-
-Urgent path:
-  1. local-context-only
-  2. dns-list-only (--subnet-file from finder)
-  3. discover
-  4. resolve-only (--manifest)
-  5. confirm-windows (--host-file) optional
-  6. parse-naabu-only (re-parse naabu artifacts without rescan)
-  7. package-only
-
-Generated output may contain operational network details. Do not commit it.
+Common options:
+  --manifest PATH --cidr CIDR --subnet-file PATH --host-file PATH
+  --output-root DIR --logs-root DIR --run-id ID
+  --confirm-tool nmap|naabu --naabu-profile NAME --pipe-followup --udp-services
+  --allow-full-ports --host URL --ports PORTS --rate N
+  --nmap-xml PATH --resolver-output PATH --resolver-dashboard PATH
+  --allow-wide --allow-public --dry-run --verbose
 USAGE
 }
+log(){ printf '[cybernet-subnet-survey] %s\n' "$*" >&2; }
+fail(){ printf '[cybernet-subnet-survey] ERROR: %s\n' "$*" >&2; exit 1; }
+vlog(){ [[ "$VERBOSE" -eq 1 ]] && log "$@"; return 0; }
+safe_site(){ SITE="$(printf '%s' "$SITE" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"; [[ -n "$SITE" ]] || fail "--site is required"; }
+safe_token(){ local raw="${1:-run}"; raw="$(printf '%s' "$raw" | tr './:' '____' | tr -cd '[:alnum:]_-')"; [[ -n "$raw" ]] || raw="run"; printf '%s' "$raw"; }
+find_python(){ if command -v python3 >/dev/null 2>&1; then echo python3; elif command -v python >/dev/null 2>&1; then echo python; elif command -v py >/dev/null 2>&1; then echo "py -3"; else fail "Python 3 is required"; fi; }
+nmap_bin(){ if command -v nmap.exe >/dev/null 2>&1; then command -v nmap.exe; else command -v nmap 2>/dev/null || true; fi; }
 
-log() { printf '[cybernet-subnet-survey] %s\n' "$*" >&2; }
-fail() { printf '[cybernet-subnet-survey] ERROR: %s\n' "$*" >&2; exit 1; }
-vlog() { [[ "$VERBOSE" -eq 1 ]] && log "$@"; return 0; }
-
-safe_site() {
-  SITE="$(printf '%s' "$SITE" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"
-  [[ -n "$SITE" ]] || fail "--site is required"
-}
-
-safe_cidr_token() {
-  printf '%s' "$1" | tr './:' '____'
-}
-
-find_python() {
-  if command -v python3 >/dev/null 2>&1; then echo python3; return 0; fi
-  if command -v python >/dev/null 2>&1; then echo python; return 0; fi
-  if command -v py >/dev/null 2>&1; then echo "py -3"; return 0; fi
-  fail "Python 3 is required for CIDR validation"
-}
-
-validate_cidr() {
-  local cidr="$1"
-  local py allow_wide="$ALLOW_WIDE" allow_public="$ALLOW_PUBLIC"
-  py="$(find_python)"
-  $py - "$cidr" "$allow_wide" "$allow_public" <<'PY'
-import ipaddress, sys
-cidr, allow_wide, allow_public = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-try:
-    net = ipaddress.ip_network(cidr, strict=False)
-except ValueError as exc:
-    print(f"invalid CIDR: {exc}", file=sys.stderr)
-    sys.exit(2)
-if net.version != 4:
-    print("only IPv4 CIDRs are supported", file=sys.stderr)
-    sys.exit(2)
-if net.prefixlen < 24 and not allow_wide:
-    print(f"CIDR {cidr} is broader than /24; pass --allow-wide", file=sys.stderr)
-    sys.exit(3)
-if not (net.is_private or net.is_loopback or net.is_link_local) and not allow_public:
-    print(f"CIDR {cidr} is not RFC1918/private; pass --allow-public", file=sys.stderr)
-    sys.exit(4)
-PY
-}
-
-load_subnet_file() {
-  local file="$1" line
-  [[ -f "$file" ]] || fail "Subnet file not found: $file"
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    line="${line%%#*}"
-    line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    [[ -z "$line" ]] && continue
-    CIDRS+=("$line")
-  done < "$file"
-}
-
-dedupe_cidrs() {
-  local -a unique=()
-  local c u seen=0
-  for c in "${CIDRS[@]}"; do
-    seen=0
-    for u in "${unique[@]:-}"; do
-      [[ "$u" == "$c" ]] && seen=1 && break
-    done
-    [[ "$seen" -eq 0 ]] && unique+=("$c")
-  done
-  CIDRS=("${unique[@]}")
-}
-
-append_summary() {
-  local run_dir="$1"
-  {
-    echo
-    echo "## $(date '+%Y-%m-%d %H:%M:%S') — mode=$MODE"
-    echo
-    printf '%s\n' "$2"
-  } >> "$run_dir/SUMMARY.md"
-}
-
-write_manifest() {
-  local run_dir="$1"
-  cat > "$run_dir/RUN_MANIFEST.env" <<EOF
+append_summary(){ local run_dir="$1"; { echo; echo "## $(date '+%Y-%m-%d %H:%M:%S') — mode=$MODE"; echo; printf '%s\n' "$2"; } >> "$run_dir/SUMMARY.md"; }
+ensure_run_dir(){
+  RUN_DIR="$OUTPUT_ROOT/${SITE}_${RUN_ID}"; HOSTS_DIR="$RUN_DIR/hosts"; RESOLVER_DIR="$RUN_DIR/resolver"; PLANNED_FILE="$RUN_DIR/planned_commands.txt"
+  mkdir -p "$RUN_DIR" "$HOSTS_DIR" "$RESOLVER_DIR" "$LOGS_ROOT" "$NETWORK_CTX_ROOT"
+  [[ -f "$RUN_DIR/SUMMARY.md" ]] || printf '# Cybernet Subnet Survey Run\n\nSite: %s\nRun ID: %s\nRun directory: %s\n\n' "$SITE" "$RUN_ID" "$RUN_DIR" > "$RUN_DIR/SUMMARY.md"
+  cat > "$RUN_DIR/RUN_MANIFEST.env" <<EOF_MANIFEST
 site=$SITE
 mode=$MODE
 run_id=$RUN_ID
-run_dir=$run_dir
+run_dir=$RUN_DIR
 logs_root=$LOGS_ROOT
 network_context_root=$NETWORK_CTX_ROOT
 output_root=$OUTPUT_ROOT
 dry_run=$DRY_RUN
 manifest=${MANIFEST:-}
 host_file=${HOST_FILE:-}
+naabu_host=${NAABU_HOST:-}
 nmap_xml=${NMAP_XML:-}
 started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-EOF
+EOF_MANIFEST
+}
+run_cmd(){ local desc="$1"; shift; vlog "$desc"; if [[ "$DRY_RUN" -eq 1 ]]; then printf '%s\n' "$*" >> "$PLANNED_FILE"; log "DRY-RUN: $*"; else [[ -n "${1:-}" ]] || fail "Command not found for: $desc"; "$@"; fi; }
+
+validate_cidr(){ local py; py="$(find_python)"; $py - "$1" "$ALLOW_WIDE" "$ALLOW_PUBLIC" <<'PY'
+import ipaddress, sys
+cidr, allow_wide, allow_public = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+net = ipaddress.ip_network(cidr, strict=False)
+if net.version != 4: sys.exit("only IPv4 CIDRs are supported")
+if net.prefixlen < 24 and not allow_wide: sys.exit(f"CIDR {cidr} is broader than /24; pass --allow-wide")
+if not (net.is_private or net.is_loopback or net.is_link_local) and not allow_public: sys.exit(f"CIDR {cidr} is not RFC1918/private; pass --allow-public")
+PY
+}
+load_subnet_file(){ local file="$1" line; [[ -f "$file" ]] || fail "Subnet file not found: $file"; while IFS= read -r line || [[ -n "$line" ]]; do line="${line%%#*}"; line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"; [[ -n "$line" ]] && CIDRS+=("$line"); done < "$file"; }
+dedupe_cidrs(){ local -a out=(); local c u seen; for c in "${CIDRS[@]:-}"; do seen=0; for u in "${out[@]:-}"; do [[ "$u" == "$c" ]] && seen=1 && break; done; [[ "$seen" -eq 0 ]] && out+=("$c"); done; CIDRS=("${out[@]}"); }
+collect_cidrs_for_scan(){ [[ -n "$SUBNET_FILE" ]] && load_subnet_file "$SUBNET_FILE"; dedupe_cidrs; [[ ${#CIDRS[@]} -gt 0 ]] || fail "No CIDRs supplied. Use --cidr and/or --subnet-file"; local c; for c in "${CIDRS[@]}"; do validate_cidr "$c"; done; }
+validate_host_file(){
+  [[ -n "$HOST_FILE" ]] || fail "confirm-windows requires --host-file for this lane"; [[ -f "$HOST_FILE" ]] || fail "Host file not found: $HOST_FILE"
+  local line count=0; while IFS= read -r line || [[ -n "$line" ]]; do line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"; [[ -z "$line" || "$line" == \#* ]] && continue; [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]] && fail "Host file must not contain CIDR/subnet lines: $line"; count=$((count+1)); done < "$HOST_FILE"
+  [[ "$count" -gt 0 ]] || fail "Host file is empty: $HOST_FILE"; [[ "$count" -le "$MAX_HOSTS" || "$ALLOW_WIDE" -eq 1 ]] || fail "Host file has $count entries (cap $MAX_HOSTS). Pass --allow-wide to proceed"
 }
 
-run_cmd() {
-  local desc="$1"; shift
-  vlog "$desc"
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    if [[ -z "${1:-}" ]]; then
-      printf 'nmap %s\n' "$*" >> "$PLANNED_FILE"
-      log "DRY-RUN: nmap $*"
-    else
-      printf '%s\n' "$*" >> "$PLANNED_FILE"
-      log "DRY-RUN: $*"
-    fi
-    return 0
-  fi
-  [[ -n "${1:-}" ]] || fail "Command not found for: $desc"
-  "$@"
-}
+naabu_followup_path(){ [[ "$1" == *.json ]] && printf '%s' "${1%.json}_followup.jsonl" || printf '%s' "${1%.*}_followup.jsonl"; }
+pick_latest_naabu_output(){ local -a matches; shopt -s nullglob; matches=("$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.json "$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.txt); shopt -u nullglob; [[ ${#matches[@]} -gt 0 ]] || fail "No naabu output found under $LOGS_ROOT for site $SITE"; ls -t "${matches[@]}" | head -n 1; }
+run_parse_naabu_evidence(){ local naabu_out="$1" followup_out="$2" csv_out="$3"; local -a args=(bash survey/sas-parse-naabu-evidence.sh --naabu-output "$naabu_out" --output "$csv_out"); [[ -n "$followup_out" ]] && args+=(--followup "$followup_out"); [[ -n "$MANIFEST" && -f "$MANIFEST" ]] && args+=(--manifest "$MANIFEST"); if [[ "$DRY_RUN" -eq 1 ]]; then printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"; log "DRY-RUN: ${args[*]}"; else [[ -f "$naabu_out" ]] || fail "Naabu output not found for parse: $naabu_out"; [[ -z "$followup_out" || -f "$followup_out" ]] || fail "Followup output not found for parse: $followup_out"; mkdir -p "$(dirname "$csv_out")"; (cd "$REPO_ROOT" && "${args[@]}"); fi; }
 
-nmap_bin() {
-  if command -v nmap.exe >/dev/null 2>&1; then command -v nmap.exe; return; fi
-  command -v nmap 2>/dev/null || true
-}
-
-naabu_bin() {
-  local vend="$REPO_ROOT/bin/naabu.exe"
-  [[ -x "$vend" ]] && { printf '%s' "$vend"; return; }
-  [[ -f "$vend" ]] && { printf '%s' "$vend"; return; }
-  if command -v naabu.exe >/dev/null 2>&1; then command -v naabu.exe; return; fi
-  command -v naabu 2>/dev/null || true
-}
-
-naabu_followup_path() {
-  local out="$1"
-  if [[ "$out" == *.json ]]; then
-    printf '%s' "${out%.json}_followup.jsonl"
-  else
-    printf '%s' "${out%.*}_followup.jsonl"
-  fi
-}
-
-pick_latest_naabu_output() {
-  local candidate
-  shopt -s nullglob
-  local -a matches=("$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.json "$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.txt)
-  shopt -u nullglob
-  if [[ ${#matches[@]} -eq 0 ]]; then
-    fail "No naabu output found under $LOGS_ROOT for site $SITE"
-  fi
-  candidate="$(ls -t "${matches[@]}" 2>/dev/null | head -n 1 || true)"
-  [[ -n "$candidate" ]] || fail "No naabu output found under $LOGS_ROOT for site $SITE"
-  printf '%s' "$candidate"
-}
-
-run_parse_naabu_evidence() {
-  local naabu_out="$1"
-  local followup_out="$2"
-  local csv_out="$3"
-  local -a parse_args=(
-    bash survey/sas-parse-naabu-evidence.sh
-    --naabu-output "$naabu_out"
-    --output "$csv_out"
-  )
-  [[ -n "$followup_out" ]] && parse_args+=(--followup "$followup_out")
-  [[ -n "$MANIFEST" && -f "$MANIFEST" ]] && parse_args+=(--manifest "$MANIFEST")
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf '%s\n' "${parse_args[@]}" >> "$PLANNED_FILE"
-    log "DRY-RUN: ${parse_args[*]}"
-    return 0
-  fi
-  [[ -f "$naabu_out" ]] || fail "Naabu output not found for parse: $naabu_out"
-  mkdir -p "$(dirname "$csv_out")"
-  (cd "$REPO_ROOT" && "${parse_args[@]}")
-}
-
-ensure_run_dir() {
-  RUN_DIR="$OUTPUT_ROOT/${SITE}_${RUN_ID}"
-  HOSTS_DIR="$RUN_DIR/hosts"
-  RESOLVER_DIR="$RUN_DIR/resolver"
-  PLANNED_FILE="$RUN_DIR/planned_commands.txt"
-  mkdir -p "$RUN_DIR" "$HOSTS_DIR" "$RESOLVER_DIR" "$LOGS_ROOT" "$NETWORK_CTX_ROOT"
-  if [[ ! -f "$RUN_DIR/SUMMARY.md" ]]; then
-    cat > "$RUN_DIR/SUMMARY.md" <<EOF
-# Cybernet Subnet Survey Run
-
-Site: $SITE
-Run ID: $RUN_ID
-Run directory: $RUN_DIR
-
-EOF
-  fi
-  write_manifest "$RUN_DIR"
-}
-
-collect_cidrs_for_scan() {
-  if [[ -n "$SUBNET_FILE" ]]; then
-    load_subnet_file "$SUBNET_FILE"
-  fi
-  dedupe_cidrs
-  [[ ${#CIDRS[@]} -gt 0 ]] || fail "No CIDRs supplied. Use --cidr and/or --subnet-file"
-  local c
-  for c in "${CIDRS[@]}"; do validate_cidr "$c"; done
-}
-
-validate_host_file() {
-  [[ -n "$HOST_FILE" ]] || fail "confirm-windows requires --host-file"
-  [[ -f "$HOST_FILE" ]] || fail "Host file not found: $HOST_FILE"
-  local line count=0
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    [[ -z "$line" || "$line" == \#* ]] && continue
-    if [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
-      fail "Host file must not contain CIDR/subnet lines: $line"
-    fi
-    count=$((count + 1))
-  done < "$HOST_FILE"
-  [[ "$count" -gt 0 ]] || fail "Host file is empty: $HOST_FILE"
-  if [[ "$count" -gt "$MAX_HOSTS" && "$ALLOW_WIDE" -eq 0 ]]; then
-    fail "Host file has $count entries (cap $MAX_HOSTS). Pass --allow-wide to proceed"
-  fi
-}
-
-extract_up_hosts() {
-  local gnmap="$1" out="$2"
-  [[ -f "$gnmap" ]] || return 0
-  awk '/Status: Up/ {print $2}' "$gnmap" | sort -u > "$out" || true
-}
-
-mode_local_context_only() {
-  ensure_run_dir
-  local finder_args=(bash survey/sas-find-local-subnets.sh --site "$SITE" --output-root survey/output/local_subnet_finder --run-id "$RUN_ID")
-  local c
-  for c in "${CIDRS[@]}"; do finder_args+=(--cidr "$c"); done
-
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf '%s\n' "${finder_args[@]}" >> "$PLANNED_FILE"
-    log "DRY-RUN: ${finder_args[*]}"
-    LOCAL_FINDER_DIR="survey/output/local_subnet_finder/${SITE}_${RUN_ID}"
-  else
-    (cd "$REPO_ROOT" && "${finder_args[@]}")
-    LOCAL_FINDER_DIR="$REPO_ROOT/survey/output/local_subnet_finder/${SITE}_${RUN_ID}"
-    [[ -d "$LOCAL_FINDER_DIR" ]] || fail "Expected finder output missing: $LOCAL_FINDER_DIR"
-  fi
-
-  local ctx_dest="$NETWORK_CTX_ROOT/${SITE}_${RUN_ID}"
-  if [[ "$DRY_RUN" -eq 0 && -d "$LOCAL_FINDER_DIR/context" ]]; then
-    mkdir -p "$ctx_dest"
-    cp -R "$LOCAL_FINDER_DIR/context/." "$ctx_dest/"
-  fi
-
-  {
-    echo "LOCAL_FINDER_DIR=$LOCAL_FINDER_DIR"
-    echo "NETWORK_CONTEXT_DIR=$ctx_dest"
-  } >> "$RUN_DIR/RUN_MANIFEST.env"
-
-  append_summary "$RUN_DIR" "Local subnet finder completed.
-Finder directory: $LOCAL_FINDER_DIR
-Network context copy: $ctx_dest"
-  log "local-context-only complete. Run dir: $RUN_DIR"
-}
-
-mode_dns_list_only() {
-  collect_cidrs_for_scan
-  ensure_run_dir
-  local nmap c safe out
-  nmap="$(nmap_bin)"
-  [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"
-  for c in "${CIDRS[@]}"; do
-    safe="$(safe_cidr_token "$c")"
-    out="$LOGS_ROOT/${SITE}_${safe}_list_dns.txt"
-    run_cmd "dns-list $c" "$nmap" -sL "$c" -oN "$out"
-    append_summary "$RUN_DIR" "dns-list-only $c -> $out (DNS/list sanity check, not host proof)"
-  done
-  log "dns-list-only complete"
-}
-
-mode_discover() {
-  collect_cidrs_for_scan
-  ensure_run_dir
-  local nmap c safe prefix
-  nmap="$(nmap_bin)"
-  [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"
-  for c in "${CIDRS[@]}"; do
-    safe="$(safe_cidr_token "$c")"
-    prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_no_dns"
-    run_cmd "discover no-dns $c" "$nmap" -sn -n --reason -oA "$prefix" "$c"
-    prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_dns"
-    run_cmd "discover dns $c" "$nmap" -sn --system-dns --reason -oA "$prefix" "$c"
-    if [[ "$DRY_RUN" -eq 0 ]]; then
-      extract_up_hosts "$LOGS_ROOT/${SITE}_${safe}_discovery_no_dns.gnmap" "$HOSTS_DIR/${safe}_up.txt"
-    fi
-    append_summary "$RUN_DIR" "discover $c -> logs under $LOGS_ROOT/${SITE}_${safe}_discovery_*"
-  done
-  log "discover complete"
-}
-
-mode_confirm_windows() {
-  validate_host_file
-  ensure_run_dir
-  local safe out nmap naabu
-  safe="$(safe_cidr_token "$(basename "$HOST_FILE")")"
+mode_local_context_only(){ ensure_run_dir; local -a args=(bash survey/sas-find-local-subnets.sh --site "$SITE" --output-root survey/output/local_subnet_finder --run-id "$RUN_ID"); local c; for c in "${CIDRS[@]:-}"; do args+=(--cidr "$c"); done; [[ "$DRY_RUN" -eq 1 ]] && { printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"; log "DRY-RUN: ${args[*]}"; } || (cd "$REPO_ROOT" && "${args[@]}"); append_summary "$RUN_DIR" "Local subnet finder planned/completed."; }
+mode_dns_list_only(){ collect_cidrs_for_scan; ensure_run_dir; local nmap c safe out; nmap="$(nmap_bin)"; [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"; for c in "${CIDRS[@]}"; do safe="$(safe_token "$c")"; out="$LOGS_ROOT/${SITE}_${safe}_list_dns.txt"; run_cmd "dns-list $c" "$nmap" -sL "$c" -oN "$out"; append_summary "$RUN_DIR" "dns-list-only $c -> $out"; done; }
+mode_discover(){ collect_cidrs_for_scan; ensure_run_dir; local nmap c safe prefix; nmap="$(nmap_bin)"; [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"; for c in "${CIDRS[@]}"; do safe="$(safe_token "$c")"; prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_no_dns"; run_cmd "discover no-dns $c" "$nmap" -sn -n --reason -oA "$prefix" "$c"; prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_dns"; run_cmd "discover dns $c" "$nmap" -sn --system-dns --reason -oA "$prefix" "$c"; append_summary "$RUN_DIR" "discover $c -> $LOGS_ROOT/${SITE}_${safe}_discovery_*"; done; }
+mode_confirm_windows(){
+  [[ "$CONFIRM_TOOL" == "nmap" || -z "$NAABU_HOST" ]] && validate_host_file
+  ensure_run_dir; local target_label="${HOST_FILE:-$NAABU_HOST}" safe out; safe="$(safe_token "$(basename "$target_label")")"
   case "$CONFIRM_TOOL" in
-    nmap)
-      nmap="$(nmap_bin)"
-      [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"
-      out="$LOGS_ROOT/${SITE}_${safe}_windows_ports"
-      run_cmd "confirm-windows nmap" "$nmap" -sT -Pn -p "$PORTS" --reason --open -iL "$HOST_FILE" -oA "$out"
-      ;;
-    naabu)
-      local ext="txt"
-      [[ "$NAABU_PROFILE" == *json* ]] && ext="json"
-      out="$LOGS_ROOT/${SITE}_${safe}_windows_ports_naabu.${ext}"
-      local pipeline_args=(
-        bash survey/sas-run-naabu-pipeline.sh
-        --site "$SITE"
-        --profile "$NAABU_PROFILE"
-        --out "$out"
-        --planned-file "$PLANNED_FILE"
-      )
-      [[ -n "$NAABU_HOST" ]] && pipeline_args+=(--host "$NAABU_HOST")
-      [[ -z "$NAABU_HOST" ]] && pipeline_args+=(--list "$HOST_FILE")
-      [[ "$PIPE_FOLLOWUP" -eq 1 ]] && pipeline_args+=(--pipe-followup)
-      [[ "$ALLOW_FULL_PORTS" -eq 1 ]] && pipeline_args+=(--allow-full-ports)
-      [[ "$ALLOW_PUBLIC" -eq 1 ]] && pipeline_args+=(--allow-public)
-      [[ "$DRY_RUN" -eq 1 ]] && pipeline_args+=(--dry-run)
-      if [[ "$DRY_RUN" -eq 1 ]]; then
-        run_cmd "confirm-windows naabu pipeline" "${pipeline_args[@]}"
-      else
-        (cd "$REPO_ROOT" && "${pipeline_args[@]}")
-      fi
-      local followup_out csv_out
-      followup_out="$(naabu_followup_path "$out")"
-      csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"
-      if [[ "$PIPE_FOLLOWUP" -eq 1 || -f "$followup_out" ]]; then
-        run_parse_naabu_evidence "$out" "$followup_out" "$csv_out"
-      else
-        run_parse_naabu_evidence "$out" "" "$csv_out"
-      fi
-      append_summary "$RUN_DIR" "confirm-windows naabu profile=$NAABU_PROFILE out=$out followup=${PIPE_FOLLOWUP:+yes} parser=$csv_out"
-      ;;
+    nmap) local nmap; nmap="$(nmap_bin)"; [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"; out="$LOGS_ROOT/${SITE}_${safe}_windows_ports"; run_cmd "confirm-windows nmap" "$nmap" -sT -Pn -p "$PORTS" --reason --open -iL "$HOST_FILE" -oA "$out"; append_summary "$RUN_DIR" "confirm-windows nmap host_file=$HOST_FILE out=$out" ;;
+    naabu) local ext="txt" followup_out csv_out followup_label="no"; [[ "$NAABU_PROFILE" == *json* ]] && ext="json"; out="$LOGS_ROOT/${SITE}_${safe}_windows_ports_naabu.${ext}"; local -a args=(bash survey/sas-run-naabu-pipeline.sh --site "$SITE" --profile "$NAABU_PROFILE" --out "$out" --planned-file "$PLANNED_FILE" --rate "$RATE"); [[ -n "$NAABU_HOST" ]] && args+=(--host "$NAABU_HOST") || args+=(--list "$HOST_FILE"); [[ "$PIPE_FOLLOWUP" -eq 1 ]] && args+=(--pipe-followup); [[ "$ALLOW_FULL_PORTS" -eq 1 ]] && args+=(--allow-full-ports); [[ "$ALLOW_PUBLIC" -eq 1 ]] && args+=(--allow-public); [[ "$DRY_RUN" -eq 1 ]] && args+=(--dry-run); [[ "$DRY_RUN" -eq 1 ]] && run_cmd "confirm-windows naabu pipeline" "${args[@]}" || (cd "$REPO_ROOT" && "${args[@]}"); followup_out="$(naabu_followup_path "$out")"; csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"; if [[ "$PIPE_FOLLOWUP" -eq 1 ]]; then followup_label="yes"; run_parse_naabu_evidence "$out" "$followup_out" "$csv_out"; else [[ -f "$followup_out" ]] && { followup_label="existing"; run_parse_naabu_evidence "$out" "$followup_out" "$csv_out"; } || run_parse_naabu_evidence "$out" "" "$csv_out"; fi; append_summary "$RUN_DIR" "confirm-windows naabu profile=$NAABU_PROFILE out=$out followup=$followup_label parser=$csv_out" ;;
     *) fail "Unsupported --confirm-tool: $CONFIRM_TOOL (use nmap or naabu)" ;;
   esac
-  append_summary "$RUN_DIR" "confirm-windows via $CONFIRM_TOOL using host file $HOST_FILE"
-  log "confirm-windows complete"
+  append_summary "$RUN_DIR" "confirm-windows via $CONFIRM_TOOL using ${HOST_FILE:-$NAABU_HOST}"; log "confirm-windows complete"
 }
-
-pick_default_nmap_xml() {
-  local candidate
-  candidate="$(ls -t "$LOGS_ROOT"/${SITE}_*_discovery_no_dns.xml 2>/dev/null | head -n 1 || true)"
-  [[ -n "$candidate" ]] || fail "No discovery XML found under $LOGS_ROOT for site $SITE; pass --nmap-xml"
-  printf '%s' "$candidate"
-}
-
-mode_resolve_only() {
-  [[ -n "$MANIFEST" ]] || fail "resolve-only requires --manifest"
-  [[ -f "$MANIFEST" ]] || fail "Manifest not found: $MANIFEST"
-  ensure_run_dir
-  local xml="$NMAP_XML"
-  [[ -n "$xml" ]] || xml="$(pick_default_nmap_xml)"
-  [[ -f "$xml" ]] || fail "Nmap XML not found: $xml"
-  [[ -z "$RESOLVER_OUTPUT" ]] && RESOLVER_OUTPUT="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.csv"
-  [[ -z "$RESOLVER_DASHBOARD" ]] && RESOLVER_DASHBOARD="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.html"
-  mkdir -p "$(dirname "$RESOLVER_OUTPUT")"
-
-  local args=(
-    bash survey/sas-resolve-nmap-evidence.sh
-    --manifest "$MANIFEST"
-    --nmap-output "$xml"
-    --output "$RESOLVER_OUTPUT"
-    --dashboard "$RESOLVER_DASHBOARD"
-  )
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"
-    log "DRY-RUN: ${args[*]}"
-  else
-    (cd "$REPO_ROOT" && "${args[@]}")
-  fi
-  append_summary "$RUN_DIR" "resolve-only manifest=$MANIFEST xml=$xml
-resolver_csv=$RESOLVER_OUTPUT
-resolver_html=$RESOLVER_DASHBOARD"
-  log "resolve-only complete"
-}
-
-mode_parse_naabu_only() {
-  ensure_run_dir
-  local naabu_out followup_out csv_out
-  naabu_out="$(pick_latest_naabu_output)"
-  followup_out="$(naabu_followup_path "$naabu_out")"
-  csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"
-  [[ -f "$followup_out" ]] || followup_out=""
-  run_parse_naabu_evidence "$naabu_out" "$followup_out" "$csv_out"
-  append_summary "$RUN_DIR" "parse-naabu-only naabu=$naabu_out followup=${followup_out:-none} csv=$csv_out"
-  log "parse-naabu-only complete"
-}
-
-mode_package_only() {
-  ensure_run_dir
-  local artifact_dir="$REPO_ROOT/survey/artifacts/${SITE}_${RUN_ID}"
-  local package_list="$artifact_dir/PACKAGE_MANIFEST.txt"
-  PACKAGE_LIST="$(mktemp)"
-  mkdir -p "$artifact_dir"
-
-  local item
-  for item in RUN_MANIFEST.env SUMMARY.md; do
-    [[ -f "$RUN_DIR/$item" ]] && cp "$RUN_DIR/$item" "$artifact_dir/" && echo "$item" >> "$PACKAGE_LIST"
-  done
-  [[ -d "$RUN_DIR/hosts" ]] && mkdir -p "$artifact_dir/hosts" && cp -R "$RUN_DIR/hosts/." "$artifact_dir/hosts/" && echo "hosts/" >> "$PACKAGE_LIST"
-  [[ -d "$RUN_DIR/resolver" ]] && mkdir -p "$artifact_dir/resolver" && cp -R "$RUN_DIR/resolver/." "$artifact_dir/resolver/" && echo "resolver/" >> "$PACKAGE_LIST"
-
-  local ctx="$NETWORK_CTX_ROOT/${SITE}_${RUN_ID}"
-  if [[ -d "$ctx" ]]; then
-    mkdir -p "$artifact_dir/network_context"
-    cp -R "$ctx/." "$artifact_dir/network_context/"
-    echo "network_context/" >> "$PACKAGE_LIST"
-  fi
-
-  shopt -s nullglob
-  local f
-  for f in "$LOGS_ROOT/${SITE}_"*; do
-    [[ -e "$f" ]] || continue
-    cp "$f" "$artifact_dir/"
-    echo "logs/$(basename "$f")" >> "$PACKAGE_LIST"
-  done
-  shopt -u nullglob
-
-  if [[ -n "$MANIFEST" && -f "$MANIFEST" ]]; then
-    mkdir -p "$artifact_dir/manifests"
-    cp "$MANIFEST" "$artifact_dir/manifests/$(basename "$MANIFEST")"
-    echo "manifests/$(basename "$MANIFEST")" >> "$PACKAGE_LIST"
-  fi
-
-  for f in \
-    "$RESOLVER_OUTPUT" \
-    "$RESOLVER_DASHBOARD" \
-    "$RUN_DIR/resolver/${SITE}_naabu_reachability.csv" \
-    "$RUN_DIR/resolver/${SITE}_nmap_identity_resolver.csv" \
-    "$RUN_DIR/resolver/${SITE}_nmap_identity_resolver.html" \
-    "$REPO_ROOT/survey/output/${SITE}_nmap_identity_resolver.csv" \
-    "$REPO_ROOT/survey/output/${SITE}_nmap_identity_resolver.html" \
-    "$REPO_ROOT/survey/output/cybernet_targets_resolved.csv" \
-    "$REPO_ROOT/survey/output/neuron_targets_resolved.csv"; do
-    if [[ -f "$f" ]]; then
-      mkdir -p "$artifact_dir/resolver"
-      cp "$f" "$artifact_dir/resolver/$(basename "$f")"
-      echo "resolver/$(basename "$f")" >> "$PACKAGE_LIST"
-    fi
-  done
-
-  sort -u "$PACKAGE_LIST" > "$package_list"
-  rm -f "$PACKAGE_LIST"
-  append_summary "$RUN_DIR" "package-only -> $artifact_dir (see PACKAGE_MANIFEST.txt)"
-  log "package-only complete: $artifact_dir"
-}
+mode_resolve_only(){ [[ -n "$MANIFEST" && -f "$MANIFEST" ]] || fail "resolve-only requires --manifest"; ensure_run_dir; local xml="$NMAP_XML"; [[ -n "$xml" ]] || xml="$(ls -t "$LOGS_ROOT"/${SITE}_*_discovery_no_dns.xml 2>/dev/null | head -n 1 || true)"; [[ -f "$xml" ]] || fail "Nmap XML not found: ${xml:-none}"; [[ -z "$RESOLVER_OUTPUT" ]] && RESOLVER_OUTPUT="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.csv"; [[ -z "$RESOLVER_DASHBOARD" ]] && RESOLVER_DASHBOARD="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.html"; local -a args=(bash survey/sas-resolve-nmap-evidence.sh --manifest "$MANIFEST" --nmap-output "$xml" --output "$RESOLVER_OUTPUT" --dashboard "$RESOLVER_DASHBOARD"); [[ "$DRY_RUN" -eq 1 ]] && { printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"; log "DRY-RUN: ${args[*]}"; } || (cd "$REPO_ROOT" && "${args[@]}"); append_summary "$RUN_DIR" "resolve-only manifest=$MANIFEST xml=$xml"; }
+mode_parse_naabu_only(){ ensure_run_dir; local naabu_out followup_out csv_out; naabu_out="$(pick_latest_naabu_output)"; followup_out="$(naabu_followup_path "$naabu_out")"; [[ -f "$followup_out" ]] || followup_out=""; csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"; run_parse_naabu_evidence "$naabu_out" "$followup_out" "$csv_out"; append_summary "$RUN_DIR" "parse-naabu-only naabu=$naabu_out followup=${followup_out:-none} csv=$csv_out"; }
+mode_package_only(){ ensure_run_dir; local artifact_dir="$REPO_ROOT/survey/artifacts/${SITE}_${RUN_ID}" package_list="$artifact_dir/PACKAGE_MANIFEST.txt"; mkdir -p "$artifact_dir"; cp "$RUN_DIR/RUN_MANIFEST.env" "$RUN_DIR/SUMMARY.md" "$artifact_dir/" 2>/dev/null || true; { echo RUN_MANIFEST.env; echo SUMMARY.md; } | sort -u > "$package_list"; append_summary "$RUN_DIR" "package-only -> $artifact_dir"; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --site) SITE="${2:?missing --site value}"; shift 2 ;;
-    --mode) MODE="${2:?missing --mode value}"; shift 2 ;;
-    --manifest) MANIFEST="${2:?missing --manifest value}"; shift 2 ;;
-    --cidr) CIDRS+=("${2:?missing --cidr value}"); shift 2 ;;
-    --subnet-file) SUBNET_FILE="${2:?missing --subnet-file value}"; shift 2 ;;
-    --host-file) HOST_FILE="${2:?missing --host-file value}"; shift 2 ;;
-    --output-root) OUTPUT_ROOT="${2:?missing --output-root value}"; shift 2 ;;
-    --logs-root) LOGS_ROOT="${2:?missing --logs-root value}"; shift 2 ;;
-    --run-id) RUN_ID="${2:?missing --run-id value}"; shift 2 ;;
-    --confirm-tool) CONFIRM_TOOL="${2:?missing --confirm-tool value}"; shift 2 ;;
-    --naabu-profile) NAABU_PROFILE="${2:?missing --naabu-profile value}"; shift 2 ;;
-    --pipe-followup) PIPE_FOLLOWUP=1; shift ;;
-    --udp-services) NAABU_PROFILE="udp_infrastructure"; shift ;;
-    --allow-full-ports) ALLOW_FULL_PORTS=1; shift ;;
-    --host) NAABU_HOST="${2:?missing --host value}"; shift 2 ;;
-    --ports) PORTS="${2:?missing --ports value}"; shift 2 ;;
-    --rate) RATE="${2:?missing --rate value}"; shift 2 ;;
-    --nmap-xml) NMAP_XML="${2:?missing --nmap-xml value}"; shift 2 ;;
-    --resolver-output) RESOLVER_OUTPUT="${2:?missing --resolver-output value}"; shift 2 ;;
-    --resolver-dashboard) RESOLVER_DASHBOARD="${2:?missing --resolver-dashboard value}"; shift 2 ;;
-    --allow-wide) ALLOW_WIDE=1; shift ;;
-    --allow-public) ALLOW_PUBLIC=1; shift ;;
-    --dry-run) DRY_RUN=1; shift ;;
-    --verbose) VERBOSE=1; shift ;;
-    --version) printf '%s\n' "$VERSION"; exit 0 ;;
-    -h|--help) usage; exit 0 ;;
-    *) fail "Unknown argument: $1" ;;
+    --site) SITE="${2:?}"; shift 2 ;; --mode) MODE="${2:?}"; shift 2 ;; --manifest) MANIFEST="${2:?}"; shift 2 ;; --cidr) CIDRS+=("${2:?}"); shift 2 ;; --subnet-file) SUBNET_FILE="${2:?}"; shift 2 ;; --host-file) HOST_FILE="${2:?}"; shift 2 ;; --output-root) OUTPUT_ROOT="${2:?}"; shift 2 ;; --logs-root) LOGS_ROOT="${2:?}"; shift 2 ;; --run-id) RUN_ID="${2:?}"; shift 2 ;; --confirm-tool) CONFIRM_TOOL="${2:?}"; shift 2 ;; --naabu-profile) NAABU_PROFILE="${2:?}"; shift 2 ;; --pipe-followup) PIPE_FOLLOWUP=1; shift ;; --udp-services) NAABU_PROFILE="udp_infrastructure"; shift ;; --allow-full-ports) ALLOW_FULL_PORTS=1; shift ;; --host) NAABU_HOST="${2:?}"; shift 2 ;; --ports) PORTS="${2:?}"; shift 2 ;; --rate) RATE="${2:?}"; shift 2 ;; --nmap-xml) NMAP_XML="${2:?}"; shift 2 ;; --resolver-output) RESOLVER_OUTPUT="${2:?}"; shift 2 ;; --resolver-dashboard) RESOLVER_DASHBOARD="${2:?}"; shift 2 ;; --allow-wide) ALLOW_WIDE=1; shift ;; --allow-public) ALLOW_PUBLIC=1; shift ;; --dry-run) DRY_RUN=1; shift ;; --verbose) VERBOSE=1; shift ;; --version) echo "$VERSION"; exit 0 ;; -h|--help) usage; exit 0 ;; *) fail "Unknown argument: $1" ;;
   esac
 done
-
-[[ -n "$SITE" ]] || fail "--site is required"
-[[ -n "$MODE" ]] || fail "--mode is required"
-safe_site
-
-case "$MODE" in
-  local-context-only) mode_local_context_only ;;
-  dns-list-only) mode_dns_list_only ;;
-  discover) mode_discover ;;
-  confirm-windows) mode_confirm_windows ;;
-  resolve-only) mode_resolve_only ;;
-  parse-naabu-only) mode_parse_naabu_only ;;
-  package-only) mode_package_only ;;
-  *) fail "Unknown mode: $MODE" ;;
-esac
+[[ -n "$SITE" ]] || fail "--site is required"; [[ -n "$MODE" ]] || fail "--mode is required"; safe_site
+case "$MODE" in local-context-only) mode_local_context_only ;; dns-list-only) mode_dns_list_only ;; discover) mode_discover ;; confirm-windows) mode_confirm_windows ;; resolve-only) mode_resolve_only ;; parse-naabu-only) mode_parse_naabu_only ;; package-only) mode_package_only ;; *) fail "Unknown mode: $MODE" ;; esac

--- a/survey/sas-cybernet-subnet-survey.sh
+++ b/survey/sas-cybernet-subnet-survey.sh
@@ -1,109 +1,592 @@
 #!/usr/bin/env bash
 # SysAdminSuite Cybernet serial-led subnet survey orchestrator.
 # Authorized internal asset discovery only. Read-only. Local output only.
+
 set -euo pipefail
 
-VERSION="0.1.1"
-SITE=""; MODE=""; RUN_ID="$(date +%Y%m%d_%H%M%S)"
-OUTPUT_ROOT="survey/output/cybernet_subnet_survey"; LOGS_ROOT="logs/nmap"; NETWORK_CTX_ROOT="logs/network_context"
-MANIFEST=""; SUBNET_FILE=""; HOST_FILE=""; NMAP_XML=""; RESOLVER_OUTPUT=""; RESOLVER_DASHBOARD=""
-CONFIRM_TOOL="nmap"; PORTS="135,445,3389"; RATE="50"; NAABU_PROFILE="keyports_cdn_json"
-PIPE_FOLLOWUP=0; ALLOW_FULL_PORTS=0; NAABU_HOST=""; CIDRS=(); ALLOW_WIDE=0; ALLOW_PUBLIC=0; DRY_RUN=0; VERBOSE=0; MAX_HOSTS=256
-RUN_DIR=""; HOSTS_DIR=""; RESOLVER_DIR=""; PLANNED_FILE=""
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERSION="0.1.0"
+SITE=""
+MODE=""
+RUN_ID="$(date +%Y%m%d_%H%M%S)"
+OUTPUT_ROOT="survey/output/cybernet_subnet_survey"
+LOGS_ROOT="logs/nmap"
+NETWORK_CTX_ROOT="logs/network_context"
+MANIFEST=""
+SUBNET_FILE=""
+HOST_FILE=""
+NMAP_XML=""
+RESOLVER_OUTPUT=""
+RESOLVER_DASHBOARD=""
+CONFIRM_TOOL="nmap"
+PORTS="135,445,3389"
+RATE="50"
+NAABU_PROFILE="keyports_cdn_json"
+PIPE_FOLLOWUP=0
+ALLOW_FULL_PORTS=0
+NAABU_HOST=""
+CIDRS=()
+ALLOW_WIDE=0
+ALLOW_PUBLIC=0
+DRY_RUN=0
+VERBOSE=0
+MAX_HOSTS=256
 
-usage(){ cat <<'USAGE'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat <<'USAGE'
 SysAdminSuite Cybernet Subnet Survey Runner
 
-Authorized internal asset discovery only. Read-only. No endpoint mutation.
-Modes: local-context-only, dns-list-only, discover, confirm-windows, resolve-only, parse-naabu-only, package-only
+Authorized internal asset discovery only.
+Read-only. No endpoint mutation.
+No evasion, spoofing, decoys, NSE/vuln scripts, brute force, credential attacks, or version detection in discovery modes.
 
 Usage:
   bash survey/sas-cybernet-subnet-survey.sh --site SITE --mode MODE [options]
 
-Common options:
-  --manifest PATH --cidr CIDR --subnet-file PATH --host-file PATH
-  --output-root DIR --logs-root DIR --run-id ID
-  --confirm-tool nmap|naabu --naabu-profile NAME --pipe-followup --udp-services
-  --allow-full-ports --host URL --ports PORTS --rate N
-  --nmap-xml PATH --resolver-output PATH --resolver-dashboard PATH
-  --allow-wide --allow-public --dry-run --verbose
+Modes:
+  local-context-only   Run local subnet finder and copy network context
+  dns-list-only        Nmap -sL list/DNS sanity check per CIDR (not host proof)
+  discover             Nmap -sn discovery (no-DNS + system-DNS) per CIDR
+  confirm-windows      Narrow Windows port confirmation against a host file only
+  resolve-only         Resolve manifest against existing Nmap XML evidence
+  parse-naabu-only     Parse existing naabu JSON/txt + followup into resolver CSV
+  package-only         Package run outputs into survey/artifacts/
+
+Required:
+  --site SITE          Site/run label (alphanumeric, dash, underscore)
+
+Options:
+  --mode MODE          One of the modes above (required)
+  --manifest PATH      Target manifest CSV (resolve-only, package-only)
+  --cidr CIDR          Approved IPv4 CIDR. Repeatable
+  --subnet-file PATH   Plain-text CIDR list (e.g. subnet_candidates.txt)
+  --host-file PATH     Host list for confirm-windows (required for that mode)
+  --output-root DIR    Default: survey/output/cybernet_subnet_survey
+  --logs-root DIR      Default: logs/nmap
+  --run-id ID          Correlate multi-step runs. Default: timestamp
+  --confirm-tool TOOL  nmap or naabu. Default: nmap
+  --naabu-profile NAME Naabu profile when --confirm-tool naabu. Default: keyports_cdn_json
+  --pipe-followup      Pipe naabu silent stdout into sas-cybernet-packet-followup.sh
+  --udp-services       Use udp_infrastructure profile (DNS/SNMP UDP)
+  --allow-full-ports   Permit naabu full_ports_cdn_guarded profile (-p - -ec)
+  --host URL           Hostname/URL for naabu -sa scans (hostname_all_ips profile)
+  --ports PORTS        Default: 135,445,3389 (nmap confirm only)
+  --rate N             Naabu rate. Default: 50
+  --nmap-xml PATH      Override Nmap XML for resolve-only
+  --resolver-output PATH
+  --resolver-dashboard PATH
+  --allow-wide         Permit CIDRs broader than /24
+  --allow-public       Permit non-RFC1918/public CIDRs
+  --dry-run            Print planned commands; do not execute nmap/naabu/finder
+  --verbose            Echo commands before execution
+  -h, --help           Show help
+
+Urgent path:
+  1. local-context-only
+  2. dns-list-only (--subnet-file from finder)
+  3. discover
+  4. resolve-only (--manifest)
+  5. confirm-windows (--host-file) optional
+  6. parse-naabu-only (re-parse naabu artifacts without rescan)
+  7. package-only
+
+Generated output may contain operational network details. Do not commit it.
 USAGE
 }
-log(){ printf '[cybernet-subnet-survey] %s\n' "$*" >&2; }
-fail(){ printf '[cybernet-subnet-survey] ERROR: %s\n' "$*" >&2; exit 1; }
-vlog(){ [[ "$VERBOSE" -eq 1 ]] && log "$@"; return 0; }
-safe_site(){ SITE="$(printf '%s' "$SITE" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"; [[ -n "$SITE" ]] || fail "--site is required"; }
-safe_token(){ local raw="${1:-run}"; raw="$(printf '%s' "$raw" | tr './:' '____' | tr -cd '[:alnum:]_-')"; [[ -n "$raw" ]] || raw="run"; printf '%s' "$raw"; }
-find_python(){ if command -v python3 >/dev/null 2>&1; then echo python3; elif command -v python >/dev/null 2>&1; then echo python; elif command -v py >/dev/null 2>&1; then echo "py -3"; else fail "Python 3 is required"; fi; }
-nmap_bin(){ if command -v nmap.exe >/dev/null 2>&1; then command -v nmap.exe; else command -v nmap 2>/dev/null || true; fi; }
 
-append_summary(){ local run_dir="$1"; { echo; echo "## $(date '+%Y-%m-%d %H:%M:%S') — mode=$MODE"; echo; printf '%s\n' "$2"; } >> "$run_dir/SUMMARY.md"; }
-ensure_run_dir(){
-  RUN_DIR="$OUTPUT_ROOT/${SITE}_${RUN_ID}"; HOSTS_DIR="$RUN_DIR/hosts"; RESOLVER_DIR="$RUN_DIR/resolver"; PLANNED_FILE="$RUN_DIR/planned_commands.txt"
-  mkdir -p "$RUN_DIR" "$HOSTS_DIR" "$RESOLVER_DIR" "$LOGS_ROOT" "$NETWORK_CTX_ROOT"
-  [[ -f "$RUN_DIR/SUMMARY.md" ]] || printf '# Cybernet Subnet Survey Run\n\nSite: %s\nRun ID: %s\nRun directory: %s\n\n' "$SITE" "$RUN_ID" "$RUN_DIR" > "$RUN_DIR/SUMMARY.md"
-  cat > "$RUN_DIR/RUN_MANIFEST.env" <<EOF_MANIFEST
+log() { printf '[cybernet-subnet-survey] %s\n' "$*" >&2; }
+fail() { printf '[cybernet-subnet-survey] ERROR: %s\n' "$*" >&2; exit 1; }
+vlog() { [[ "$VERBOSE" -eq 1 ]] && log "$@"; return 0; }
+
+safe_site() {
+  SITE="$(printf '%s' "$SITE" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"
+  [[ -n "$SITE" ]] || fail "--site is required"
+}
+
+safe_cidr_token() {
+  printf '%s' "$1" | tr './:' '____'
+}
+
+find_python() {
+  if command -v python3 >/dev/null 2>&1; then echo python3; return 0; fi
+  if command -v python >/dev/null 2>&1; then echo python; return 0; fi
+  if command -v py >/dev/null 2>&1; then echo "py -3"; return 0; fi
+  fail "Python 3 is required for CIDR validation"
+}
+
+validate_cidr() {
+  local cidr="$1"
+  local py allow_wide="$ALLOW_WIDE" allow_public="$ALLOW_PUBLIC"
+  py="$(find_python)"
+  $py - "$cidr" "$allow_wide" "$allow_public" <<'PY'
+import ipaddress, sys
+cidr, allow_wide, allow_public = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+try:
+    net = ipaddress.ip_network(cidr, strict=False)
+except ValueError as exc:
+    print(f"invalid CIDR: {exc}", file=sys.stderr)
+    sys.exit(2)
+if net.version != 4:
+    print("only IPv4 CIDRs are supported", file=sys.stderr)
+    sys.exit(2)
+if net.prefixlen < 24 and not allow_wide:
+    print(f"CIDR {cidr} is broader than /24; pass --allow-wide", file=sys.stderr)
+    sys.exit(3)
+if not (net.is_private or net.is_loopback or net.is_link_local) and not allow_public:
+    print(f"CIDR {cidr} is not RFC1918/private; pass --allow-public", file=sys.stderr)
+    sys.exit(4)
+PY
+}
+
+load_subnet_file() {
+  local file="$1" line
+  [[ -f "$file" ]] || fail "Subnet file not found: $file"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"
+    line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [[ -z "$line" ]] && continue
+    CIDRS+=("$line")
+  done < "$file"
+}
+
+dedupe_cidrs() {
+  local -a unique=()
+  local c u seen=0
+  for c in "${CIDRS[@]}"; do
+    seen=0
+    for u in "${unique[@]:-}"; do
+      [[ "$u" == "$c" ]] && seen=1 && break
+    done
+    [[ "$seen" -eq 0 ]] && unique+=("$c")
+  done
+  CIDRS=("${unique[@]}")
+}
+
+append_summary() {
+  local run_dir="$1"
+  {
+    echo
+    echo "## $(date '+%Y-%m-%d %H:%M:%S') — mode=$MODE"
+    echo
+    printf '%s\n' "$2"
+  } >> "$run_dir/SUMMARY.md"
+}
+
+write_manifest() {
+  local run_dir="$1"
+  cat > "$run_dir/RUN_MANIFEST.env" <<EOF
 site=$SITE
 mode=$MODE
 run_id=$RUN_ID
-run_dir=$RUN_DIR
+run_dir=$run_dir
 logs_root=$LOGS_ROOT
 network_context_root=$NETWORK_CTX_ROOT
 output_root=$OUTPUT_ROOT
 dry_run=$DRY_RUN
 manifest=${MANIFEST:-}
 host_file=${HOST_FILE:-}
-naabu_host=${NAABU_HOST:-}
 nmap_xml=${NMAP_XML:-}
 started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-EOF_MANIFEST
-}
-run_cmd(){ local desc="$1"; shift; vlog "$desc"; if [[ "$DRY_RUN" -eq 1 ]]; then printf '%s\n' "$*" >> "$PLANNED_FILE"; log "DRY-RUN: $*"; else [[ -n "${1:-}" ]] || fail "Command not found for: $desc"; "$@"; fi; }
-
-validate_cidr(){ local py; py="$(find_python)"; $py - "$1" "$ALLOW_WIDE" "$ALLOW_PUBLIC" <<'PY'
-import ipaddress, sys
-cidr, allow_wide, allow_public = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-net = ipaddress.ip_network(cidr, strict=False)
-if net.version != 4: sys.exit("only IPv4 CIDRs are supported")
-if net.prefixlen < 24 and not allow_wide: sys.exit(f"CIDR {cidr} is broader than /24; pass --allow-wide")
-if not (net.is_private or net.is_loopback or net.is_link_local) and not allow_public: sys.exit(f"CIDR {cidr} is not RFC1918/private; pass --allow-public")
-PY
-}
-load_subnet_file(){ local file="$1" line; [[ -f "$file" ]] || fail "Subnet file not found: $file"; while IFS= read -r line || [[ -n "$line" ]]; do line="${line%%#*}"; line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"; [[ -n "$line" ]] && CIDRS+=("$line"); done < "$file"; }
-dedupe_cidrs(){ local -a out=(); local c u seen; for c in "${CIDRS[@]:-}"; do seen=0; for u in "${out[@]:-}"; do [[ "$u" == "$c" ]] && seen=1 && break; done; [[ "$seen" -eq 0 ]] && out+=("$c"); done; CIDRS=("${out[@]}"); }
-collect_cidrs_for_scan(){ [[ -n "$SUBNET_FILE" ]] && load_subnet_file "$SUBNET_FILE"; dedupe_cidrs; [[ ${#CIDRS[@]} -gt 0 ]] || fail "No CIDRs supplied. Use --cidr and/or --subnet-file"; local c; for c in "${CIDRS[@]}"; do validate_cidr "$c"; done; }
-validate_host_file(){
-  [[ -n "$HOST_FILE" ]] || fail "confirm-windows requires --host-file for this lane"; [[ -f "$HOST_FILE" ]] || fail "Host file not found: $HOST_FILE"
-  local line count=0; while IFS= read -r line || [[ -n "$line" ]]; do line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"; [[ -z "$line" || "$line" == \#* ]] && continue; [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]] && fail "Host file must not contain CIDR/subnet lines: $line"; count=$((count+1)); done < "$HOST_FILE"
-  [[ "$count" -gt 0 ]] || fail "Host file is empty: $HOST_FILE"; [[ "$count" -le "$MAX_HOSTS" || "$ALLOW_WIDE" -eq 1 ]] || fail "Host file has $count entries (cap $MAX_HOSTS). Pass --allow-wide to proceed"
+EOF
 }
 
-naabu_followup_path(){ [[ "$1" == *.json ]] && printf '%s' "${1%.json}_followup.jsonl" || printf '%s' "${1%.*}_followup.jsonl"; }
-pick_latest_naabu_output(){ local -a matches; shopt -s nullglob; matches=("$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.json "$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.txt); shopt -u nullglob; [[ ${#matches[@]} -gt 0 ]] || fail "No naabu output found under $LOGS_ROOT for site $SITE"; ls -t "${matches[@]}" | head -n 1; }
-run_parse_naabu_evidence(){ local naabu_out="$1" followup_out="$2" csv_out="$3"; local -a args=(bash survey/sas-parse-naabu-evidence.sh --naabu-output "$naabu_out" --output "$csv_out"); [[ -n "$followup_out" ]] && args+=(--followup "$followup_out"); [[ -n "$MANIFEST" && -f "$MANIFEST" ]] && args+=(--manifest "$MANIFEST"); if [[ "$DRY_RUN" -eq 1 ]]; then printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"; log "DRY-RUN: ${args[*]}"; else [[ -f "$naabu_out" ]] || fail "Naabu output not found for parse: $naabu_out"; [[ -z "$followup_out" || -f "$followup_out" ]] || fail "Followup output not found for parse: $followup_out"; mkdir -p "$(dirname "$csv_out")"; (cd "$REPO_ROOT" && "${args[@]}"); fi; }
+run_cmd() {
+  local desc="$1"; shift
+  vlog "$desc"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    if [[ -z "${1:-}" ]]; then
+      printf 'nmap %s\n' "$*" >> "$PLANNED_FILE"
+      log "DRY-RUN: nmap $*"
+    else
+      printf '%s\n' "$*" >> "$PLANNED_FILE"
+      log "DRY-RUN: $*"
+    fi
+    return 0
+  fi
+  [[ -n "${1:-}" ]] || fail "Command not found for: $desc"
+  "$@"
+}
 
-mode_local_context_only(){ ensure_run_dir; local -a args=(bash survey/sas-find-local-subnets.sh --site "$SITE" --output-root survey/output/local_subnet_finder --run-id "$RUN_ID"); local c; for c in "${CIDRS[@]:-}"; do args+=(--cidr "$c"); done; [[ "$DRY_RUN" -eq 1 ]] && { printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"; log "DRY-RUN: ${args[*]}"; } || (cd "$REPO_ROOT" && "${args[@]}"); append_summary "$RUN_DIR" "Local subnet finder planned/completed."; }
-mode_dns_list_only(){ collect_cidrs_for_scan; ensure_run_dir; local nmap c safe out; nmap="$(nmap_bin)"; [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"; for c in "${CIDRS[@]}"; do safe="$(safe_token "$c")"; out="$LOGS_ROOT/${SITE}_${safe}_list_dns.txt"; run_cmd "dns-list $c" "$nmap" -sL "$c" -oN "$out"; append_summary "$RUN_DIR" "dns-list-only $c -> $out"; done; }
-mode_discover(){ collect_cidrs_for_scan; ensure_run_dir; local nmap c safe prefix; nmap="$(nmap_bin)"; [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"; for c in "${CIDRS[@]}"; do safe="$(safe_token "$c")"; prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_no_dns"; run_cmd "discover no-dns $c" "$nmap" -sn -n --reason -oA "$prefix" "$c"; prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_dns"; run_cmd "discover dns $c" "$nmap" -sn --system-dns --reason -oA "$prefix" "$c"; append_summary "$RUN_DIR" "discover $c -> $LOGS_ROOT/${SITE}_${safe}_discovery_*"; done; }
-mode_confirm_windows(){
-  [[ "$CONFIRM_TOOL" == "nmap" || -z "$NAABU_HOST" ]] && validate_host_file
-  ensure_run_dir; local target_label="${HOST_FILE:-$NAABU_HOST}" safe out; safe="$(safe_token "$(basename "$target_label")")"
+nmap_bin() {
+  if command -v nmap.exe >/dev/null 2>&1; then command -v nmap.exe; return; fi
+  command -v nmap 2>/dev/null || true
+}
+
+naabu_bin() {
+  local vend="$REPO_ROOT/bin/naabu.exe"
+  [[ -x "$vend" ]] && { printf '%s' "$vend"; return; }
+  [[ -f "$vend" ]] && { printf '%s' "$vend"; return; }
+  if command -v naabu.exe >/dev/null 2>&1; then command -v naabu.exe; return; fi
+  command -v naabu 2>/dev/null || true
+}
+
+naabu_followup_path() {
+  local out="$1"
+  if [[ "$out" == *.json ]]; then
+    printf '%s' "${out%.json}_followup.jsonl"
+  else
+    printf '%s' "${out%.*}_followup.jsonl"
+  fi
+}
+
+pick_latest_naabu_output() {
+  local candidate
+  shopt -s nullglob
+  local -a matches=("$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.json "$LOGS_ROOT"/${SITE}_*_windows_ports_naabu.txt)
+  shopt -u nullglob
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    fail "No naabu output found under $LOGS_ROOT for site $SITE"
+  fi
+  candidate="$(ls -t "${matches[@]}" 2>/dev/null | head -n 1 || true)"
+  [[ -n "$candidate" ]] || fail "No naabu output found under $LOGS_ROOT for site $SITE"
+  printf '%s' "$candidate"
+}
+
+run_parse_naabu_evidence() {
+  local naabu_out="$1"
+  local followup_out="$2"
+  local csv_out="$3"
+  local -a parse_args=(
+    bash survey/sas-parse-naabu-evidence.sh
+    --naabu-output "$naabu_out"
+    --output "$csv_out"
+  )
+  [[ -n "$followup_out" ]] && parse_args+=(--followup "$followup_out")
+  [[ -n "$MANIFEST" && -f "$MANIFEST" ]] && parse_args+=(--manifest "$MANIFEST")
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '%s\n' "${parse_args[@]}" >> "$PLANNED_FILE"
+    log "DRY-RUN: ${parse_args[*]}"
+    return 0
+  fi
+  [[ -f "$naabu_out" ]] || fail "Naabu output not found for parse: $naabu_out"
+  mkdir -p "$(dirname "$csv_out")"
+  (cd "$REPO_ROOT" && "${parse_args[@]}")
+}
+
+ensure_run_dir() {
+  RUN_DIR="$OUTPUT_ROOT/${SITE}_${RUN_ID}"
+  HOSTS_DIR="$RUN_DIR/hosts"
+  RESOLVER_DIR="$RUN_DIR/resolver"
+  PLANNED_FILE="$RUN_DIR/planned_commands.txt"
+  mkdir -p "$RUN_DIR" "$HOSTS_DIR" "$RESOLVER_DIR" "$LOGS_ROOT" "$NETWORK_CTX_ROOT"
+  if [[ ! -f "$RUN_DIR/SUMMARY.md" ]]; then
+    cat > "$RUN_DIR/SUMMARY.md" <<EOF
+# Cybernet Subnet Survey Run
+
+Site: $SITE
+Run ID: $RUN_ID
+Run directory: $RUN_DIR
+
+EOF
+  fi
+  write_manifest "$RUN_DIR"
+}
+
+collect_cidrs_for_scan() {
+  if [[ -n "$SUBNET_FILE" ]]; then
+    load_subnet_file "$SUBNET_FILE"
+  fi
+  dedupe_cidrs
+  [[ ${#CIDRS[@]} -gt 0 ]] || fail "No CIDRs supplied. Use --cidr and/or --subnet-file"
+  local c
+  for c in "${CIDRS[@]}"; do validate_cidr "$c"; done
+}
+
+validate_host_file() {
+  [[ -n "$HOST_FILE" ]] || fail "confirm-windows requires --host-file"
+  [[ -f "$HOST_FILE" ]] || fail "Host file not found: $HOST_FILE"
+  local line count=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    if [[ "$line" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
+      fail "Host file must not contain CIDR/subnet lines: $line"
+    fi
+    count=$((count + 1))
+  done < "$HOST_FILE"
+  [[ "$count" -gt 0 ]] || fail "Host file is empty: $HOST_FILE"
+  if [[ "$count" -gt "$MAX_HOSTS" && "$ALLOW_WIDE" -eq 0 ]]; then
+    fail "Host file has $count entries (cap $MAX_HOSTS). Pass --allow-wide to proceed"
+  fi
+}
+
+extract_up_hosts() {
+  local gnmap="$1" out="$2"
+  [[ -f "$gnmap" ]] || return 0
+  awk '/Status: Up/ {print $2}' "$gnmap" | sort -u > "$out" || true
+}
+
+mode_local_context_only() {
+  ensure_run_dir
+  local finder_args=(bash survey/sas-find-local-subnets.sh --site "$SITE" --output-root survey/output/local_subnet_finder --run-id "$RUN_ID")
+  local c
+  for c in "${CIDRS[@]}"; do finder_args+=(--cidr "$c"); done
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '%s\n' "${finder_args[@]}" >> "$PLANNED_FILE"
+    log "DRY-RUN: ${finder_args[*]}"
+    LOCAL_FINDER_DIR="survey/output/local_subnet_finder/${SITE}_${RUN_ID}"
+  else
+    (cd "$REPO_ROOT" && "${finder_args[@]}")
+    LOCAL_FINDER_DIR="$REPO_ROOT/survey/output/local_subnet_finder/${SITE}_${RUN_ID}"
+    [[ -d "$LOCAL_FINDER_DIR" ]] || fail "Expected finder output missing: $LOCAL_FINDER_DIR"
+  fi
+
+  local ctx_dest="$NETWORK_CTX_ROOT/${SITE}_${RUN_ID}"
+  if [[ "$DRY_RUN" -eq 0 && -d "$LOCAL_FINDER_DIR/context" ]]; then
+    mkdir -p "$ctx_dest"
+    cp -R "$LOCAL_FINDER_DIR/context/." "$ctx_dest/"
+  fi
+
+  {
+    echo "LOCAL_FINDER_DIR=$LOCAL_FINDER_DIR"
+    echo "NETWORK_CONTEXT_DIR=$ctx_dest"
+  } >> "$RUN_DIR/RUN_MANIFEST.env"
+
+  append_summary "$RUN_DIR" "Local subnet finder completed.
+Finder directory: $LOCAL_FINDER_DIR
+Network context copy: $ctx_dest"
+  log "local-context-only complete. Run dir: $RUN_DIR"
+}
+
+mode_dns_list_only() {
+  collect_cidrs_for_scan
+  ensure_run_dir
+  local nmap c safe out
+  nmap="$(nmap_bin)"
+  [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"
+  for c in "${CIDRS[@]}"; do
+    safe="$(safe_cidr_token "$c")"
+    out="$LOGS_ROOT/${SITE}_${safe}_list_dns.txt"
+    run_cmd "dns-list $c" "$nmap" -sL "$c" -oN "$out"
+    append_summary "$RUN_DIR" "dns-list-only $c -> $out (DNS/list sanity check, not host proof)"
+  done
+  log "dns-list-only complete"
+}
+
+mode_discover() {
+  collect_cidrs_for_scan
+  ensure_run_dir
+  local nmap c safe prefix
+  nmap="$(nmap_bin)"
+  [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"
+  for c in "${CIDRS[@]}"; do
+    safe="$(safe_cidr_token "$c")"
+    prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_no_dns"
+    run_cmd "discover no-dns $c" "$nmap" -sn -n --reason -oA "$prefix" "$c"
+    prefix="$LOGS_ROOT/${SITE}_${safe}_discovery_dns"
+    run_cmd "discover dns $c" "$nmap" -sn --system-dns --reason -oA "$prefix" "$c"
+    if [[ "$DRY_RUN" -eq 0 ]]; then
+      extract_up_hosts "$LOGS_ROOT/${SITE}_${safe}_discovery_no_dns.gnmap" "$HOSTS_DIR/${safe}_up.txt"
+    fi
+    append_summary "$RUN_DIR" "discover $c -> logs under $LOGS_ROOT/${SITE}_${safe}_discovery_*"
+  done
+  log "discover complete"
+}
+
+mode_confirm_windows() {
+  validate_host_file
+  ensure_run_dir
+  local safe out nmap naabu
+  safe="$(safe_cidr_token "$(basename "$HOST_FILE")")"
   case "$CONFIRM_TOOL" in
-    nmap) local nmap; nmap="$(nmap_bin)"; [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"; out="$LOGS_ROOT/${SITE}_${safe}_windows_ports"; run_cmd "confirm-windows nmap" "$nmap" -sT -Pn -p "$PORTS" --reason --open -iL "$HOST_FILE" -oA "$out"; append_summary "$RUN_DIR" "confirm-windows nmap host_file=$HOST_FILE out=$out" ;;
-    naabu) local ext="txt" followup_out csv_out followup_label="no"; [[ "$NAABU_PROFILE" == *json* ]] && ext="json"; out="$LOGS_ROOT/${SITE}_${safe}_windows_ports_naabu.${ext}"; local -a args=(bash survey/sas-run-naabu-pipeline.sh --site "$SITE" --profile "$NAABU_PROFILE" --out "$out" --planned-file "$PLANNED_FILE" --rate "$RATE"); [[ -n "$NAABU_HOST" ]] && args+=(--host "$NAABU_HOST") || args+=(--list "$HOST_FILE"); [[ "$PIPE_FOLLOWUP" -eq 1 ]] && args+=(--pipe-followup); [[ "$ALLOW_FULL_PORTS" -eq 1 ]] && args+=(--allow-full-ports); [[ "$ALLOW_PUBLIC" -eq 1 ]] && args+=(--allow-public); [[ "$DRY_RUN" -eq 1 ]] && args+=(--dry-run); [[ "$DRY_RUN" -eq 1 ]] && run_cmd "confirm-windows naabu pipeline" "${args[@]}" || (cd "$REPO_ROOT" && "${args[@]}"); followup_out="$(naabu_followup_path "$out")"; csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"; if [[ "$PIPE_FOLLOWUP" -eq 1 ]]; then followup_label="yes"; run_parse_naabu_evidence "$out" "$followup_out" "$csv_out"; else [[ -f "$followup_out" ]] && { followup_label="existing"; run_parse_naabu_evidence "$out" "$followup_out" "$csv_out"; } || run_parse_naabu_evidence "$out" "" "$csv_out"; fi; append_summary "$RUN_DIR" "confirm-windows naabu profile=$NAABU_PROFILE out=$out followup=$followup_label parser=$csv_out" ;;
+    nmap)
+      nmap="$(nmap_bin)"
+      [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"
+      out="$LOGS_ROOT/${SITE}_${safe}_windows_ports"
+      run_cmd "confirm-windows nmap" "$nmap" -sT -Pn -p "$PORTS" --reason --open -iL "$HOST_FILE" -oA "$out"
+      ;;
+    naabu)
+      local ext="txt"
+      [[ "$NAABU_PROFILE" == *json* ]] && ext="json"
+      out="$LOGS_ROOT/${SITE}_${safe}_windows_ports_naabu.${ext}"
+      local pipeline_args=(
+        bash survey/sas-run-naabu-pipeline.sh
+        --site "$SITE"
+        --profile "$NAABU_PROFILE"
+        --out "$out"
+        --planned-file "$PLANNED_FILE"
+      )
+      [[ -n "$NAABU_HOST" ]] && pipeline_args+=(--host "$NAABU_HOST")
+      [[ -z "$NAABU_HOST" ]] && pipeline_args+=(--list "$HOST_FILE")
+      [[ "$PIPE_FOLLOWUP" -eq 1 ]] && pipeline_args+=(--pipe-followup)
+      [[ "$ALLOW_FULL_PORTS" -eq 1 ]] && pipeline_args+=(--allow-full-ports)
+      [[ "$ALLOW_PUBLIC" -eq 1 ]] && pipeline_args+=(--allow-public)
+      [[ "$DRY_RUN" -eq 1 ]] && pipeline_args+=(--dry-run)
+      if [[ "$DRY_RUN" -eq 1 ]]; then
+        run_cmd "confirm-windows naabu pipeline" "${pipeline_args[@]}"
+      else
+        (cd "$REPO_ROOT" && "${pipeline_args[@]}")
+      fi
+      local followup_out csv_out
+      followup_out="$(naabu_followup_path "$out")"
+      csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"
+      if [[ "$PIPE_FOLLOWUP" -eq 1 || -f "$followup_out" ]]; then
+        run_parse_naabu_evidence "$out" "$followup_out" "$csv_out"
+      else
+        run_parse_naabu_evidence "$out" "" "$csv_out"
+      fi
+      append_summary "$RUN_DIR" "confirm-windows naabu profile=$NAABU_PROFILE out=$out followup=${PIPE_FOLLOWUP:+yes} parser=$csv_out"
+      ;;
     *) fail "Unsupported --confirm-tool: $CONFIRM_TOOL (use nmap or naabu)" ;;
   esac
-  append_summary "$RUN_DIR" "confirm-windows via $CONFIRM_TOOL using ${HOST_FILE:-$NAABU_HOST}"; log "confirm-windows complete"
+  append_summary "$RUN_DIR" "confirm-windows via $CONFIRM_TOOL using host file $HOST_FILE"
+  log "confirm-windows complete"
 }
-mode_resolve_only(){ [[ -n "$MANIFEST" && -f "$MANIFEST" ]] || fail "resolve-only requires --manifest"; ensure_run_dir; local xml="$NMAP_XML"; [[ -n "$xml" ]] || xml="$(ls -t "$LOGS_ROOT"/${SITE}_*_discovery_no_dns.xml 2>/dev/null | head -n 1 || true)"; [[ -f "$xml" ]] || fail "Nmap XML not found: ${xml:-none}"; [[ -z "$RESOLVER_OUTPUT" ]] && RESOLVER_OUTPUT="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.csv"; [[ -z "$RESOLVER_DASHBOARD" ]] && RESOLVER_DASHBOARD="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.html"; local -a args=(bash survey/sas-resolve-nmap-evidence.sh --manifest "$MANIFEST" --nmap-output "$xml" --output "$RESOLVER_OUTPUT" --dashboard "$RESOLVER_DASHBOARD"); [[ "$DRY_RUN" -eq 1 ]] && { printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"; log "DRY-RUN: ${args[*]}"; } || (cd "$REPO_ROOT" && "${args[@]}"); append_summary "$RUN_DIR" "resolve-only manifest=$MANIFEST xml=$xml"; }
-mode_parse_naabu_only(){ ensure_run_dir; local naabu_out followup_out csv_out; naabu_out="$(pick_latest_naabu_output)"; followup_out="$(naabu_followup_path "$naabu_out")"; [[ -f "$followup_out" ]] || followup_out=""; csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"; run_parse_naabu_evidence "$naabu_out" "$followup_out" "$csv_out"; append_summary "$RUN_DIR" "parse-naabu-only naabu=$naabu_out followup=${followup_out:-none} csv=$csv_out"; }
-mode_package_only(){ ensure_run_dir; local artifact_dir="$REPO_ROOT/survey/artifacts/${SITE}_${RUN_ID}" package_list="$artifact_dir/PACKAGE_MANIFEST.txt"; mkdir -p "$artifact_dir"; cp "$RUN_DIR/RUN_MANIFEST.env" "$RUN_DIR/SUMMARY.md" "$artifact_dir/" 2>/dev/null || true; { echo RUN_MANIFEST.env; echo SUMMARY.md; } | sort -u > "$package_list"; append_summary "$RUN_DIR" "package-only -> $artifact_dir"; }
+
+pick_default_nmap_xml() {
+  local candidate
+  candidate="$(ls -t "$LOGS_ROOT"/${SITE}_*_discovery_no_dns.xml 2>/dev/null | head -n 1 || true)"
+  [[ -n "$candidate" ]] || fail "No discovery XML found under $LOGS_ROOT for site $SITE; pass --nmap-xml"
+  printf '%s' "$candidate"
+}
+
+mode_resolve_only() {
+  [[ -n "$MANIFEST" ]] || fail "resolve-only requires --manifest"
+  [[ -f "$MANIFEST" ]] || fail "Manifest not found: $MANIFEST"
+  ensure_run_dir
+  local xml="$NMAP_XML"
+  [[ -n "$xml" ]] || xml="$(pick_default_nmap_xml)"
+  [[ -f "$xml" ]] || fail "Nmap XML not found: $xml"
+  [[ -z "$RESOLVER_OUTPUT" ]] && RESOLVER_OUTPUT="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.csv"
+  [[ -z "$RESOLVER_DASHBOARD" ]] && RESOLVER_DASHBOARD="$RESOLVER_DIR/${SITE}_nmap_identity_resolver.html"
+  mkdir -p "$(dirname "$RESOLVER_OUTPUT")"
+
+  local args=(
+    bash survey/sas-resolve-nmap-evidence.sh
+    --manifest "$MANIFEST"
+    --nmap-output "$xml"
+    --output "$RESOLVER_OUTPUT"
+    --dashboard "$RESOLVER_DASHBOARD"
+  )
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '%s\n' "${args[@]}" >> "$PLANNED_FILE"
+    log "DRY-RUN: ${args[*]}"
+  else
+    (cd "$REPO_ROOT" && "${args[@]}")
+  fi
+  append_summary "$RUN_DIR" "resolve-only manifest=$MANIFEST xml=$xml
+resolver_csv=$RESOLVER_OUTPUT
+resolver_html=$RESOLVER_DASHBOARD"
+  log "resolve-only complete"
+}
+
+mode_parse_naabu_only() {
+  ensure_run_dir
+  local naabu_out followup_out csv_out
+  naabu_out="$(pick_latest_naabu_output)"
+  followup_out="$(naabu_followup_path "$naabu_out")"
+  csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"
+  [[ -f "$followup_out" ]] || followup_out=""
+  run_parse_naabu_evidence "$naabu_out" "$followup_out" "$csv_out"
+  append_summary "$RUN_DIR" "parse-naabu-only naabu=$naabu_out followup=${followup_out:-none} csv=$csv_out"
+  log "parse-naabu-only complete"
+}
+
+mode_package_only() {
+  ensure_run_dir
+  local artifact_dir="$REPO_ROOT/survey/artifacts/${SITE}_${RUN_ID}"
+  local package_list="$artifact_dir/PACKAGE_MANIFEST.txt"
+  PACKAGE_LIST="$(mktemp)"
+  mkdir -p "$artifact_dir"
+
+  local item
+  for item in RUN_MANIFEST.env SUMMARY.md; do
+    [[ -f "$RUN_DIR/$item" ]] && cp "$RUN_DIR/$item" "$artifact_dir/" && echo "$item" >> "$PACKAGE_LIST"
+  done
+  [[ -d "$RUN_DIR/hosts" ]] && mkdir -p "$artifact_dir/hosts" && cp -R "$RUN_DIR/hosts/." "$artifact_dir/hosts/" && echo "hosts/" >> "$PACKAGE_LIST"
+  [[ -d "$RUN_DIR/resolver" ]] && mkdir -p "$artifact_dir/resolver" && cp -R "$RUN_DIR/resolver/." "$artifact_dir/resolver/" && echo "resolver/" >> "$PACKAGE_LIST"
+
+  local ctx="$NETWORK_CTX_ROOT/${SITE}_${RUN_ID}"
+  if [[ -d "$ctx" ]]; then
+    mkdir -p "$artifact_dir/network_context"
+    cp -R "$ctx/." "$artifact_dir/network_context/"
+    echo "network_context/" >> "$PACKAGE_LIST"
+  fi
+
+  shopt -s nullglob
+  local f
+  for f in "$LOGS_ROOT/${SITE}_"*; do
+    [[ -e "$f" ]] || continue
+    cp "$f" "$artifact_dir/"
+    echo "logs/$(basename "$f")" >> "$PACKAGE_LIST"
+  done
+  shopt -u nullglob
+
+  if [[ -n "$MANIFEST" && -f "$MANIFEST" ]]; then
+    mkdir -p "$artifact_dir/manifests"
+    cp "$MANIFEST" "$artifact_dir/manifests/$(basename "$MANIFEST")"
+    echo "manifests/$(basename "$MANIFEST")" >> "$PACKAGE_LIST"
+  fi
+
+  for f in \
+    "$RESOLVER_OUTPUT" \
+    "$RESOLVER_DASHBOARD" \
+    "$RUN_DIR/resolver/${SITE}_naabu_reachability.csv" \
+    "$RUN_DIR/resolver/${SITE}_nmap_identity_resolver.csv" \
+    "$RUN_DIR/resolver/${SITE}_nmap_identity_resolver.html" \
+    "$REPO_ROOT/survey/output/${SITE}_nmap_identity_resolver.csv" \
+    "$REPO_ROOT/survey/output/${SITE}_nmap_identity_resolver.html" \
+    "$REPO_ROOT/survey/output/cybernet_targets_resolved.csv" \
+    "$REPO_ROOT/survey/output/neuron_targets_resolved.csv"; do
+    if [[ -f "$f" ]]; then
+      mkdir -p "$artifact_dir/resolver"
+      cp "$f" "$artifact_dir/resolver/$(basename "$f")"
+      echo "resolver/$(basename "$f")" >> "$PACKAGE_LIST"
+    fi
+  done
+
+  sort -u "$PACKAGE_LIST" > "$package_list"
+  rm -f "$PACKAGE_LIST"
+  append_summary "$RUN_DIR" "package-only -> $artifact_dir (see PACKAGE_MANIFEST.txt)"
+  log "package-only complete: $artifact_dir"
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --site) SITE="${2:?}"; shift 2 ;; --mode) MODE="${2:?}"; shift 2 ;; --manifest) MANIFEST="${2:?}"; shift 2 ;; --cidr) CIDRS+=("${2:?}"); shift 2 ;; --subnet-file) SUBNET_FILE="${2:?}"; shift 2 ;; --host-file) HOST_FILE="${2:?}"; shift 2 ;; --output-root) OUTPUT_ROOT="${2:?}"; shift 2 ;; --logs-root) LOGS_ROOT="${2:?}"; shift 2 ;; --run-id) RUN_ID="${2:?}"; shift 2 ;; --confirm-tool) CONFIRM_TOOL="${2:?}"; shift 2 ;; --naabu-profile) NAABU_PROFILE="${2:?}"; shift 2 ;; --pipe-followup) PIPE_FOLLOWUP=1; shift ;; --udp-services) NAABU_PROFILE="udp_infrastructure"; shift ;; --allow-full-ports) ALLOW_FULL_PORTS=1; shift ;; --host) NAABU_HOST="${2:?}"; shift 2 ;; --ports) PORTS="${2:?}"; shift 2 ;; --rate) RATE="${2:?}"; shift 2 ;; --nmap-xml) NMAP_XML="${2:?}"; shift 2 ;; --resolver-output) RESOLVER_OUTPUT="${2:?}"; shift 2 ;; --resolver-dashboard) RESOLVER_DASHBOARD="${2:?}"; shift 2 ;; --allow-wide) ALLOW_WIDE=1; shift ;; --allow-public) ALLOW_PUBLIC=1; shift ;; --dry-run) DRY_RUN=1; shift ;; --verbose) VERBOSE=1; shift ;; --version) echo "$VERSION"; exit 0 ;; -h|--help) usage; exit 0 ;; *) fail "Unknown argument: $1" ;;
+    --site) SITE="${2:?missing --site value}"; shift 2 ;;
+    --mode) MODE="${2:?missing --mode value}"; shift 2 ;;
+    --manifest) MANIFEST="${2:?missing --manifest value}"; shift 2 ;;
+    --cidr) CIDRS+=("${2:?missing --cidr value}"); shift 2 ;;
+    --subnet-file) SUBNET_FILE="${2:?missing --subnet-file value}"; shift 2 ;;
+    --host-file) HOST_FILE="${2:?missing --host-file value}"; shift 2 ;;
+    --output-root) OUTPUT_ROOT="${2:?missing --output-root value}"; shift 2 ;;
+    --logs-root) LOGS_ROOT="${2:?missing --logs-root value}"; shift 2 ;;
+    --run-id) RUN_ID="${2:?missing --run-id value}"; shift 2 ;;
+    --confirm-tool) CONFIRM_TOOL="${2:?missing --confirm-tool value}"; shift 2 ;;
+    --naabu-profile) NAABU_PROFILE="${2:?missing --naabu-profile value}"; shift 2 ;;
+    --pipe-followup) PIPE_FOLLOWUP=1; shift ;;
+    --udp-services) NAABU_PROFILE="udp_infrastructure"; shift ;;
+    --allow-full-ports) ALLOW_FULL_PORTS=1; shift ;;
+    --host) NAABU_HOST="${2:?missing --host value}"; shift 2 ;;
+    --ports) PORTS="${2:?missing --ports value}"; shift 2 ;;
+    --rate) RATE="${2:?missing --rate value}"; shift 2 ;;
+    --nmap-xml) NMAP_XML="${2:?missing --nmap-xml value}"; shift 2 ;;
+    --resolver-output) RESOLVER_OUTPUT="${2:?missing --resolver-output value}"; shift 2 ;;
+    --resolver-dashboard) RESOLVER_DASHBOARD="${2:?missing --resolver-dashboard value}"; shift 2 ;;
+    --allow-wide) ALLOW_WIDE=1; shift ;;
+    --allow-public) ALLOW_PUBLIC=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --verbose) VERBOSE=1; shift ;;
+    --version) printf '%s\n' "$VERSION"; exit 0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
   esac
 done
-[[ -n "$SITE" ]] || fail "--site is required"; [[ -n "$MODE" ]] || fail "--mode is required"; safe_site
-case "$MODE" in local-context-only) mode_local_context_only ;; dns-list-only) mode_dns_list_only ;; discover) mode_discover ;; confirm-windows) mode_confirm_windows ;; resolve-only) mode_resolve_only ;; parse-naabu-only) mode_parse_naabu_only ;; package-only) mode_package_only ;; *) fail "Unknown mode: $MODE" ;; esac
+
+[[ -n "$SITE" ]] || fail "--site is required"
+[[ -n "$MODE" ]] || fail "--mode is required"
+safe_site
+
+case "$MODE" in
+  local-context-only) mode_local_context_only ;;
+  dns-list-only) mode_dns_list_only ;;
+  discover) mode_discover ;;
+  confirm-windows) mode_confirm_windows ;;
+  resolve-only) mode_resolve_only ;;
+  parse-naabu-only) mode_parse_naabu_only ;;
+  package-only) mode_package_only ;;
+  *) fail "Unknown mode: $MODE" ;;
+esac

--- a/survey/sas-parse-naabu-evidence.sh
+++ b/survey/sas-parse-naabu-evidence.sh
@@ -14,7 +14,7 @@ Usage: bash survey/sas-parse-naabu-evidence.sh --naabu-output PATH [options]
 Options:
   --naabu-output PATH   naabu -o file (.txt host:port or .json / JSONL)
   --followup PATH       Optional followup JSONL from sas-cybernet-packet-followup.sh
-  --manifest PATH       Optional manifest CSV to join (best-effort host match)
+  --manifest PATH       Optional manifest CSV to join (best-effort normalized host/IP/MAC/serial match)
   --output PATH         Output CSV. Default: survey/output/naabu_identity_resolver.csv
   -h, --help            Show help
 USAGE
@@ -26,6 +26,7 @@ log(){ echo "[naabu-parser] $*" >&2; }
 find_python() {
   if command -v python3 >/dev/null 2>&1; then echo python3; return 0; fi
   if command -v python >/dev/null 2>&1; then echo python; return 0; fi
+  if command -v py >/dev/null 2>&1; then echo "py -3"; return 0; fi
   fail "Python 3 required"
 }
 
@@ -42,25 +43,79 @@ done
 
 [[ -n "$NAABU_OUTPUT" ]] || fail "--naabu-output is required"
 [[ -f "$NAABU_OUTPUT" ]] || fail "Naabu output not found: $NAABU_OUTPUT"
+if [[ -n "$FOLLOWUP" && ! -f "$FOLLOWUP" ]]; then
+  fail "Followup file not found: $FOLLOWUP"
+fi
+if [[ -n "$MANIFEST" && ! -f "$MANIFEST" ]]; then
+  fail "Manifest file not found: $MANIFEST"
+fi
 
 py="$(find_python)"
 $py - "$NAABU_OUTPUT" "$FOLLOWUP" "$MANIFEST" "$OUTPUT" <<'PY'
-import csv, json, sys
+import csv, ipaddress, json, re, sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 naabu_path, followup_path, manifest_path, out_path = sys.argv[1:5]
 rows = []
 
+HOST_COLS = {"hostname", "host", "computername", "computer", "name", "target", "identifier"}
+IP_COLS = {"ip", "ipaddress", "address", "resolvedaddress", "dnsips"}
+MAC_COLS = {"mac", "macaddress", "ethernetmac", "wifimac"}
+SERIAL_COLS = {"serial", "serialnumber", "servicetag", "assetserial"}
+
+def clean(value):
+    return str(value or "").strip()
+
+def strip_url(value):
+    text = clean(value)
+    if "://" in text:
+        parsed = urlparse(text)
+        text = parsed.hostname or text
+    return text.strip("[]")
+
+def short_host(value):
+    text = strip_url(value).lower()
+    return text.split(".", 1)[0] if text else ""
+
+def norm_mac(value):
+    hx = re.sub(r"[^0-9A-Fa-f]", "", clean(value)).upper()
+    if len(hx) == 12:
+        return ":".join(hx[i:i+2] for i in range(0, 12, 2))
+    return clean(value).upper()
+
+def norm_serial(value):
+    return re.sub(r"\s+", "", clean(value)).upper()
+
 def add_row(host, port, source):
+    host = strip_url(host)
+    port = clean(port)
     if host and port:
-        rows.append({"host": host, "port": str(port), "source": source})
+        rows.append({"host": host, "port": port, "source": source})
+
+def split_host_port(line):
+    line = clean(line)
+    if not line:
+        return "", ""
+    if line.startswith("[") and "]:" in line:
+        host, port = line.rsplit(":", 1)
+        return host.strip("[]"), port
+    if ":" not in line:
+        return line, ""
+    try:
+        ipaddress.ip_address(line)
+        return line, ""
+    except ValueError:
+        pass
+    host, port = line.rsplit(":", 1)
+    return host, port
 
 def load_txt(path):
     for raw in Path(path).read_text(encoding="utf-8", errors="replace").splitlines():
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        host, _, port = line.partition(":")
+        host, port = split_host_port(line)
         add_row(host, port, "naabu_txt")
 
 def load_json(path):
@@ -81,12 +136,14 @@ def load_json(path):
             except json.JSONDecodeError:
                 continue
     for item in items:
+        if not isinstance(item, dict):
+            continue
         host = item.get("host") or item.get("ip") or ""
         port = item.get("port", "")
         add_row(host, port, "naabu_json")
 
 followup_meta = {}
-if followup_path and Path(followup_path).is_file():
+if followup_path:
     for line in Path(followup_path).read_text(encoding="utf-8", errors="replace").splitlines():
         line = line.strip()
         if not line:
@@ -95,8 +152,8 @@ if followup_path and Path(followup_path).is_file():
             item = json.loads(line)
         except json.JSONDecodeError:
             continue
-        host = str(item.get("host", ""))
-        port = str(item.get("port", ""))
+        host = strip_url(item.get("host", ""))
+        port = clean(item.get("port", ""))
         key = f"{host}:{port}"
         followup_meta[key] = {
             "cybernet_signal": item.get("cybernet_signal", ""),
@@ -104,14 +161,30 @@ if followup_path and Path(followup_path).is_file():
             "timestamp": item.get("timestamp", ""),
         }
 
-manifest_hosts = set()
-if manifest_path and Path(manifest_path).is_file():
-    with open(manifest_path, newline="", encoding="utf-8", errors="replace") as fh:
+manifest_tokens = set()
+if manifest_path:
+    with open(manifest_path, newline="", encoding="utf-8-sig", errors="replace") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
-            for col in row.values():
-                if col:
-                    manifest_hosts.add(col.strip().lower())
+            for key, value in row.items():
+                value = clean(value)
+                if not value:
+                    continue
+                col = clean(key).lower()
+                values = re.split(r"[;,| ]+", value) if col in IP_COLS else [value]
+                for item in values:
+                    item = clean(item)
+                    if not item:
+                        continue
+                    if col in HOST_COLS:
+                        manifest_tokens.add(strip_url(item).lower())
+                        manifest_tokens.add(short_host(item))
+                    elif col in IP_COLS:
+                        manifest_tokens.add(item.lower())
+                    elif col in MAC_COLS:
+                        manifest_tokens.add(norm_mac(item))
+                    elif col in SERIAL_COLS:
+                        manifest_tokens.add(norm_serial(item))
 
 p = Path(naabu_path)
 if p.suffix.lower() in (".json", ".jsonl"):
@@ -130,7 +203,8 @@ with open(out_path, "w", newline="", encoding="utf-8") as fh:
         row["cybernet_signal"] = meta.get("cybernet_signal", "")
         row["site"] = meta.get("site", "")
         row["timestamp"] = meta.get("timestamp", "")
-        row["manifest_match"] = "yes" if row["host"].lower() in manifest_hosts else ""
+        host_tokens = {row["host"].lower(), short_host(row["host"])}
+        row["manifest_match"] = "yes" if host_tokens & manifest_tokens else ""
         w.writerow(row)
 
 print(f"Wrote {len(rows)} row(s) to {out_path}")

--- a/survey/sas-run-naabu-pipeline.sh
+++ b/survey/sas-run-naabu-pipeline.sh
@@ -2,7 +2,7 @@
 # CDN-safe naabu pipeline — approved targets only, silent output, local artifacts.
 set -euo pipefail
 
-VERSION="0.1.0"
+VERSION="0.1.1"
 SITE=""
 PROFILE="keyports_cdn"
 LIST=""
@@ -14,7 +14,9 @@ ALLOW_FULL_PORTS=0
 ALLOW_PUBLIC=0
 DRY_RUN=0
 VERBOSE=0
+RATE=""
 PLANNED_FILE=""
+NAABU_ARGS=()
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -45,6 +47,7 @@ Options:
   --pipe-followup          Pipe naabu -silent stdout into sas-cybernet-packet-followup.sh
   --allow-full-ports       Permit full_ports_cdn_guarded profile (-p - -ec)
   --allow-public           Permit public IPs in target list
+  --rate N                 Optional naabu -rate value
   --dry-run                Write planned command only; no packets
   --planned-file PATH      Append planned command to file
   --verbose                Log resolved argv
@@ -64,6 +67,7 @@ vlog() { [[ "$VERBOSE" -eq 1 ]] && log "$@"; return 0; }
 find_python() {
   if command -v python3 >/dev/null 2>&1; then echo python3; return 0; fi
   if command -v python >/dev/null 2>&1; then echo python; return 0; fi
+  if command -v py >/dev/null 2>&1; then echo "py -3"; return 0; fi
   fail "Python 3 required"
 }
 
@@ -117,10 +121,10 @@ build_naabu_argv() {
   local py tmp
   py="$(find_python)"
   tmp="$(mktemp)"
-  $py - "$PROFILE_JSON" "$PROFILE" "$LIST" "$HOST" "$OUT" "$ALLOW_FULL_PORTS" <<'PY' > "$tmp"
+  $py - "$PROFILE_JSON" "$PROFILE" "$LIST" "$HOST" "$OUT" "$ALLOW_FULL_PORTS" "$RATE" <<'PY' > "$tmp"
 import json, sys
 
-profile_path, profile_id, list_path, host, out_path, allow_full = sys.argv[1:7]
+profile_path, profile_id, list_path, host, out_path, allow_full, rate = sys.argv[1:8]
 allow_full = allow_full == "1"
 with open(profile_path, encoding="utf-8") as fh:
     cfg = json.load(fh)
@@ -165,6 +169,11 @@ if p.get("silent", True):
     argv += ["-silent"]
 if p.get("disableUpdateCheck", True):
     argv += ["-duc"]
+if rate:
+    if not str(rate).isdigit() or int(rate) <= 0:
+        print("--rate must be a positive integer", file=sys.stderr)
+        sys.exit(6)
+    argv += ["-rate", str(rate)]
 
 fmt = p.get("outputFormat", "txt")
 if out_path:
@@ -186,7 +195,9 @@ PY
 
 run_pipeline() {
   local naabu_bin followup_out count
-  naabu_bin="$(bash "$ENSURE_SCRIPT" ${DRY_RUN:+--dry-run})"
+  local -a ensure_args=()
+  [[ "$DRY_RUN" -eq 1 ]] && ensure_args+=(--dry-run)
+  naabu_bin="$(bash "$ENSURE_SCRIPT" "${ensure_args[@]}")"
   vlog "naabu binary: $naabu_bin"
 
   if [[ -n "$LIST" ]]; then
@@ -197,15 +208,22 @@ run_pipeline() {
 
   build_naabu_argv
 
+  if [[ -n "$OUT" ]]; then
+    mkdir -p "$(dirname "$OUT")"
+  fi
+
   local cmd_display="$naabu_bin ${NAABU_ARGS[*]}"
   if [[ "$PIPE_FOLLOWUP" -eq 1 ]]; then
+    [[ -f "$FOLLOWUP_SCRIPT" ]] || fail "followup script not found: $FOLLOWUP_SCRIPT"
     followup_out="${OUT%.txt}_followup.jsonl"
     [[ "$OUT" == *.json ]] && followup_out="${OUT%.json}_followup.jsonl"
     [[ -z "$OUT" ]] && followup_out="logs/nmap/${SITE}_followup.jsonl"
+    mkdir -p "$(dirname "$followup_out")"
     cmd_display="${cmd_display} | bash ${FOLLOWUP_SCRIPT} --site ${SITE} --stdin --cybernet-detect > ${followup_out}"
   fi
 
   if [[ -n "$PLANNED_FILE" ]]; then
+    mkdir -p "$(dirname "$PLANNED_FILE")"
     printf '%s\n' "$cmd_display" >> "$PLANNED_FILE"
   fi
 
@@ -216,7 +234,6 @@ run_pipeline() {
 
   log "Running: $naabu_bin ${NAABU_ARGS[*]}"
   if [[ "$PIPE_FOLLOWUP" -eq 1 ]]; then
-    mkdir -p "$(dirname "$followup_out")"
     "$naabu_bin" "${NAABU_ARGS[@]}" | bash "$FOLLOWUP_SCRIPT" --site "$SITE" --stdin --cybernet-detect > "$followup_out"
     log "Followup JSONL: $followup_out"
   else
@@ -235,6 +252,7 @@ while [[ $# -gt 0 ]]; do
     --pipe-followup) PIPE_FOLLOWUP=1; shift ;;
     --allow-full-ports) ALLOW_FULL_PORTS=1; shift ;;
     --allow-public) ALLOW_PUBLIC=1; shift ;;
+    --rate) RATE="${2:?}"; shift 2 ;;
     --dry-run) DRY_RUN=1; shift ;;
     --planned-file) PLANNED_FILE="${2:?}"; shift 2 ;;
     --verbose) VERBOSE=1; shift ;;
@@ -247,6 +265,7 @@ done
 [[ -n "$SITE" ]] || fail "--site is required"
 safe_site
 [[ -f "$PROFILE_JSON" ]] || fail "Missing $PROFILE_JSON"
+[[ -f "$ENSURE_SCRIPT" ]] || fail "Missing $ENSURE_SCRIPT"
 
 if [[ "$PROFILE" == "full_ports_cdn_guarded" && "$ALLOW_FULL_PORTS" -eq 0 ]]; then
   fail "Profile full_ports_cdn_guarded requires --allow-full-ports"


### PR DESCRIPTION
## Summary
- Hardens the Naabu pipeline dry-run/preflight path.
- Adds optional rate handling in the pipeline.
- Creates output and planned-command directories before writing artifacts.
- Hardens parser handling for missing files, Windows Python launcher fallback, bracketed host:port input, and normalized manifest matching.

## Scope
This PR changes only:
- `survey/sas-run-naabu-pipeline.sh`
- `survey/sas-parse-naabu-evidence.sh`

The subnet survey runner integration is intentionally not included here and should be handled separately.

## Validation
Previously checked locally:
- `bash -n survey/sas-run-naabu-pipeline.sh`
- `bash -n survey/sas-parse-naabu-evidence.sh`
- pipeline dry-run/preflight with list, rate, output, and planned-file paths
- parser checks for manifest matching and bracketed host:port input

No live field execution was performed.