### PR TITLE
docs(survey): low-noise survey doctrine + naabu profiles

### DIFF
--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -74,6 +74,15 @@ Use `subnet_candidates.txt` as the fast approved CIDR shortlist for the rest of 
 5. Build manifests with `bash survey/sas-survey-targets.sh`
 6. Contract tests: `bash tests/bash/test-cybernet-subnet-survey-contracts.sh`
 
+## Low-noise survey discipline
+
+This workflow follows low-noise survey discipline (authorized, scoped, no-target-mutation,
+local evidence only). The subnet orchestrator path above is for discovery context; it is
+**not** the registered Cybernet population source. For Phase 2b reachability confirmation,
+prefer an AD-derived host list placed in the local gitignored `logs/targets/` store and
+validate reachability against that list only. See
+[`docs/LOW_NOISE_SURVEY_DOCTRINE.md`](docs/LOW_NOISE_SURVEY_DOCTRINE.md).
+
 ## Evidence notes
 
 - **Nmap** helps find live hosts, DNS names, MACs on local L2, and XML evidence for resolver tooling.

--- a/docs/CYBERNET_EVIDENCE_CORRELATION.md
+++ b/docs/CYBERNET_EVIDENCE_CORRELATION.md
@@ -14,6 +14,21 @@ Build a Cybernet presence report from:
 
 Nmap is only confirmation evidence. DNS, AD, DHCP, endpoint tools, and tracker data are usually better sources for where a Cybernet should be.
 
