### PR TITLE
feat: AD registered population integration (Agent D)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,11 @@ data/updated/*
 *.tsv
 !input/cybernet-serials.example.csv
 !input/site-subnets.example.csv
+!survey/fixtures/ad_registered_cybernet.sample.csv
+!survey/fixtures/ad_evidence_manifest.sample.csv
+!survey/fixtures/ad_network_evidence.sample.csv
+!survey/fixtures/ad_live_serial.sample.csv
+!dashboard/samples/*.csv
 *.zip
 !**/.gitkeep
 
@@ -110,6 +115,8 @@ logs/network_context/*
 logs/nmap/*
 !logs/network_context/.gitkeep
 !logs/nmap/.gitkeep
+logs/targets/*
+!logs/targets/.gitkeep
 
 # Cybernet subnet discovery runtime evidence (serials, IPs, DNS — live field data)
 evidence/*

--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -12,10 +12,21 @@ Use the Cybernet-first dashboard when you want a guided wizard instead of memori
 2. **Start Cybernet Survey** — opens the wizard (progress rail: Targets → Network posture → Identity evidence → Reachability → Review package).
 3. **Copy posture and identity commands** — run network preflight and workstation identity on the admin box; keep output local.
 4. **Optional reachability** — wizard step 4 is skippable; uses profile `keyports_cybernet_json` when you need low-noise port confirmation.
-5. **Load Evidence** — drop `network_preflight.csv`, `workstation_identity.csv`, and optional reachability JSON.
+5. **Load Evidence** — drop `network_preflight.csv`, `workstation_identity.csv`, optional reachability JSON, normalized target manifests, and AD population CSVs.
 6. **Review Results** — use the Cybernet review summary; open **Advanced Tools** only for detailed panels or legacy command generation.
 
 For subnet discovery and Nmap orchestration, use the CLI path below.
+
+## AD-first warning
+
+**Active Directory registered population is the population authority.** When an authorized AD computer export is available, reconcile AD before building scan candidate lists.
+
+1. Place the approved export locally (do not commit live CSVs). Use `targets/local/` or `logs/targets/` per [`docs/TARGETS_FOLDER_POLICY.md`](docs/TARGETS_FOLDER_POLICY.md).
+2. Run `bash survey/sas-ad-reconcile.sh --ad-csv <local-export.csv> --output-dir survey/output/ad_reconcile/<run-id>`.
+3. Use `ad_targets_hostnames.txt` and `ad_evidence_matches.csv` to drive manifests and downstream validation.
+4. Treat Naabu/Nmap as **reachability validation only** against AD-derived targets — not as the population source.
+
+See [`docs/AD_REGISTERED_POPULATION.md`](docs/AD_REGISTERED_POPULATION.md) and [`docs/AD_CYBERNET_EXPORT_CONTRACT.md`](docs/AD_CYBERNET_EXPORT_CONTRACT.md).
 
 ## Urgent path (orchestrator)
 

--- a/Tests/bash/smoke-ad-reconcile.sh
+++ b/Tests/bash/smoke-ad-reconcile.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke test for AD registered population reconcile.
+# Uses synthetic fixtures only. No live AD, DNS, Naabu, or Nmap.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="$ROOT/survey/output/test-ad-reconcile"
+FIXTURE_AD="$ROOT/survey/fixtures/ad_registered_cybernet.sample.csv"
+FIXTURE_EVIDENCE="$ROOT/survey/fixtures/ad_evidence_manifest.sample.csv"
+FIXTURE_NETWORK="$ROOT/survey/fixtures/ad_network_evidence.sample.csv"
+FIXTURE_SERIAL="$ROOT/survey/fixtures/ad_live_serial.sample.csv"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+bash "$ROOT/survey/sas-ad-reconcile.sh" \
+  --ad-csv "$FIXTURE_AD" \
+  --evidence-csv "$FIXTURE_EVIDENCE" \
+  --network-csv "$FIXTURE_NETWORK" \
+  --serial-csv "$FIXTURE_SERIAL" \
+  --output-dir "$OUT_DIR" \
+  --prefix CYB \
+  --stale-days 90
+
+required_files=(
+  ad_registered_normalized.csv
+  ad_targets_hostnames.txt
+  ad_targets_dns.txt
+  ad_evidence_matches.csv
+  ad_only.csv
+  evidence_only.csv
+  ad_disabled.csv
+  ad_stale.csv
+  ad_missing_dns.csv
+  ad_duplicates.csv
+  network_reachable.csv
+  network_silent.csv
+  live_serial_matched.csv
+  live_serial_unavailable.csv
+  ad_summary.json
+  README.txt
+)
+
+for f in "${required_files[@]}"; do
+  [[ -f "$OUT_DIR/$f" ]] || { echo "FAIL: missing $f" >&2; exit 1; }
+done
+
+grep -q 'CYBTEST001' "$OUT_DIR/ad_targets_hostnames.txt" || { echo "FAIL: expected CYBTEST001 in hostnames" >&2; exit 1; }
+grep -q 'CYBTEST999' "$OUT_DIR/evidence_only.csv" || { echo "FAIL: expected CYBTEST999 in evidence_only" >&2; exit 1; }
+grep -q 'CYBTEST003' "$OUT_DIR/ad_disabled.csv" || { echo "FAIL: expected CYBTEST003 in ad_disabled" >&2; exit 1; }
+grep -q 'CYBTEST002' "$OUT_DIR/ad_missing_dns.csv" || { echo "FAIL: expected CYBTEST002 in ad_missing_dns" >&2; exit 1; }
+grep -q 'ad_registered' "$OUT_DIR/ad_summary.json" || { echo "FAIL: summary missing population authority" >&2; exit 1; }
+grep -q 'reachable' "$OUT_DIR/network_reachable.csv" || { echo "FAIL: expected reachable network evidence" >&2; exit 1; }
+grep -q 'matched' "$OUT_DIR/live_serial_matched.csv" || { echo "FAIL: expected matched serial evidence" >&2; exit 1; }
+
+echo "PASS: AD registered population reconcile smoke test"

--- a/dashboard/css/style.css
+++ b/dashboard/css/style.css
@@ -1173,6 +1173,7 @@ textarea.paste-area:focus { border-color: var(--accent); }
 
 .evidence-loader,
 .cybernet-review,
+.cybernet-ad-population-summary,
 .advanced-section {
   flex-shrink: 0;
   margin: 12px 18px;
@@ -1184,6 +1185,7 @@ textarea.paste-area:focus { border-color: var(--accent); }
 
 .evidence-loader-head h3,
 .cybernet-review h3,
+.cybernet-ad-population-summary h3,
 .advanced-section-head h3 { font-size: 14px; margin-bottom: 4px; }
 .evidence-loader-head p,
 .advanced-section-head p { color: var(--text-dim); font-size: 12px; margin-bottom: 10px; }
@@ -1211,6 +1213,9 @@ textarea.paste-area:focus { border-color: var(--accent); }
 .cybernet-review-stats li { font-size: 12px; margin-bottom: 4px; color: var(--text-dim); }
 .cybernet-review-warn { color: var(--warning); font-size: 12px; margin: 8px 0; }
 .cybernet-review-next { font-size: 12px; color: var(--text-dim); }
+
+.cybernet-ad-population-note { color: var(--text-dim); font-size: 12px; margin: 0 0 8px; }
+.cybernet-ad-population-stats { font-size: 12px; color: var(--text-dim); line-height: 1.5; }
 
 .mode-toggle-advanced { margin-bottom: 10px; }
 .advanced-panels-label {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -102,6 +102,12 @@
     </div>
   </section>
 
+  <section id="cybernet-ad-population-summary" class="cybernet-ad-population-summary hidden" aria-label="AD registered population summary">
+    <h3>AD Registered Population</h3>
+    <p class="cybernet-ad-population-note">Registered computer accounts from AD exports. Population authority only — not serial or reachability proof.</p>
+    <div id="cybernet-ad-population-stats" class="cybernet-ad-population-stats"></div>
+  </section>
+
   <section id="cybernet-review" class="cybernet-review hidden" aria-label="Cybernet survey review">
     <h3>Review Results</h3>
     <div id="cybernet-review-body" class="cybernet-review-body"></div>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -31,6 +31,7 @@ const TYPE_SECTION_LABELS = {
   'network-preflight': 'Network review',
   'smb-recon': 'Network review',
   'naabu-reachability': 'Reachability evidence',
+  'ad-registered-population': 'AD registered population',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
   'software-superset': 'Software tracker',
@@ -56,6 +57,7 @@ const TYPE_TO_PANELS = {
   'naabu-reachability':  ['network'],
   'software-tracker':    ['software'],
   'software-superset':   ['software'],
+  'ad-registered-population': ['inventory', 'network'],
 };
 
 // ── Bootstrap ──────────────────────────────────────────────────────────────
@@ -347,6 +349,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'ram-info': '🧠', 'monitor-info': '🖥️', 'neuron-inventory': '🗂️',
     'smb-recon': '📂', 'status-json': '💚', 'remote-task': '⚡',
     'naabu-reachability': '🔌',
+    'ad-registered-population': '🏢',
     'software-tracker': '📦', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
@@ -576,12 +579,12 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Load evidence and review',
     railLabel: 'Review package',
-    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Do not expect the dashboard to import normalized target manifests until parser support is added.',
-    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)',
+    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. AD registered population CSVs show candidate targets — not serial or reachability proof.',
+    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/ad_reconcile/<run>/ad_registered_normalized.csv',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
-      'cybernet_targets.csv from sas-survey-targets.sh is not a dashboard import yet.'
+      'Treat AD rows as registered computer accounts, not confirmed Cybernet identity.'
     ],
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
@@ -1110,6 +1113,7 @@ function refreshAllPanels() {
   try { renderNetworkPanel(store); } catch(e) { console.warn('Network panel error:', e); }
   try { renderSoftwarePanel(store); } catch(e) { console.warn('Software panel error:', e); }
   updateCybernetReview();
+  updateCybernetAdPopulationSummary();
 }
 
 function _countUniqueTargets(rows, field = 'Target') {
@@ -1177,6 +1181,52 @@ function updateCybernetReview() {
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
   `;
+}
+
+function updateCybernetAdPopulationSummary() {
+  const root = document.getElementById('cybernet-ad-population-summary');
+  const stats = document.getElementById('cybernet-ad-population-stats');
+  if (!root || !stats) return;
+
+  const rows = store.adRegisteredPopulation || [];
+  if (!rows.length) {
+    root.classList.add('hidden');
+    stats.textContent = '';
+    return;
+  }
+
+  const enabled = rows.filter(r => {
+    const bucket = (r.ReconcileBucket || '').toLowerCase();
+    const en = String(r.Enabled ?? '').toLowerCase();
+    return bucket !== 'disabled' && en !== 'false' && bucket !== 'ad_disabled';
+  }).length;
+  const disabled = rows.filter(r => {
+    const bucket = (r.ReconcileBucket || '').toLowerCase();
+    const en = String(r.Enabled ?? '').toLowerCase();
+    return bucket === 'disabled' || bucket === 'ad_disabled' || en === 'false';
+  }).length;
+  const stale = rows.filter(r => (r.ReconcileBucket || '').toLowerCase() === 'stale').length;
+  const missingDns = rows.filter(r => !(r.DNSHostName || r.dnsHostName)).length;
+  const hostCounts = new Map();
+  for (const r of rows) {
+    const h = (r.HostName || '').toUpperCase();
+    if (h) hostCounts.set(h, (hostCounts.get(h) || 0) + 1);
+  }
+  const duplicates = [...hostCounts.values()].filter(n => n > 1).length;
+  const matchedManifest = rows.filter(r => (r.ReconcileBucket || '').toLowerCase() === 'matched').length;
+  const adOnly = rows.filter(r => (r.ReconcileBucket || '').toLowerCase() === 'ad_only').length;
+
+  stats.innerHTML = [
+    `<span><strong>${rows.length}</strong> registered computer accounts</span>`,
+    `<span><strong>${enabled}</strong> enabled candidates</span>`,
+    `<span><strong>${disabled}</strong> disabled</span>`,
+    `<span><strong>${stale}</strong> stale</span>`,
+    `<span><strong>${missingDns}</strong> missing DNS</span>`,
+    `<span><strong>${duplicates}</strong> duplicate names</span>`,
+    `<span><strong>${matchedManifest}</strong> matched manifest</span>`,
+    `<span><strong>${adOnly}</strong> AD-only</span>`,
+  ].join(' · ');
+  root.classList.remove('hidden');
 }
 
 // Update software tab badge when store changes

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -263,7 +263,8 @@ function contentLooksLikeNaabuReachability(content) {
  * Detect the log type from filename and/or CSV headers.
  * Returns one of: 'preflight', 'results', 'workstation-identity',
  *   'printer-probe', 'network-preflight', 'machine-info', 'ram-info',
- *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon', 'naabu-reachability', 'unknown'
+ *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon',
+ *   'ad-registered-population', 'naabu-reachability', 'unknown'
  */
 function detectFileType(filename, content) {
   const fn = filename.toLowerCase();
@@ -322,7 +323,11 @@ function detectFileType(filename, content) {
   if (fn.startsWith('installed_software_') || fn.includes('/installed_software_') || fn.includes('\\installed_software_')) return 'software-superset';
   if (fn.includes('qrtask') || fn.includes('qr_task') || fn.includes('invoke-techtask') || fn.includes('runtask')) return 'remote-task';
   if (fn.includes('runcontrol') || fn.includes('run_control')) return 'remote-task';
-  if (fn.includes('wmi_identity') || fn.includes('wmi-identity')) return 'workstation-identity';
+  if (fn.includes('ad_registered') || fn.includes('ad-registered') || fn.includes('ad_evidence') ||
+      fn.includes('ad_only') || fn.includes('ad_disabled') || fn.includes('ad_stale') ||
+      fn.includes('ad_missing_dns') || fn.includes('ad_duplicates') || fn.includes('evidence_only')) {
+    return 'ad-registered-population';
+  }
 
   // Detect by headers if content is provided
   if (typeof content === 'string' && content.includes(',')) {
@@ -338,7 +343,9 @@ function detectFileType(filename, content) {
     if (firstLine.includes('targethost') && firstLine.includes('matchexpected')) return 'neuron-inventory';
     if (firstLine.includes('share') && firstLine.includes('liststatus')) return 'smb-recon';
     if (firstLine.includes('taskname') || firstLine.includes('taskid') || firstLine.includes('outcome')) return 'remote-task';
-    if (firstLine.includes('publisher') && firstLine.includes('host') && firstLine.includes('name')) return 'software-superset';
+    if (firstLine.includes('populationauthority') && firstLine.includes('reconcilebucket')) return 'ad-registered-population';
+    if (firstLine.includes('populationauthority') && firstLine.includes('adstatus')) return 'ad-registered-population';
+    if (firstLine.includes('reconcilebucket') && firstLine.includes('hostname')) return 'ad-registered-population';
   }
 
   return 'unknown';
@@ -365,6 +372,7 @@ function parseFileContent(type, content, filename) {
     case 'software-tracker': return parseSoftwareTracker(content, filename);
     case 'software-superset': return parseSoftwareSuperset(content);
     case 'naabu-reachability': return parseNaabuReachability(content, filename);
+    case 'ad-registered-population': return parseAdRegisteredPopulation(content, filename);
     default: return { type: 'unknown', rows: [], meta: {} };
   }
 }
@@ -557,6 +565,38 @@ function parseRemoteTask(content) {
   }
 
   return { type: 'remote-task', rows: [], meta: { count: 0 } };
+}
+
+/**
+ * Parse AD registered population reconcile CSVs.
+ * Expected columns include HostName, PopulationAuthority, ReconcileBucket / Bucket.
+ */
+function parseAdRegisteredPopulation(content, filename) {
+  const rows = parseCSV(content);
+  const normalized = rows.map(r => ({
+    HostName:        r.HostName        || r.hostname        || r.ComputerName || '',
+    DNSHostName:     r.DNSHostName     || r.dnshostname     || r.FQDN         || '',
+    ADStatus:        r.ADStatus        || r.adstatus        || '',
+    Enabled:         r.Enabled         || r.enabled         || '',
+    OperatingSystem: r.OperatingSystem || r.operatingsystem || r.OS           || '',
+    LastLogonDate:   r.LastLogonDate   || r.lastlogondate   || '',
+    Description:     r.Description     || r.description     || '',
+    ReconcileBucket: r.ReconcileBucket || r.reconcilebucket || r.Bucket       || '',
+    PopulationAuthority: r.PopulationAuthority || r.populationauthority || 'ad_registered',
+    MatchStatus:     r.MatchStatus     || r.matchstatus     || '',
+    EvidenceSerial:  r.EvidenceSerial  || r.evidenceserial  || r.Serial       || '',
+    EvidenceSource:  r.EvidenceSource  || r.evidencesource  || r.Source       || '',
+    Reachability:    r.Reachability    || r.reachability    || '',
+    ProbeStatus:     r.ProbeStatus     || r.probestatus     || '',
+    Reason:          r.Reason          || r.reason          || '',
+    _sourceFile:     filename || '',
+  })).filter(r => r.HostName);
+  const buckets = {};
+  for (const row of normalized) {
+    const b = row.ReconcileBucket || 'registered';
+    buckets[b] = (buckets[b] || 0) + 1;
+  }
+  return { type: 'ad-registered-population', rows: normalized, meta: { count: normalized.length, buckets } };
 }
 
 /**
@@ -778,6 +818,9 @@ function mergeDataStore(existing, incoming) {
     case 'naabu-reachability':
       store.naabuReachability = (store.naabuReachability || []).concat(rows);
       break;
+    case 'ad-registered-population':
+      store.adRegisteredPopulation = (store.adRegisteredPopulation || []).concat(rows);
+      break;
   }
 
   return store;
@@ -828,6 +871,18 @@ function buildInventoryRows(store) {
       Room: row.Room || '',
       Status: row.Status || hostMap[key]?.Status || '',
       _neuron: row
+    });
+  }
+
+  for (const row of (store.adRegisteredPopulation || [])) {
+    const h = row.HostName || '';
+    if (!h) continue;
+    const key = h.toUpperCase();
+    addHost(h, {
+      Status: row.ReconcileBucket || row.ADStatus || hostMap[key]?.Status || '',
+      Site: row.PopulationAuthority || 'ad_registered',
+      Serial: row.EvidenceSerial || hostMap[key]?.Serial || '',
+      _adPopulation: row
     });
   }
 
@@ -1044,6 +1099,28 @@ function buildProtocolRows(store) {
     if (!port) continue;
     const reach = (row.reachability || 'open').toLowerCase();
     hostMap[t].ports[port] = reach === 'open' ? 'Open' : reach;
+  }
+
+  // AD registered population — reconcile buckets; do not treat AD as serial or reachability proof
+  for (const row of (store.adRegisteredPopulation || [])) {
+    const t = row.HostName || '';
+    if (!t) continue;
+    if (!hostMap[t]) {
+      hostMap[t] = {
+        Target: t,
+        ResolvedAddress: row.DNSHostName || '',
+        ports: {},
+        steps: {}
+      };
+    }
+    hostMap[t].ADStatus = row.ADStatus || '';
+    hostMap[t].ReconcileBucket = row.ReconcileBucket || '';
+    hostMap[t].PopulationAuthority = row.PopulationAuthority || 'ad_registered';
+    if (row.Reachability) {
+      hostMap[t].steps.Ping = (row.Reachability || '').toLowerCase().includes('reach') ? 'success' : 'failed';
+    }
+    if (row.EvidenceSerial) hostMap[t].ObservedSerial = row.EvidenceSerial;
+    hostMap[t].Notes = [row.Reason, row.EvidenceSource, row.ProbeStatus].filter(Boolean).join(' | ');
   }
 
   return Object.values(hostMap).sort((a, b) => (a.Target || '').localeCompare(b.Target || ''));
@@ -3603,6 +3680,7 @@ const TYPE_SECTION_LABELS = {
   'network-preflight': 'Network review',
   'smb-recon': 'Network review',
   'naabu-reachability': 'Reachability evidence',
+  'ad-registered-population': 'AD registered population',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
   'software-superset': 'Software tracker',
@@ -3628,6 +3706,7 @@ const TYPE_TO_PANELS = {
   'naabu-reachability':  ['network'],
   'software-tracker':    ['software'],
   'software-superset':   ['software'],
+  'ad-registered-population': ['inventory', 'network'],
 };
 
 // ── Bootstrap ──────────────────────────────────────────────────────────────
@@ -3919,6 +3998,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'ram-info': '🧠', 'monitor-info': '🖥️', 'neuron-inventory': '🗂️',
     'smb-recon': '📂', 'status-json': '💚', 'remote-task': '⚡',
     'naabu-reachability': '🔌',
+    'ad-registered-population': '🏢',
     'software-tracker': '📦', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
@@ -4148,12 +4228,12 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Load evidence and review',
     railLabel: 'Review package',
-    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Do not expect the dashboard to import normalized target manifests until parser support is added.',
-    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)',
+    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. AD registered population CSVs show candidate targets — not serial or reachability proof.',
+    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/ad_reconcile/<run>/ad_registered_normalized.csv',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
-      'cybernet_targets.csv from sas-survey-targets.sh is not a dashboard import yet.'
+      'Treat AD rows as registered computer accounts, not confirmed Cybernet identity.'
     ],
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
@@ -4682,6 +4762,7 @@ function refreshAllPanels() {
   try { renderNetworkPanel(store); } catch(e) { console.warn('Network panel error:', e); }
   try { renderSoftwarePanel(store); } catch(e) { console.warn('Software panel error:', e); }
   updateCybernetReview();
+  updateCybernetAdPopulationSummary();
 }
 
 function _countUniqueTargets(rows, field = 'Target') {
@@ -4749,6 +4830,52 @@ function updateCybernetReview() {
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
   `;
+}
+
+function updateCybernetAdPopulationSummary() {
+  const root = document.getElementById('cybernet-ad-population-summary');
+  const stats = document.getElementById('cybernet-ad-population-stats');
+  if (!root || !stats) return;
+
+  const rows = store.adRegisteredPopulation || [];
+  if (!rows.length) {
+    root.classList.add('hidden');
+    stats.textContent = '';
+    return;
+  }
+
+  const enabled = rows.filter(r => {
+    const bucket = (r.ReconcileBucket || '').toLowerCase();
+    const en = String(r.Enabled ?? '').toLowerCase();
+    return bucket !== 'disabled' && en !== 'false' && bucket !== 'ad_disabled';
+  }).length;
+  const disabled = rows.filter(r => {
+    const bucket = (r.ReconcileBucket || '').toLowerCase();
+    const en = String(r.Enabled ?? '').toLowerCase();
+    return bucket === 'disabled' || bucket === 'ad_disabled' || en === 'false';
+  }).length;
+  const stale = rows.filter(r => (r.ReconcileBucket || '').toLowerCase() === 'stale').length;
+  const missingDns = rows.filter(r => !(r.DNSHostName || r.dnsHostName)).length;
+  const hostCounts = new Map();
+  for (const r of rows) {
+    const h = (r.HostName || '').toUpperCase();
+    if (h) hostCounts.set(h, (hostCounts.get(h) || 0) + 1);
+  }
+  const duplicates = [...hostCounts.values()].filter(n => n > 1).length;
+  const matchedManifest = rows.filter(r => (r.ReconcileBucket || '').toLowerCase() === 'matched').length;
+  const adOnly = rows.filter(r => (r.ReconcileBucket || '').toLowerCase() === 'ad_only').length;
+
+  stats.innerHTML = [
+    `<span><strong>${rows.length}</strong> registered computer accounts</span>`,
+    `<span><strong>${enabled}</strong> enabled candidates</span>`,
+    `<span><strong>${disabled}</strong> disabled</span>`,
+    `<span><strong>${stale}</strong> stale</span>`,
+    `<span><strong>${missingDns}</strong> missing DNS</span>`,
+    `<span><strong>${duplicates}</strong> duplicate names</span>`,
+    `<span><strong>${matchedManifest}</strong> matched manifest</span>`,
+    `<span><strong>${adOnly}</strong> AD-only</span>`,
+  ].join(' · ');
+  root.classList.remove('hidden');
 }
 
 // Update software tab badge when store changes

--- a/dashboard/js/parsers.js
+++ b/dashboard/js/parsers.js
@@ -36,7 +36,8 @@ function contentLooksLikeNaabuReachability(content) {
  * Detect the log type from filename and/or CSV headers.
  * Returns one of: 'preflight', 'results', 'workstation-identity',
  *   'printer-probe', 'network-preflight', 'machine-info', 'ram-info',
- *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon', 'naabu-reachability', 'unknown'
+ *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon',
+ *   'ad-registered-population', 'naabu-reachability', 'unknown'
  */
 export function detectFileType(filename, content) {
   const fn = filename.toLowerCase();
@@ -95,7 +96,11 @@ export function detectFileType(filename, content) {
   if (fn.startsWith('installed_software_') || fn.includes('/installed_software_') || fn.includes('\\installed_software_')) return 'software-superset';
   if (fn.includes('qrtask') || fn.includes('qr_task') || fn.includes('invoke-techtask') || fn.includes('runtask')) return 'remote-task';
   if (fn.includes('runcontrol') || fn.includes('run_control')) return 'remote-task';
-  if (fn.includes('wmi_identity') || fn.includes('wmi-identity')) return 'workstation-identity';
+  if (fn.includes('ad_registered') || fn.includes('ad-registered') || fn.includes('ad_evidence') ||
+      fn.includes('ad_only') || fn.includes('ad_disabled') || fn.includes('ad_stale') ||
+      fn.includes('ad_missing_dns') || fn.includes('ad_duplicates') || fn.includes('evidence_only')) {
+    return 'ad-registered-population';
+  }
 
   // Detect by headers if content is provided
   if (typeof content === 'string' && content.includes(',')) {
@@ -111,7 +116,9 @@ export function detectFileType(filename, content) {
     if (firstLine.includes('targethost') && firstLine.includes('matchexpected')) return 'neuron-inventory';
     if (firstLine.includes('share') && firstLine.includes('liststatus')) return 'smb-recon';
     if (firstLine.includes('taskname') || firstLine.includes('taskid') || firstLine.includes('outcome')) return 'remote-task';
-    if (firstLine.includes('publisher') && firstLine.includes('host') && firstLine.includes('name')) return 'software-superset';
+    if (firstLine.includes('populationauthority') && firstLine.includes('reconcilebucket')) return 'ad-registered-population';
+    if (firstLine.includes('populationauthority') && firstLine.includes('adstatus')) return 'ad-registered-population';
+    if (firstLine.includes('reconcilebucket') && firstLine.includes('hostname')) return 'ad-registered-population';
   }
 
   return 'unknown';
@@ -138,6 +145,7 @@ export function parseFileContent(type, content, filename) {
     case 'software-tracker': return parseSoftwareTracker(content, filename);
     case 'software-superset': return parseSoftwareSuperset(content);
     case 'naabu-reachability': return parseNaabuReachability(content, filename);
+    case 'ad-registered-population': return parseAdRegisteredPopulation(content, filename);
     default: return { type: 'unknown', rows: [], meta: {} };
   }
 }
@@ -330,6 +338,38 @@ function parseRemoteTask(content) {
   }
 
   return { type: 'remote-task', rows: [], meta: { count: 0 } };
+}
+
+/**
+ * Parse AD registered population reconcile CSVs.
+ * Expected columns include HostName, PopulationAuthority, ReconcileBucket / Bucket.
+ */
+function parseAdRegisteredPopulation(content, filename) {
+  const rows = parseCSV(content);
+  const normalized = rows.map(r => ({
+    HostName:        r.HostName        || r.hostname        || r.ComputerName || '',
+    DNSHostName:     r.DNSHostName     || r.dnshostname     || r.FQDN         || '',
+    ADStatus:        r.ADStatus        || r.adstatus        || '',
+    Enabled:         r.Enabled         || r.enabled         || '',
+    OperatingSystem: r.OperatingSystem || r.operatingsystem || r.OS           || '',
+    LastLogonDate:   r.LastLogonDate   || r.lastlogondate   || '',
+    Description:     r.Description     || r.description     || '',
+    ReconcileBucket: r.ReconcileBucket || r.reconcilebucket || r.Bucket       || '',
+    PopulationAuthority: r.PopulationAuthority || r.populationauthority || 'ad_registered',
+    MatchStatus:     r.MatchStatus     || r.matchstatus     || '',
+    EvidenceSerial:  r.EvidenceSerial  || r.evidenceserial  || r.Serial       || '',
+    EvidenceSource:  r.EvidenceSource  || r.evidencesource  || r.Source       || '',
+    Reachability:    r.Reachability    || r.reachability    || '',
+    ProbeStatus:     r.ProbeStatus     || r.probestatus     || '',
+    Reason:          r.Reason          || r.reason          || '',
+    _sourceFile:     filename || '',
+  })).filter(r => r.HostName);
+  const buckets = {};
+  for (const row of normalized) {
+    const b = row.ReconcileBucket || 'registered';
+    buckets[b] = (buckets[b] || 0) + 1;
+  }
+  return { type: 'ad-registered-population', rows: normalized, meta: { count: normalized.length, buckets } };
 }
 
 /**
@@ -551,6 +591,9 @@ export function mergeDataStore(existing, incoming) {
     case 'naabu-reachability':
       store.naabuReachability = (store.naabuReachability || []).concat(rows);
       break;
+    case 'ad-registered-population':
+      store.adRegisteredPopulation = (store.adRegisteredPopulation || []).concat(rows);
+      break;
   }
 
   return store;
@@ -601,6 +644,18 @@ export function buildInventoryRows(store) {
       Room: row.Room || '',
       Status: row.Status || hostMap[key]?.Status || '',
       _neuron: row
+    });
+  }
+
+  for (const row of (store.adRegisteredPopulation || [])) {
+    const h = row.HostName || '';
+    if (!h) continue;
+    const key = h.toUpperCase();
+    addHost(h, {
+      Status: row.ReconcileBucket || row.ADStatus || hostMap[key]?.Status || '',
+      Site: row.PopulationAuthority || 'ad_registered',
+      Serial: row.EvidenceSerial || hostMap[key]?.Serial || '',
+      _adPopulation: row
     });
   }
 
@@ -817,6 +872,28 @@ export function buildProtocolRows(store) {
     if (!port) continue;
     const reach = (row.reachability || 'open').toLowerCase();
     hostMap[t].ports[port] = reach === 'open' ? 'Open' : reach;
+  }
+
+  // AD registered population — reconcile buckets; do not treat AD as serial or reachability proof
+  for (const row of (store.adRegisteredPopulation || [])) {
+    const t = row.HostName || '';
+    if (!t) continue;
+    if (!hostMap[t]) {
+      hostMap[t] = {
+        Target: t,
+        ResolvedAddress: row.DNSHostName || '',
+        ports: {},
+        steps: {}
+      };
+    }
+    hostMap[t].ADStatus = row.ADStatus || '';
+    hostMap[t].ReconcileBucket = row.ReconcileBucket || '';
+    hostMap[t].PopulationAuthority = row.PopulationAuthority || 'ad_registered';
+    if (row.Reachability) {
+      hostMap[t].steps.Ping = (row.Reachability || '').toLowerCase().includes('reach') ? 'success' : 'failed';
+    }
+    if (row.EvidenceSerial) hostMap[t].ObservedSerial = row.EvidenceSerial;
+    hostMap[t].Notes = [row.Reason, row.EvidenceSource, row.ProbeStatus].filter(Boolean).join(' | ');
   }
 
   return Object.values(hostMap).sort((a, b) => (a.Target || '').localeCompare(b.Target || ''));

--- a/dashboard/samples/ad_registered_normalized.csv
+++ b/dashboard/samples/ad_registered_normalized.csv
@@ -1,0 +1,3 @@
+HostName,DNSHostName,ADStatus,Enabled,OperatingSystem,LastLogonDate,Description,DistinguishedName,SourceFile,PopulationAuthority,ReconcileBucket
+CYBTEST001,CYBTEST001.sample.local,AD_REGISTERED,true,Windows 10 Enterprise,2026-06-01,Cybernet synthetic fixture,CN=CYBTEST001,OU=Cybernet,DC=sample,DC=local,survey/fixtures/ad_registered_cybernet.sample.csv,ad_registered,matched
+CYBTEST002,,AD_REGISTERED,true,Windows 10 Enterprise,2026-06-15,Cybernet missing DNS fixture,CN=CYBTEST002,OU=Cybernet,DC=sample,DC=local,survey/fixtures/ad_registered_cybernet.sample.csv,ad_registered,missing_dns

--- a/dashboard/samples/ad_registered_population.sample.csv
+++ b/dashboard/samples/ad_registered_population.sample.csv
@@ -1,0 +1,8 @@
+HostName,DNSHostName,Enabled,ADStatus,ReconcileBucket,PopulationAuthority,LastLogonDate,Description
+CYBTEST001,CYBTEST001.sample.local,true,AD_REGISTERED,matched,ad_registered,2026-06-01,enabled matched fixture
+CYBTEST002,disabled.sample.local,false,AD_DISABLED,disabled,ad_registered,2026-06-01,disabled fixture
+CYBTEST003,stale.sample.local,true,AD_REGISTERED,stale,ad_registered,2024-01-01,stale fixture
+CYBTEST004,,true,AD_REGISTERED,missing_dns,ad_registered,2026-06-01,missing DNS fixture
+CYBTEST005,dup.sample.local,true,AD_REGISTERED,registered,ad_registered,2026-06-01,duplicate name A
+CYBTEST005,dup-b.sample.local,true,AD_REGISTERED,registered,ad_registered,2026-06-01,duplicate name B
+CYBTEST006,adonly.sample.local,true,AD_REGISTERED,ad_only,ad_registered,2026-06-01,AD-only fixture

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -28,6 +28,8 @@ const cases = [
   { file: 'status.json',                           expectedType: 'status-json',         minRows: null },
   { file: 'QRTask_log.json',                       expectedType: 'remote-task',         minRows: 3 },
   { file: 'RunControl_events.json',                expectedType: 'remote-task',         minRows: 3 },
+  { file: 'ad_registered_normalized.csv',            expectedType: 'ad-registered-population', minRows: 1 },
+  { file: 'ad_registered_population.sample.csv',    expectedType: 'ad-registered-population', minRows: 6 },
 ];
 
 // ── Naabu reachability parser cases (synthetic samples only) ────────────────
@@ -161,7 +163,16 @@ const contractChecks = [
   ['--targets-file /tmp/sas-cybernet/targets.txt', 'preflight/identity --targets-file'],
   ['--file /tmp/sas-cybernet/targets.txt', 'normalize --file reference'],
   ['keyports_cybernet_json', 'low-noise reachability profile'],
-  ['not a dashboard import yet', 'no false manifest import claim'],
+  ['ad-registered-population', 'AD parser type wired'],
+  ['store.adRegisteredPopulation', 'AD store wiring'],
+];
+
+const adContractChecks = [
+  ['cybernet-ad-population-summary', 'AD summary container in HTML'],
+  ['AD Registered Population', 'AD summary heading'],
+  ['registered computer accounts', 'AD population row label'],
+  ['not serial or reachability proof', 'no false AD proof claim'],
+  ['AD registered population', 'AD section label'],
 ];
 
 // ── Naabu reachability Cybernet review contracts (app.js) ───────────────────
@@ -204,6 +215,17 @@ for (const [needle, label] of naabuContractChecks) {
     shellFailed++;
   } else {
     console.log(`PASS [naabu-contract:${label}]`);
+    shellPassed++;
+  }
+}
+
+for (const [needle, label] of adContractChecks) {
+  const src = needle === 'cybernet-ad-population-summary' ? indexHtml : appJs;
+  if (!src.includes(needle)) {
+    console.error(`FAIL [ad-contract:${label}]: missing "${needle}"`);
+    shellFailed++;
+  } else {
+    console.log(`PASS [ad-contract:${label}]`);
     shellPassed++;
   }
 }

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -220,7 +220,9 @@ for (const [needle, label] of naabuContractChecks) {
 }
 
 for (const [needle, label] of adContractChecks) {
-  const src = needle === 'cybernet-ad-population-summary' ? indexHtml : appJs;
+  const src = (needle === 'cybernet-ad-population-summary' || needle === 'AD Registered Population')
+    ? indexHtml
+    : appJs;
   if (!src.includes(needle)) {
     console.error(`FAIL [ad-contract:${label}]: missing "${needle}"`);
     shellFailed++;

--- a/docs/AD_CYBERNET_EXPORT_CONTRACT.md
+++ b/docs/AD_CYBERNET_EXPORT_CONTRACT.md
@@ -1,0 +1,90 @@
+# AD Cybernet Export Contract
+
+This contract defines the minimum CSV shape for **authorized offline AD computer exports** consumed by `survey/sas-ad-reconcile.sh` and `survey/sas-import-ad-computers.py`.
+
+No live AD queries are performed by these tools. An administrator produces the export through approved directory tooling and places it in `logs/targets/` or passes `--ad-csv` explicitly.
+
+## Required semantics
+
+Each row represents one AD computer object. The reconcile tooling normalizes flexible column names but expects these meanings:
+
+| Field | Accepted column names | Required | Notes |
+|---|---|---|---|
+| Short hostname | `Name`, `HostName`, `Hostname`, `ComputerName`, `CN` | Yes | Normalized to uppercase short name |
+| DNS hostname | `DNSHostName`, `DNS Host Name`, `FQDN` | Recommended | Empty values bucket to `ad_missing_dns.csv` |
+| Enabled flag | `Enabled`, `AccountEnabled`, `ADEnabled` | Recommended | `false` / `0` → `ad_disabled.csv` |
+| Last logon | `LastLogonDate`, `LastLogonTimestamp`, `LastLogon`, `LastSeen` | Recommended | Used for `ad_stale.csv` when older than `--stale-days` |
+| Operating system | `OperatingSystem`, `OS` | Optional | Carried into normalized output |
+| Description | `Description`, `Comment`, `Notes` | Optional | Useful for Cybernet serial hints in downstream tooling |
+| Distinguished name | `DistinguishedName`, `DN`, `CanonicalName` | Optional | Audit trail only |
+
+## Example export command (admin workstation)
+
+PowerShell is used **only at export time** by authorized admins. The reconcile lane does not invoke it.
+
+```powershell
+Get-ADComputer -Filter {Name -like 'CYB*'} -Properties DNSHostName,OperatingSystem,LastLogonDate,Enabled,Description |
+  Select-Object Name,DNSHostName,OperatingSystem,LastLogonDate,Enabled,Description,DistinguishedName |
+  Export-Csv .\logs\targets\ad_cybernet_computers.csv -NoTypeInformation
+```
+
+## Synthetic fixture (committed)
+
+Smoke tests use `survey/fixtures/ad_registered_cybernet.sample.csv` with hostnames `CYBTEST001`, `CYBTEST002`, and `WNH000TEST001` only. No live Northwell identifiers.
+
+## Normalized output columns
+
+`ad_registered_normalized.csv` always uses:
+
+```text
+HostName,DNSHostName,ADStatus,Enabled,OperatingSystem,LastLogonDate,Description,DistinguishedName,SourceFile,PopulationAuthority,ReconcileBucket
+```
+
+- `PopulationAuthority` is always `ad_registered`.
+- `ReconcileBucket` is assigned during reconcile (`registered`, `disabled`, `stale`, `missing_dns`, `duplicate`, etc.).
+
+## Supplemental evidence CSVs (optional)
+
+### Manifest / tracker evidence (`--evidence-csv`)
+
+| Meaning | Accepted columns |
+|---|---|
+| Hostname | `HostName`, `Hostname`, `ComputerName`, `Target` |
+| Device type | `DeviceType`, `Type` |
+| Serial | `Serial`, `SerialNumber`, `ExpectedCybernetSerial` |
+| Source | `Source`, `SourceFile` |
+
+### Network reachability evidence (`--network-csv`)
+
+Pre-validated reachability only. Produced by approved Naabu/Nmap pipelines — **not** by `sas-ad-reconcile.sh`.
+
+| Meaning | Accepted columns |
+|---|---|
+| Hostname | `HostName`, `Hostname`, `Target` |
+| Reachability | `Reachability`, `Status`, `PingStatus` |
+| Source | `Source` |
+
+Values containing `reach`, `up`, `open`, or `success` (case-insensitive) classify as reachable. Values containing `silent`, `down`, `unreach`, `timeout`, or `fail` classify as silent.
+
+### Live serial evidence (`--serial-csv`)
+
+| Meaning | Accepted columns |
+|---|---|
+| Hostname | `HostName`, `Hostname`, `Target`, `ObservedHostName` |
+| Serial | `Serial`, `ObservedSerial`, `ResolvedSerial` |
+| Probe status | `ProbeStatus`, `SerialProbeStatus`, `serial_probe_status` |
+| Source | `Source`, `EvidenceSource` |
+
+Statuses containing `match`, `confirm`, or `found` → matched. Statuses containing `unavail`, `missing`, `fail`, or `no_match` → unavailable.
+
+## Population authority rule
+
+When AD and supplemental evidence disagree:
+
+1. AD registered population defines membership.
+2. Evidence-only rows are flagged in `evidence_only.csv` for manual review.
+3. AD-only rows remain valid registered targets until evidence proves otherwise.
+
+## Dashboard ingestion
+
+Drop `ad_registered_normalized.csv`, `ad_evidence_matches.csv`, or bucket CSVs into the dashboard. Files are detected as parser type `ad-registered-population`.

--- a/docs/AD_REGISTERED_POPULATION.md
+++ b/docs/AD_REGISTERED_POPULATION.md
@@ -1,0 +1,87 @@
+# AD Registered Population Doctrine
+
+Active Directory registered population is the **population authority** for Cybernet and Neuron target reconciliation in Northwell-forward field workflows.
+
+## Principle
+
+When an authorized AD computer export is available, treat AD as the authoritative registered population. Deployment trackers, subnet scans, and port probes are **evidence layers** that confirm or challenge AD records — they do not replace AD as the population source.
+
+## Approved input store
+
+Place authorized, scoped AD-derived exports in:
+
+```text
+logs/targets/
+```
+
+This directory is for **approved local AD-derived target input** only. Do not commit live exports. Synthetic fixtures under `survey/fixtures/` exist for smoke tests and dashboard parser validation.
+
+## Workflow boundary
+
+| Layer | Role | Mutates targets? |
+|---|---|---|
+| AD export CSV | Population authority | No |
+| `sas-ad-reconcile.sh` | Normalize, bucket, reconcile | No |
+| Naabu / Nmap | Reachability validation only | No |
+| Live serial / identity CSV | Correlation evidence | No |
+
+`sas-ad-reconcile.sh` consumes AD CSV and optional offline evidence. It does **not** query AD live, run Naabu, or run Nmap.
+
+## Required outputs
+
+Each reconcile run writes a self-contained output directory:
+
+| File | Purpose |
+|---|---|
+| `ad_registered_normalized.csv` | Normalized AD population |
+| `ad_targets_hostnames.txt` | Approved hostname targets (enabled, non-duplicate) |
+| `ad_targets_dns.txt` | Approved DNS names where present |
+| `ad_evidence_matches.csv` | AD rows matched to supplemental evidence |
+| `ad_only.csv` | Registered in AD, absent from evidence |
+| `evidence_only.csv` | Present in evidence, absent from AD |
+| `ad_disabled.csv` | Disabled AD computer accounts |
+| `ad_stale.csv` | Stale last-logon records (configurable threshold) |
+| `ad_missing_dns.csv` | Enabled hosts missing `DNSHostName` |
+| `ad_duplicates.csv` | Duplicate normalized hostname keys |
+| `network_reachable.csv` | Optional reachability evidence: reachable |
+| `network_silent.csv` | Optional reachability evidence: silent / unreachable |
+| `live_serial_matched.csv` | Optional serial evidence: matched |
+| `live_serial_unavailable.csv` | Optional serial evidence: unavailable |
+| `ad_summary.json` | Bucket counts and run metadata |
+| `README.txt` | Human-readable output guide |
+
+## Field command
+
+```bash
+bash survey/sas-ad-reconcile.sh \
+  --ad-csv logs/targets/ad_computers_export.csv \
+  --evidence-csv survey/input/cybernet_manifest.csv \
+  --network-csv survey/output/network_reachability.csv \
+  --serial-csv survey/output/live_serial_probe_results.csv \
+  --output-dir survey/output/ad_reconcile/run_001 \
+  --prefix CYB \
+  --stale-days 90
+```
+
+Use `--prefix` to scope hostname filters (`CYB`, `WNH`, etc.). Omit when the export is already scoped.
+
+## Evidence classification
+
+- **AD registered population** answers: *what should exist according to directory registration?*
+- **Reachability evidence** answers: *did an approved validation tool see the host?*
+- **Serial evidence** answers: *does an approved identity source align with the registered hostname?*
+
+Do not invert this order. Build manifests from AD reconciliation first, then attach reachability and serial evidence as secondary layers.
+
+## Safety
+
+- Authorized, scoped exports only.
+- Local import, reconcile, and report — no target mutation.
+- No live AD queries from Bash reconcile tooling.
+- No network scans from this script.
+
+## Related documents
+
+- [AD_CYBERNET_EXPORT_CONTRACT.md](AD_CYBERNET_EXPORT_CONTRACT.md) — CSV export contract for AD computer inventory
+- [CYBERNET_EVIDENCE_CORRELATION.md](CYBERNET_EVIDENCE_CORRELATION.md) — multi-source evidence merge (downstream)
+- [START-HERE-CYBERNET-NEURON-SURVEY.md](../START-HERE-CYBERNET-NEURON-SURVEY.md) — field workflow entry point

--- a/docs/dashboard/PR56_BROWSER_QA.md
+++ b/docs/dashboard/PR56_BROWSER_QA.md
@@ -1,0 +1,40 @@
+# PR56 Browser QA Status
+
+Branch: `feature/ad-registered-population-integration`
+Base: `main @ 2f526ed` (rebased)
+Date: 2026-06-25
+Browser harness: **not run in this lane** (no Playwright/browser automation invoked in agent runtime)
+
+## Result
+
+Overall QA result: **BLOCKED — manual browser pass required**
+
+Automated coverage: dashboard smoke **64/64 PASS** (18 parser + 24 shell + 18 tour + ad contracts), targets policy PASS, `Tests/bash/smoke-ad-reconcile.sh` PASS.
+
+## Smoke evidence (automated)
+
+| Check | Result |
+|-------|--------|
+| AD sample detected as `ad-registered-population` | PASS |
+| `store.adRegisteredPopulation` wiring in app.js | PASS |
+| AD summary container in index.html | PASS |
+| No false AD serial/reachability proof language | PASS |
+| Naabu parser contracts | PASS (no regression) |
+| Cybernet-first shell + tour | PASS (no regression) |
+
+## Manual browser checklist (operator)
+
+- [ ] First screen still has exactly 3 actions: Start Cybernet Survey, Load Evidence, Advanced Tools
+- [ ] Load `dashboard/samples/ad_registered_population.sample.csv`
+- [ ] Load Naabu sample JSON/JSONL
+- [ ] Confirm AD Registered Population summary appears separately from Review Results reachability block
+- [ ] Confirm UI does not claim AD proves serial or reachability
+- [ ] 320px viewport: no horizontal overflow on hero/review sections
+- [ ] Keyboard navigation through hero actions and Advanced Tools toggle
+- [ ] Advanced Tools panels still behave
+
+## Notes
+
+- AD population is **population authority**, not hardware identity or reachability proof.
+- Synthetic fixtures only; no live AD exports committed.
+- `logs/targets/` not touched in PR branch (`.gitkeep` removed per policy).

--- a/survey/fixtures/ad_evidence_manifest.sample.csv
+++ b/survey/fixtures/ad_evidence_manifest.sample.csv
@@ -1,0 +1,3 @@
+HostName,DeviceType,Serial,Source
+CYBTEST001,Cybernet,SERIAL-CYB-001,deployment_tracker_fixture
+CYBTEST999,Cybernet,SERIAL-CYB-999,manual_list_fixture

--- a/survey/fixtures/ad_live_serial.sample.csv
+++ b/survey/fixtures/ad_live_serial.sample.csv
@@ -1,0 +1,3 @@
+HostName,Serial,ProbeStatus,Source
+CYBTEST001,SERIAL-CYB-001,matched,identity_fixture
+CYBTEST002,,unavailable,identity_fixture

--- a/survey/fixtures/ad_network_evidence.sample.csv
+++ b/survey/fixtures/ad_network_evidence.sample.csv
@@ -1,0 +1,3 @@
+HostName,Reachability,Source
+CYBTEST001,reachable,naabu_fixture
+CYBTEST002,silent,naabu_fixture

--- a/survey/fixtures/ad_registered_cybernet.sample.csv
+++ b/survey/fixtures/ad_registered_cybernet.sample.csv
@@ -1,0 +1,7 @@
+Name,DNSHostName,Enabled,OperatingSystem,LastLogonDate,Description,DistinguishedName
+CYBTEST001,CYBTEST001.sample.local,True,Windows 10 Enterprise,2026-06-01,Cybernet synthetic fixture CYBTEST001,CN=CYBTEST001,OU=Cybernet,DC=sample,DC=local
+CYBTEST002,,True,Windows 10 Enterprise,2026-06-15,Cybernet missing DNS fixture,CN=CYBTEST002,OU=Cybernet,DC=sample,DC=local
+CYBTEST003,CYBTEST003.sample.local,False,Windows 10 Enterprise,2025-01-01,Disabled cybernet fixture,CN=CYBTEST003,OU=Cybernet,DC=sample,DC=local
+CYBTEST004,CYBTEST004-a.sample.local,True,Windows 10 Enterprise,2026-06-01,Duplicate hostname key fixture A,CN=CYBTEST004,OU=Cybernet,DC=sample,DC=local
+CYBTEST004,CYBTEST004-b.sample.local,True,Windows 10 Enterprise,2026-06-01,Duplicate hostname key fixture B,CN=CYBTEST004-B,OU=Cybernet,DC=sample,DC=local
+WNH000TEST001,WNH000TEST001.sample.local,True,Windows 10 IoT Enterprise,2024-01-01,Stale neuron synthetic fixture,CN=WNH000TEST001,OU=Neuron,DC=sample,DC=local

--- a/survey/sas-ad-reconcile.sh
+++ b/survey/sas-ad-reconcile.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+# Normalize AD registered population CSV, reconcile optional offline evidence,
+# and emit bucketed target lists. No live AD queries. No network scans.
+set -euo pipefail
+
+VERSION="1.0.0"
+AD_CSV=""
+EVIDENCE_CSV=""
+NETWORK_CSV=""
+SERIAL_CSV=""
+OUTPUT_DIR="survey/output/ad_reconcile"
+PREFIX=""
+STALE_DAYS=90
+PASS_THRU=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash survey/sas-ad-reconcile.sh --ad-csv PATH [options]
+
+Normalize an authorized AD computer export and reconcile optional offline evidence.
+Population authority is AD. This script does not query AD live or run Naabu/Nmap.
+
+Options:
+  --ad-csv PATH         Required AD computer CSV export
+  --evidence-csv PATH   Optional manifest/tracker evidence CSV
+  --network-csv PATH    Optional pre-validated reachability evidence CSV
+  --serial-csv PATH     Optional live-serial / identity evidence CSV
+  --output-dir PATH     Output directory (default: survey/output/ad_reconcile)
+  --prefix PREFIX       Optional hostname prefix filter (e.g. CYB, WNH)
+  --stale-days N        Days before LastLogonDate is stale (default: 90)
+  --pass-thru           Print ad_summary.json after writing
+  --version             Print version and exit
+  -h, --help            Show help
+
+Outputs (under --output-dir):
+  ad_registered_normalized.csv, ad_targets_hostnames.txt, ad_targets_dns.txt,
+  ad_evidence_matches.csv, ad_only.csv, evidence_only.csv, ad_disabled.csv,
+  ad_stale.csv, ad_missing_dns.csv, ad_duplicates.csv, network_reachable.csv,
+  network_silent.csv, live_serial_matched.csv, live_serial_unavailable.csv,
+  ad_summary.json, README.txt
+USAGE
+}
+
+fail() { echo "[ad-reconcile] ERROR: $*" >&2; exit 1; }
+log() { echo "[ad-reconcile] $*" >&2; }
+
+find_python() {
+  if command -v python3 >/dev/null 2>&1; then echo python3; return 0; fi
+  if command -v python >/dev/null 2>&1; then echo python; return 0; fi
+  fail "Python 3 required"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ad-csv) AD_CSV="${2:?}"; shift 2 ;;
+    --evidence-csv) EVIDENCE_CSV="${2:?}"; shift 2 ;;
+    --network-csv) NETWORK_CSV="${2:?}"; shift 2 ;;
+    --serial-csv) SERIAL_CSV="${2:?}"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="${2:?}"; shift 2 ;;
+    --prefix) PREFIX="${2:?}"; shift 2 ;;
+    --stale-days) STALE_DAYS="${2:?}"; shift 2 ;;
+    --pass-thru) PASS_THRU=1; shift ;;
+    --version) printf '%s\n' "$VERSION"; exit 0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$AD_CSV" ]] || fail "--ad-csv is required"
+[[ -f "$AD_CSV" ]] || fail "AD CSV not found: $AD_CSV"
+[[ "$STALE_DAYS" =~ ^[0-9]+$ ]] || fail "--stale-days must be a non-negative integer"
+
+mkdir -p "$OUTPUT_DIR"
+py="$(find_python)"
+
+"$py" - "$AD_CSV" "$EVIDENCE_CSV" "$NETWORK_CSV" "$SERIAL_CSV" "$OUTPUT_DIR" "$PREFIX" "$STALE_DAYS" <<'PY'
+import csv
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+ad_csv, evidence_csv, network_csv, serial_csv, output_dir, prefix, stale_days_s = sys.argv[1:8]
+out = Path(output_dir)
+out.mkdir(parents=True, exist_ok=True)
+prefix = (prefix or "").strip().upper()
+stale_days = int(stale_days_s or "90")
+now = dt.datetime.now(dt.timezone.utc)
+
+NORM_FIELDS = [
+    "HostName", "DNSHostName", "ADStatus", "Enabled", "OperatingSystem",
+    "LastLogonDate", "Description", "DistinguishedName", "SourceFile",
+    "PopulationAuthority", "ReconcileBucket",
+]
+
+MATCH_FIELDS = NORM_FIELDS + ["EvidenceHostName", "EvidenceDeviceType", "EvidenceSerial", "EvidenceSource", "MatchStatus"]
+BUCKET_FIELDS = ["HostName", "DNSHostName", "Bucket", "Reason", "PopulationAuthority", "SourceFile"]
+NET_FIELDS = ["HostName", "Reachability", "Source", "PopulationAuthority"]
+SERIAL_FIELDS = ["HostName", "Serial", "ProbeStatus", "Source", "PopulationAuthority"]
+
+
+def clean(value):
+    return str(value or "").strip()
+
+
+def norm_host(value):
+    value = clean(value).upper()
+    return value.split(".", 1)[0] if value else ""
+
+
+def first(row, names):
+    lowered = {str(k).lower(): clean(v) for k, v in row.items() if k is not None}
+    for name in names:
+        val = lowered.get(name.lower(), "")
+        if val:
+            return val
+    return ""
+
+
+def parse_bool_enabled(value):
+    val = clean(value).lower()
+    if val in {"false", "0", "no", "disabled"}:
+        return False
+    if val in {"true", "1", "yes", "enabled"}:
+        return True
+    return True
+
+
+def parse_date(value):
+    raw = clean(value)
+    if not raw:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%m/%d/%Y %H:%M:%S", "%m/%d/%Y"):
+        try:
+            parsed = dt.datetime.strptime(raw[:19], fmt)
+            return parsed.replace(tzinfo=dt.timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def is_stale(last_logon):
+    if last_logon is None:
+        return False
+    age = now - last_logon
+    return age.days > stale_days
+
+
+def write_csv(path, fields, rows):
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, quoting=csv.QUOTE_MINIMAL, lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in fields})
+
+
+def write_lines(path, lines):
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def load_ad_rows(path):
+    with Path(path).open(newline="", encoding="utf-8-sig") as handle:
+        return list(csv.DictReader(handle))
+
+
+def normalize_ad(path):
+    rows = []
+    host_counts = {}
+    for row in load_ad_rows(path):
+        dns_host = first(row, ["DNSHostName", "DNS Host Name", "FQDN"])
+        host = first(row, ["Name", "HostName", "Hostname", "ComputerName", "Computer", "CN"])
+        if not host and dns_host:
+            host = dns_host
+        host_norm = norm_host(host)
+        if not host_norm:
+            continue
+        if prefix and not host_norm.startswith(prefix):
+            continue
+        enabled = parse_bool_enabled(first(row, ["Enabled", "AccountEnabled", "ADEnabled"]))
+        last_logon_raw = first(row, ["LastLogonDate", "LastLogonTimestamp", "LastLogon", "Last Seen", "LastSeen"])
+        last_logon = parse_date(last_logon_raw)
+        host_counts[host_norm] = host_counts.get(host_norm, 0) + 1
+        ad_status = "AD_DISABLED" if not enabled else "AD_REGISTERED"
+        rows.append({
+            "HostName": host_norm,
+            "DNSHostName": clean(dns_host),
+            "ADStatus": ad_status,
+            "Enabled": "true" if enabled else "false",
+            "OperatingSystem": first(row, ["OperatingSystem", "OS", "Operating System"]),
+            "LastLogonDate": last_logon_raw,
+            "Description": first(row, ["Description", "Comment", "Notes"]),
+            "DistinguishedName": first(row, ["DistinguishedName", "DN", "CanonicalName"]),
+            "SourceFile": str(path),
+            "PopulationAuthority": "ad_registered",
+            "ReconcileBucket": "registered",
+            "_enabled": enabled,
+            "_stale": is_stale(last_logon),
+            "_missing_dns": not clean(dns_host),
+            "_duplicate": False,
+            "_host_count": 0,
+        })
+    for row in rows:
+        row["_host_count"] = host_counts.get(row["HostName"], 0)
+        row["_duplicate"] = row["_host_count"] > 1
+    return rows
+
+
+def load_evidence(path):
+    if not path or not Path(path).is_file():
+        return {}
+    index = {}
+    with Path(path).open(newline="", encoding="utf-8-sig") as handle:
+        for row in csv.DictReader(handle):
+            host = norm_host(first(row, ["HostName", "Hostname", "ComputerName", "Target", "Name"]))
+            if not host:
+                continue
+            index[host] = {
+                "EvidenceHostName": host,
+                "EvidenceDeviceType": first(row, ["DeviceType", "Type"]),
+                "EvidenceSerial": first(row, ["Serial", "SerialNumber", "ExpectedCybernetSerial", "ExpectedNeuronSerial"]),
+                "EvidenceSource": first(row, ["Source", "SourceFile"]) or str(path),
+            }
+    return index
+
+
+def load_network(path):
+    reachable, silent = [], []
+    if not path or not Path(path).is_file():
+        return reachable, silent
+    with Path(path).open(newline="", encoding="utf-8-sig") as handle:
+        for row in csv.DictReader(handle):
+            host = norm_host(first(row, ["HostName", "Hostname", "Target", "ComputerName"]))
+            if not host:
+                continue
+            status = clean(first(row, ["Reachability", "Status", "PingStatus"])).lower()
+            source = first(row, ["Source", "SourceFile"]) or str(path)
+            entry = {"HostName": host, "Reachability": status, "Source": source, "PopulationAuthority": "ad_registered"}
+            if any(tok in status for tok in ("reach", "up", "open", "success", "online")):
+                reachable.append(entry)
+            elif any(tok in status for tok in ("silent", "down", "unreach", "timeout", "fail", "offline")):
+                silent.append(entry)
+    return reachable, silent
+
+
+def load_serial(path):
+    matched, unavailable = [], []
+    if not path or not Path(path).is_file():
+        return matched, unavailable
+    with Path(path).open(newline="", encoding="utf-8-sig") as handle:
+        for row in csv.DictReader(handle):
+            host = norm_host(first(row, ["HostName", "Hostname", "Target", "ObservedHostName", "resolved_hostname"]))
+            if not host:
+                continue
+            serial = first(row, ["Serial", "ObservedSerial", "ResolvedSerial", "resolved_serial"])
+            status = clean(first(row, ["ProbeStatus", "SerialProbeStatus", "serial_probe_status"])).lower()
+            source = first(row, ["Source", "EvidenceSource", "evidence_source"]) or str(path)
+            entry = {"HostName": host, "Serial": serial, "ProbeStatus": status, "Source": source, "PopulationAuthority": "ad_registered"}
+            if any(tok in status for tok in ("match", "confirm", "found", "resolved")):
+                matched.append(entry)
+            elif any(tok in status for tok in ("unavail", "missing", "fail", "no_match", "unknown")) or not serial:
+                unavailable.append(entry)
+    return matched, unavailable
+
+
+ad_rows = normalize_ad(ad_csv)
+evidence = load_evidence(evidence_csv)
+network_reachable, network_silent = load_network(network_csv)
+serial_matched, serial_unavailable = load_serial(serial_csv)
+
+ad_hosts = {r["HostName"] for r in ad_rows}
+evidence_hosts = set(evidence.keys())
+
+disabled, stale, missing_dns, duplicates = [], [], [], []
+ad_only, evidence_only, matches = [], [], []
+target_hostnames, target_dns = [], []
+
+for row in ad_rows:
+    host = row["HostName"]
+    base = {k: row[k] for k in NORM_FIELDS}
+    if not row["_enabled"]:
+        row["ReconcileBucket"] = "disabled"
+        disabled.append({**base, "Bucket": "ad_disabled", "Reason": "AD account disabled"})
+        continue
+    if row["_duplicate"]:
+        row["ReconcileBucket"] = "duplicate"
+        duplicates.append({**base, "Bucket": "ad_duplicates", "Reason": "Duplicate normalized hostname key"})
+        continue
+    if row["_stale"]:
+        row["ReconcileBucket"] = "stale"
+        stale.append({**base, "Bucket": "ad_stale", "Reason": f"LastLogonDate older than {stale_days} days"})
+    if row["_missing_dns"]:
+        row["ReconcileBucket"] = "missing_dns"
+        missing_dns.append({**base, "Bucket": "ad_missing_dns", "Reason": "Missing DNSHostName"})
+    if row["ReconcileBucket"] == "registered":
+        target_hostnames.append(host)
+        if row["DNSHostName"]:
+            target_dns.append(row["DNSHostName"])
+    if host in evidence_hosts:
+        ev = evidence[host]
+        matches.append({**base, **ev, "MatchStatus": "ad_evidence_match"})
+        row["ReconcileBucket"] = "matched"
+    elif row["ReconcileBucket"] in {"registered", "stale", "missing_dns"}:
+        ad_only.append({**base, "Bucket": "ad_only", "Reason": "Registered in AD, absent from supplemental evidence"})
+
+for host, ev in sorted(evidence.items()):
+    if host not in ad_hosts:
+        evidence_only.append({
+            "HostName": host,
+            "DNSHostName": "",
+            "Bucket": "evidence_only",
+            "Reason": "Present in supplemental evidence, absent from AD export",
+            "PopulationAuthority": "ad_registered",
+            "SourceFile": ev.get("EvidenceSource", ""),
+            **{k: ev.get(k, "") for k in ("EvidenceHostName", "EvidenceDeviceType", "EvidenceSerial", "EvidenceSource")},
+        })
+
+normalized = [{k: row[k] for k in NORM_FIELDS} for row in ad_rows]
+write_csv(out / "ad_registered_normalized.csv", NORM_FIELDS, normalized)
+write_lines(out / "ad_targets_hostnames.txt", sorted(set(target_hostnames)))
+write_lines(out / "ad_targets_dns.txt", sorted(set(target_dns)))
+write_csv(out / "ad_evidence_matches.csv", MATCH_FIELDS, matches)
+write_csv(out / "ad_only.csv", BUCKET_FIELDS, ad_only)
+write_csv(out / "evidence_only.csv", BUCKET_FIELDS + ["EvidenceDeviceType", "EvidenceSerial", "EvidenceSource"],
+          [{k: r.get(k, "") for k in BUCKET_FIELDS + ["EvidenceDeviceType", "EvidenceSerial", "EvidenceSource"]} for r in evidence_only])
+write_csv(out / "ad_disabled.csv", BUCKET_FIELDS, disabled)
+write_csv(out / "ad_stale.csv", BUCKET_FIELDS, stale)
+write_csv(out / "ad_missing_dns.csv", BUCKET_FIELDS, missing_dns)
+write_csv(out / "ad_duplicates.csv", BUCKET_FIELDS, duplicates)
+write_csv(out / "network_reachable.csv", NET_FIELDS, network_reachable)
+write_csv(out / "network_silent.csv", NET_FIELDS, network_silent)
+write_csv(out / "live_serial_matched.csv", SERIAL_FIELDS, serial_matched)
+write_csv(out / "live_serial_unavailable.csv", SERIAL_FIELDS, serial_unavailable)
+
+summary = {
+    "population_authority": "ad_registered",
+    "source_ad_csv": str(ad_csv),
+    "output_dir": str(out),
+    "prefix_filter": prefix or None,
+    "stale_days": stale_days,
+    "generated_at": now.isoformat(),
+    "counts": {
+        "ad_registered_normalized": len(normalized),
+        "ad_targets_hostnames": len(set(target_hostnames)),
+        "ad_targets_dns": len(set(target_dns)),
+        "ad_evidence_matches": len(matches),
+        "ad_only": len(ad_only),
+        "evidence_only": len(evidence_only),
+        "ad_disabled": len(disabled),
+        "ad_stale": len(stale),
+        "ad_missing_dns": len(missing_dns),
+        "ad_duplicates": len(duplicates),
+        "network_reachable": len(network_reachable),
+        "network_silent": len(network_silent),
+        "live_serial_matched": len(serial_matched),
+        "live_serial_unavailable": len(serial_unavailable),
+    },
+}
+(out / "ad_summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+readme = f"""AD Registered Population Reconcile Output
+=========================================
+
+Population authority: ad_registered
+Source AD CSV: {ad_csv}
+Generated: {summary['generated_at']}
+
+Bucket files:
+  ad_registered_normalized.csv  — full normalized AD population
+  ad_targets_hostnames.txt      — approved hostname targets
+  ad_targets_dns.txt            — approved DNS names
+  ad_evidence_matches.csv       — AD rows matched to supplemental evidence
+  ad_only.csv                   — AD without supplemental evidence
+  evidence_only.csv             — supplemental evidence without AD row
+  ad_disabled.csv               — disabled AD accounts
+  ad_stale.csv                  — stale last-logon records (>{stale_days} days)
+  ad_missing_dns.csv            — enabled hosts missing DNSHostName
+  ad_duplicates.csv             — duplicate normalized hostname keys
+  network_reachable.csv         — optional pre-validated reachability (reachable)
+  network_silent.csv            — optional pre-validated reachability (silent)
+  live_serial_matched.csv       — optional serial evidence (matched)
+  live_serial_unavailable.csv   — optional serial evidence (unavailable)
+  ad_summary.json               — machine-readable counts
+
+This directory is local evidence only. Do not commit live exports.
+See docs/AD_REGISTERED_POPULATION.md for doctrine.
+"""
+(out / "README.txt").write_text(readme, encoding="utf-8")
+
+print(json.dumps(summary))
+PY
+
+log "Wrote AD reconcile outputs to $OUTPUT_DIR"
+
+if [[ "$PASS_THRU" -eq 1 ]]; then
+  cat "$OUTPUT_DIR/ad_summary.json"
+fi


### PR DESCRIPTION
## **User description**
## Summary
- Add AD-first doctrine and Cybernet export contract docs with START-HERE AD-first warning.
- Add `survey/sas-ad-reconcile.sh` to normalize authorized AD CSV exports, bucket population rows, and reconcile optional offline evidence (no live AD, no scans).
- Add dashboard parser type `ad-registered-population` with synthetic fixtures and smoke coverage.

## Test plan
- [x] `bash -n survey/sas-ad-reconcile.sh`
- [x] `bash Tests/bash/smoke-ad-reconcile.sh`
- [x] `node --check dashboard/js/parsers.js`
- [x] `node --check dashboard/js/app.js`
- [x] `node dashboard/build-bundle.js`
- [x] `node --check dashboard/js/bundle.js`
- [x] `python -m py_compile server.py`
- [ ] `node dashboard/smoke-test.js` — fails pre-existing: missing `dashboard/samples/Preflight.csv` and other legacy samples (not introduced by this PR)

## Notes
- Does not touch PRs #46, #47, or #49.
- Agent B cybernet-target-manifest parser reconciliation deferred to merge review.

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Use AD as the source of truth for registered Cybernet and Neuron targets**

### What Changed
- Added an AD reconcile flow that turns an authorized computer export into approved target lists, bucketed reports, and a summary file
- Split results into clear groups such as enabled targets, disabled accounts, stale records, missing DNS names, duplicates, AD-only rows, and evidence-only rows
- Dashboard now recognizes the new AD population files and shows them in inventory and network views
- Added smoke coverage and workflow guidance so teams use AD reconciliation before reachability checks

### Impact
`✅ Clearer target approval`
`✅ Fewer untracked AD exports`
`✅ Faster review of disabled, stale, and duplicate hosts`title: |-
Use AD reconciliation as the first step for Cybernet target lists
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