+## Agent F — Low-Noise Survey Doctrine
+
+Purpose:
+Codifies low-noise Naabu/Cybernet survey profiles:
+- AD-derived targets first
+- -silent always for local output hygiene
+- -ec to avoid CDN/cloud firewall waste where appropriate
+- JSON for parser-facing outputs
+- TXT/stdout only for raw pipeline handoff
+- UDP only by justified profile
+- no target-side writes or scripts
+- no live field execution in this lane
+
+See [`LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md) and the profile contract [`../survey/naabu_profiles.json`](../survey/naabu_profiles.json).
+
 ## Safety model
 
 These tools are local-output-only and read-only.

--- a/docs/LOW_NOISE_SURVEY_DOCTRINE.md
+++ b/docs/LOW_NOISE_SURVEY_DOCTRINE.md
@@ -1,0 +1,165 @@
+# Low-Noise Survey Doctrine
+
+This document codifies low-noise Cybernet/Neuron survey discipline for SysAdminSuite.
+It is doctrine, command profiles, and guardrails — not a live field scan lane.
+
+The goal is to stop wasting time on broad probing, CDN/cloud firewall endpoints,
+noisy default output, and scan-first assumptions. AD defines the registered
+population. Network tools validate reachability only. Evidence is written locally.
+
+## Truth model
+
+```text
+AD registered population = source of registered Cybernet population
+Naabu/Nmap = reachability validation only
+HTTP/Cybernet detection = enrichment only
+UDP probes = optional, justified profile only
+Local pipeline = clean local evidence transformation
+Target boxes = no writes, no scripts, no agent install
+```
+
+## 1. Purpose
+
+Low-noise survey discipline exists to:
+
+- Minimize wasted probes.
+- Avoid scanning cloud/CDN/firewall edges as if they are Cybernets.
+- Keep output clean and machine-readable.
+- Prefer AD-derived target population before network reachability validation.
+- Avoid target-side artifacts.
+- Write all evidence locally.
+
+Logging reality (use this wording, do not claim "no logs"):
+
+```text
+The survey must not write logs or artifacts to target workstations.
+The survey writes evidence locally only.
+Assume network monitoring may observe authorized traffic.
+```
+
+## 2. Language boundary
+
+```text
+This project uses "low-noise survey discipline," not "stealth."
+The goal is authorized, scoped, no-target-mutation validation.
+Do not attempt to bypass monitoring, evade security tools, hide activity, or defeat logging.
+Assume enterprise network monitoring may record authorized traffic.
+```
+
+The intent is to avoid waste, avoid target-side changes, avoid broad scans, and
+produce clean local evidence. The intent is not to evade monitoring.
+
+## 3. Population vs reachability
+
+| Layer                             | Role                                    |
+| --------------------------------- | --------------------------------------- |
+| AD export                         | registered Cybernet population          |
+| logs/targets                      | local approved AD-derived target inputs |
+| Naabu/Nmap                        | reachability validation                 |
+| Cybernet detector/http enrichment | optional service fingerprint/enrichment |
+| CIM/WMI/SCCM/vendor/manual        | serial/identity proof where approved    |
+| survey/artifacts                  | local packaged evidence                 |
+
+Do not use naabu or nmap discovery output as the device population. Export the
+registered Cybernet devices from AD (or an approved AD-derived report), place the
+export in the local gitignored `logs/targets/` store, then derive a plain-text
+host list for reachability validation.
+
+## 4. Command principles
+
+- Use AD-derived host lists, not guessed subnets.
+- Avoid broad subnet sweeps unless explicitly approved.
+- Use `-ec` to exclude CDN/cloud edge targets where appropriate.
+- Use key ports only when the use case requires them.
+- Use `-silent` for local output hygiene.
+- Prefer JSON for structured parsing.
+- Prefer plain text when the next pipeline tool expects raw `host:port`.
+- Use `-sa` for domain names/load-balanced hosts when all resolved IPs matter.
+- Include UDP only when the Cybernet survey needs UDP evidence.
+- Avoid banner/logo/noisy output in pipelines.
+- Pipeline outputs directly into local parsers/enrichers when possible.
+- Never write to target machines.
+
+## 5. Approved profile examples
+
+The commands below are templates, not commands to run blindly. Replace
+`<site>` and `<runid>` and confirm the target list is an approved AD-derived host
+list. `cybernet-detect` is a project placeholder for the local enrichment step;
+do not depend on `httpx` unless the repo already provides that dependency.
+
+### TCP structured JSON
+
+```bash
+naabu -list logs/targets/<site>_confirm_hosts.txt -json -silent -ec -o logs/nmap/<site>_<runid>_naabu.json
+```
+
+### TCP raw pipeline
+
+```bash
+naabu -list logs/targets/<site>_confirm_hosts.txt -silent -ec | cybernet-detect --stdin --jsonl > logs/nmap/<site>_<runid>_cybernet_detect.jsonl
+```
+
+### Key ports
+
+```bash
+naabu -list logs/targets/<site>_confirm_hosts.txt -p 80,443,135,445,3389,5985,5986 -json -silent -ec -o logs/nmap/<site>_<runid>_keyports.json
+```
+
+### All ports, only when justified
+
+```bash
+naabu -list logs/targets/<site>_confirm_hosts.txt -p - -json -silent -ec -o logs/nmap/<site>_<runid>_allports.json
+```
+
+### UDP optional profile
+
+```bash
+naabu -list logs/targets/<site>_confirm_hosts.txt -p u:53,u:161 -uP -json -silent -ec -o logs/nmap/<site>_<runid>_udp.json
+```
+
+```text
+UDP profiles require explicit justification. They are not default Phase 2b.
+```
+
+### SYN-style host discovery for standard web-path mitigation
+
+```bash
+naabu -list logs/targets/<site>_subnets.txt -sn -pe -ps 80 -silent -ec -o logs/nmap/<site>_<runid>_host_discovery.txt
+```
+
+```text
+Use subnet host discovery only when subnet scope is approved. Do not use this to define the Cybernet population.
+```
+
+### Load-balanced hostnames
+
+```bash
+naabu -host https://example.invalid -sa -json -silent -ec -o logs/nmap/<site>_<runid>_all_resolved_ips.json
+```
+
+```text
+Use -sa when domain names may resolve to multiple IPs and every resolved IP matters.
+Do not use public vendor/cloud examples in repo docs except example.invalid placeholders.
+```
+
+## 6. Output discipline
+
+```text
+All output must land in logs/nmap/, survey/output/, survey/artifacts/, or another documented gitignored output path.
+Do not emit live results into repo root.
+Do not commit live JSON, TXT, CSV, ZIP, or XLSX evidence.
+```
+
+## Profiles and tooling
+
+- Canonical doctrine profiles: [`survey/naabu_profiles.json`](../survey/naabu_profiles.json)
+- Profile contract validator: [`tests/bash/smoke-naabu-profiles.sh`](../tests/bash/smoke-naabu-profiles.sh)
+- Render-only command helper: [`survey/sas-naabu-profile-command.sh`](../survey/sas-naabu-profile-command.sh)
+- Operational naabu runbook (runtime config): [`docs/NAABU_CYBERNET_PROFILES.md`](NAABU_CYBERNET_PROFILES.md)
+- WAB field gate (Phase 2b): [`docs/WAB_TEST_READINESS.md`](WAB_TEST_READINESS.md)
+
+The runtime pipeline ([`survey/sas-run-naabu-pipeline.sh`](../survey/sas-run-naabu-pipeline.sh))
+currently reads its execution profiles from `Config/cybernet-naabu-profiles.json`.
+The doctrine contract in `survey/naabu_profiles.json` is the reference shape for a
+future integration lane; it is not yet wired into the orchestrator. See the
+known-gaps note in the Agent F handoff.

--- a/docs/WAB_TEST_READINESS.md
+++ b/docs/WAB_TEST_READINESS.md
@@ -104,7 +104,7 @@ Do not mark it as a SysAdminSuite failure.
 
 ### Phase 2b: Naabu CDN-safe reachability (authorized network only)
 
-After Phase 2 passes, validate the naabu pipeline on an **approved small host list** (not guest network). See [`NAABU_CYBERNET_PROFILES.md`](NAABU_CYBERNET_PROFILES.md).
+After Phase 2 passes, validate the naabu pipeline on an **approved small host list** (not guest network). Follow low-noise survey discipline: AD-derived targets first, `-silent` for local output hygiene, `-ec` to avoid CDN/cloud edge waste, JSON for parser-facing output, no target-side writes. See [`NAABU_CYBERNET_PROFILES.md`](NAABU_CYBERNET_PROFILES.md), [`LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md), and the doctrine profile contract [`../survey/naabu_profiles.json`](../survey/naabu_profiles.json).
 
 ```bash
 bash survey/sas-ensure-naabu.sh
@@ -156,6 +156,19 @@ Every WAB/network test issue should include:
 - Raw output.
 - Artifact paths created.
 - Result classification from the table above.
+
+## Agent F — Low-Noise Survey Doctrine
+
+Purpose:
+Codifies low-noise Naabu/Cybernet survey profiles:
+- AD-derived targets first
+- -silent always for local output hygiene
+- -ec to avoid CDN/cloud firewall waste where appropriate
+- JSON for parser-facing outputs
+- TXT/stdout only for raw pipeline handoff
+- UDP only by justified profile
+- no target-side writes or scripts
+- no live field execution in this lane
 
 ## Do not skip this
 

--- a/survey/naabu_profiles.json
+++ b/survey/naabu_profiles.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "doctrine": "AD-derived targets first; Naabu validates reachability only.",
+  "profiles": {
+    "keyports_cybernet": {
+      "description": "Default Cybernet reachability validation profile.",
+      "ports": "80,443,135,445,3389,5985,5986",
+      "flags": ["-json", "-silent", "-ec"],
+      "output": "json",
+      "default": true
+    },
+    "allports_low_noise": {
+      "description": "All TCP ports against approved AD-derived hosts only.",
+      "ports": "-",
+      "flags": ["-json", "-silent", "-ec"],
+      "output": "json",
+      "requiresJustification": true
+    },
+    "udp_dns_snmp": {
+      "description": "UDP DNS/SNMP probe where Cybernet survey requires UDP evidence.",
+      "ports": "u:53,u:161",
+      "flags": ["-uP", "-json", "-silent", "-ec"],
+      "output": "json",
+      "requiresJustification": true
+    },
+    "host_discovery_web_syn": {
+      "description": "Approved subnet host discovery using web-like SYN path. Not a population source.",
+      "mode": "host-discovery",
+      "flags": ["-sn", "-pe", "-ps", "80", "-silent", "-ec"],
+      "output": "txt",
+      "requiresApprovedSubnetScope": true
+    },
+    "load_balanced_hostname_all_ips": {
+      "description": "Resolve and scan all IPs for load-balanced hostnames.",
+      "flags": ["-sa", "-json", "-silent", "-ec"],
+      "output": "json",
+      "requiresHostnameInput": true
+    }
+  }
+}

--- a/survey/sas-cybernet-packet-followup.sh
+++ b/survey/sas-cybernet-packet-followup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Cybernet packet follow-up — httpx placeholder. Reads naabu -silent stdout (host:port).
+# Enrichment only under low-noise survey doctrine. See docs/LOW_NOISE_SURVEY_DOCTRINE.md.
 set -euo pipefail
 
 SITE=""

--- a/survey/sas-cybernet-subnet-survey.sh
+++ b/survey/sas-cybernet-subnet-survey.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # SysAdminSuite Cybernet serial-led subnet survey orchestrator.
 # Authorized internal asset discovery only. Read-only. Local output only.
+# Low-noise survey doctrine: this subnet path is discovery context, NOT the registered
+# Cybernet population source. Prefer AD-derived host lists for confirm-windows reachability.
+# See docs/LOW_NOISE_SURVEY_DOCTRINE.md. Note: default --naabu-profile keyports_cdn_json
+# validates web ports (80,443); the doctrine keyports contract covers full Cybernet ports.
 
 set -euo pipefail
 

--- a/survey/sas-naabu-profile-command.sh
+++ b/survey/sas-naabu-profile-command.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Render a naabu command from survey/naabu_profiles.json without running it.
+# Low-noise survey doctrine: see docs/LOW_NOISE_SURVEY_DOCTRINE.md.
+# Render-only. This script never executes naabu and never touches target hosts.
+set -euo pipefail
+
+VERSION="0.1.0"
+PROFILE=""
+LIST=""
+HOST=""
+OUT=""
+ALLOW_ANY_LIST=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROFILE_JSON="${REPO_ROOT}/survey/naabu_profiles.json"
+
+usage() {
+  cat <<'USAGE'
+SysAdminSuite Naabu Profile Command Renderer (render-only)
+
+Prints the naabu command for a doctrine profile from survey/naabu_profiles.json.
+It does not run naabu and does not contact any host.
+
+Usage:
+  bash survey/sas-naabu-profile-command.sh --profile NAME [options]
+
+Required:
+  --profile NAME       Profile id from survey/naabu_profiles.json
+
+Target input:
+  --list PATH          Approved AD-derived host/subnet list (one entry per line)
+  --host URL           Hostname/URL for load-balanced -sa profiles
+
+Options:
+  --out PATH           Output file path (logs/nmap/ convention preferred)
+  --allow-any-list     Permit a --list path outside logs/targets/
+  -h, --help           Show help
+  --version            Print version
+
+Doctrine: AD-derived targets first; naabu validates reachability only.
+USAGE
+}
+
+log() { printf '[naabu-profile-command] %s\n' "$*" >&2; }
+fail() { printf '[naabu-profile-command] ERROR: %s\n' "$*" >&2; exit 1; }
+
+find_python() {
+  if command -v python3 >/dev/null 2>&1; then echo python3; return 0; fi
+  if command -v python >/dev/null 2>&1; then echo python; return 0; fi
+  fail "Python 3 required to read survey/naabu_profiles.json"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile) PROFILE="${2:?missing --profile value}"; shift 2 ;;
+    --list) LIST="${2:?missing --list value}"; shift 2 ;;
+    --host) HOST="${2:?missing --host value}"; shift 2 ;;
+    --out) OUT="${2:?missing --out value}"; shift 2 ;;
+    --allow-any-list) ALLOW_ANY_LIST=1; shift ;;
+    --version) printf '%s\n' "$VERSION"; exit 0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$PROFILE" ]] || fail "--profile is required"
+[[ -f "$PROFILE_JSON" ]] || fail "Missing $PROFILE_JSON"
+
+# Approved target-input convention check (unless explicitly overridden).
+# --allow-any-list bypasses both the convention check and the existence check.
+if [[ -n "$LIST" && "$ALLOW_ANY_LIST" -ne 1 ]]; then
+  if [[ "$LIST" != logs/targets/* ]]; then
+    fail "--list must be under logs/targets/ (AD-derived store) or pass --allow-any-list: $LIST"
+  fi
+  [[ -f "$LIST" ]] || fail "Target list not found: $LIST (render expects an existing approved list)"
+fi
+
+PY="$(find_python)"
+"$PY" - "$PROFILE_JSON" "$PROFILE" "$LIST" "$HOST" "$OUT" <<'PY'
+import json, sys
+
+profile_path, profile_id, list_path, host, out_path = sys.argv[1:6]
+with open(profile_path, encoding="utf-8") as fh:
+    cfg = json.load(fh)
+profiles = cfg.get("profiles", {})
+if profile_id not in profiles:
+    sys.stderr.write(f"[naabu-profile-command] ERROR: unknown profile: {profile_id}\n")
+    sys.exit(2)
+p = profiles[profile_id]
+
+argv = ["naabu"]
+
+if p.get("requiresHostnameInput"):
+    if not host:
+        sys.stderr.write(f"[naabu-profile-command] ERROR: profile {profile_id} requires --host\n")
+        sys.exit(3)
+    argv += ["-host", host]
+elif list_path:
+    argv += ["-list", list_path]
+else:
+    sys.stderr.write(f"[naabu-profile-command] ERROR: profile {profile_id} requires --list (or --host)\n")
+    sys.exit(4)
+
+ports = p.get("ports")
+if ports and p.get("mode") != "host-discovery":
+    argv += ["-p", str(ports)]
+
+argv += [str(flag) for flag in p.get("flags", [])]
+
+if out_path:
+    argv += ["-o", out_path]
+
+print(" ".join(argv))
+PY

--- a/survey/sas-parse-naabu-evidence.sh
+++ b/survey/sas-parse-naabu-evidence.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Convert naabu TXT/JSON + optional followup JSONL into resolver-ready CSV.
+# Local evidence transformation only under low-noise survey doctrine.
+# See docs/LOW_NOISE_SURVEY_DOCTRINE.md.
 set -euo pipefail
 
 NAABU_OUTPUT=""

--- a/survey/sas-run-naabu-pipeline.sh
+++ b/survey/sas-run-naabu-pipeline.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # CDN-safe naabu pipeline — approved targets only, silent output, local artifacts.
+# Low-noise survey doctrine: AD-derived targets first, -silent/-ec defaults, JSON for
+# parsers, no target-side writes. See docs/LOW_NOISE_SURVEY_DOCTRINE.md. Runtime profiles
+# live in Config/cybernet-naabu-profiles.json (doctrine contract: survey/naabu_profiles.json).
 set -euo pipefail
 
 VERSION="0.1.0"

--- a/tests/bash/smoke-naabu-profiles.sh
+++ b/tests/bash/smoke-naabu-profiles.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Contract validator for survey/naabu_profiles.json (low-noise survey doctrine).
+# See docs/LOW_NOISE_SURVEY_DOCTRINE.md. Read-only. No network, no targets.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PROFILE_JSON="${REPO_ROOT}/survey/naabu_profiles.json"
+
+fail() { printf 'smoke-naabu-profiles: FAIL: %s\n' "$*" >&2; exit 1; }
+
+[[ -f "$PROFILE_JSON" ]] || fail "missing survey/naabu_profiles.json"
+
+find_python() {
+  if command -v python3 >/dev/null 2>&1; then echo python3; return 0; fi
+  if command -v python >/dev/null 2>&1; then echo python; return 0; fi
+  fail "Python 3 required"
+}
+
+PY="$(find_python)"
+
+"$PY" - "$PROFILE_JSON" <<'PY'
+import ipaddress
+import json
+import re
+import sys
+
+path = sys.argv[1]
+
+try:
+    with open(path, encoding="utf-8") as fh:
+        cfg = json.load(fh)
+except (OSError, ValueError) as exc:
+    print(f"smoke-naabu-profiles: FAIL: JSON parse error: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+errors = []
+
+profiles = cfg.get("profiles")
+if not isinstance(profiles, dict) or not profiles:
+    print("smoke-naabu-profiles: FAIL: no profiles object", file=sys.stderr)
+    sys.exit(1)
+
+# Live-looking domain detection. example.invalid is the only permitted placeholder.
+DOMAIN_RE = re.compile(r"\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9-]+)+\b", re.IGNORECASE)
+ALLOWED_DOMAINS = {"example.invalid"}
+
+
+def iter_strings(obj):
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from iter_strings(item)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            yield from iter_strings(value)
+
+
+def looks_like_private_ip(token):
+    try:
+        ip = ipaddress.ip_address(token)
+    except ValueError:
+        return False
+    return ip.is_private or ip.is_loopback or ip.is_link_local
+
+
+for name, prof in profiles.items():
+    if not isinstance(prof, dict):
+        errors.append(f"profile {name} is not an object")
+        continue
+
+    flags = prof.get("flags", [])
+    if not isinstance(flags, list):
+        errors.append(f"profile {name} flags must be a list")
+        flags = []
+
+    mode = prof.get("mode", "")
+    ports = prof.get("ports")
+    is_host_discovery = mode == "host-discovery"
+    # A port-scanning profile validates TCP/UDP ports (has ports OR -p flag),
+    # and is not a pure host-discovery profile.
+    is_port_scan = (ports is not None or "-p" in flags) and not is_host_discovery
+
+    # -silent required for any TCP/UDP port-scanning profile.
+    if is_port_scan and "-silent" not in flags:
+        errors.append(f"profile {name} missing -silent")
+    # host-discovery profiles also emit local output; require -silent for hygiene.
+    if is_host_discovery and "-silent" not in flags:
+        errors.append(f"profile {name} (host-discovery) missing -silent")
+
+    # -ec required on reachability profiles unless explicitly allowing CDN edges.
+    is_reachability = is_port_scan or is_host_discovery
+    if is_reachability and not prof.get("allowCdnEdges", False) and "-ec" not in flags:
+        errors.append(f"profile {name} missing -ec (set allowCdnEdges:true to opt out)")
+
+    # UDP profiles require explicit justification.
+    is_udp = "-uP" in flags or (isinstance(ports, str) and "u:" in ports)
+    if is_udp and prof.get("requiresJustification") is not True:
+        errors.append(f"profile {name} is UDP and must set requiresJustification:true")
+
+    # Subnet host discovery profiles require approved subnet scope.
+    if is_host_discovery and prof.get("requiresApprovedSubnetScope") is not True:
+        errors.append(f"profile {name} (host-discovery) must set requiresApprovedSubnetScope:true")
+
+    # No live-looking domains or real private/corp targets in any field.
+    for token in iter_strings(prof):
+        for match in DOMAIN_RE.findall(token):
+            if match.lower() in ALLOWED_DOMAINS:
+                continue
+            # Skip pure flag/port tokens that the domain regex won't match anyway.
+            errors.append(f"profile {name} contains live-looking domain: {match}")
+        for word in re.split(r"[\s,]+", token):
+            if looks_like_private_ip(word):
+                errors.append(f"profile {name} contains private/corp IP: {word}")
+
+if errors:
+    for err in errors:
+        print(f"smoke-naabu-profiles: FAIL: {err}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+echo "smoke-naabu-profiles: PASS"


### PR DESCRIPTION
## **User description**
## Summary

Codifies authorized **low-noise, scoped, no-target-mutation** Cybernet/Neuron survey discipline for SysAdminSuite. This lane is doctrine + command profiles + a validation contract only — it does **not** wire runtime profile integration and does **not** perform live field execution.

- `docs/LOW_NOISE_SURVEY_DOCTRINE.md` — doctrine: AD-derived targets first, Naabu/Nmap for reachability validation only, `-silent` output hygiene, `-ec` to avoid cloud/CDN waste, JSON for parsers / TXT for raw handoff, UDP only with justification, `-sa` for load-balanced hostnames, no target-side writes, local evidence pipeline.
- `survey/naabu_profiles.json` — reference profile contract (keyports, all-ports, UDP, host-discovery, load-balanced) with justification/scope guards.
- `tests/bash/smoke-naabu-profiles.sh` — profile contract validator.
- `survey/sas-naabu-profile-command.sh` — render-only command helper (no execution).
- Cross-links into AD/WAB/evidence docs (`WAB_TEST_READINESS.md`, `CYBERNET_EVIDENCE_CORRELATION.md`, `NAABU_CYBERNET_PROFILES.md`).

### Language boundary
Uses **low-noise / authorized / scoped** framing. The only occurrence of `stealth` explicitly disavows it. PowerShell legacy framing and merged work preserved.

### Scope guardrails (this lane)
- No runtime profile integration (deferred to a separate integration lane).
- No live field execution.
- No merge to main.

## Validation
Rebased cleanly onto current `origin/main` (c7feb5d3b944b3d64f85ccd945102cc36442c32c, includes merged Cybernet MVP):

- `python -m json.tool survey/naabu_profiles.json` -> OK
- `bash tests/bash/smoke-naabu-profiles.sh` -> smoke-naabu-profiles: PASS
- `bash -n survey/sas-cybernet-subnet-survey.sh` -> OK
- `bash -n survey/sas-cybernet-packet-followup.sh` -> OK
- `bash -n survey/sas-parse-naabu-evidence.sh` -> OK
- `bash -n survey/sas-naabu-profile-command.sh` -> OK
- `git diff --check` -> clean
- `git status --short` -> clean

## Known gaps / next lane
`survey/sas-run-naabu-pipeline.sh` still reads execution profiles from `Config/cybernet-naabu-profiles.json`. Wiring `survey/naabu_profiles.json` into the orchestrator is intentionally out of scope here and is the recommended next lane (runtime profile integration).

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add low-noise survey doctrine, profile templates, and contract checks**

### What Changed
- Added a low-noise survey doctrine that tells users to use AD-derived target lists first, keep output local and clean, avoid target-side changes, and treat Naabu as reachability validation only
- Added approved Naabu profile templates for key ports, all ports, UDP, subnet host discovery, and load-balanced hostnames
- Added a render-only helper that prints the Naabu command for a chosen profile without running any scan
- Added a smoke test that checks the profile file for required output hygiene and scope rules
- Cross-linked the doctrine into the survey workflow and related readiness/evidence docs

### Impact
`✅ Clearer reachability workflow`
`✅ Fewer noisy scans`
`✅ Safer approved-target survey runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
