### PR TITLE
feat(survey): Cybernet xlsx target ingester with offline enrichment

### DIFF
--- a/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
+++ b/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+RUNNER="survey/sas-cybernet-xlsx-targets.sh"
+PY="survey/sas-cybernet-xlsx-targets.py"
+
+[[ -f "$RUNNER" ]] || { echo "missing runner: $RUNNER"; exit 1; }
+[[ -f "$PY" ]] || { echo "missing python ingester: $PY"; exit 1; }
+bash -n "$RUNNER"
+
+command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1 || {
+  echo "python required for contract test"
+  exit 1
+}
+
+PYTHON_CMD=(python3)
+command -v python3 >/dev/null 2>&1 || PYTHON_CMD=(python)
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PRIMARY="$TMP_DIR/alejandro-fixture.xlsx"
+ENRICH="$TMP_DIR/enrichment-fixture.xlsx"
+OUT_MANIFEST="$TMP_DIR/cybernet_targets.csv"
+OUT_REPORT="$TMP_DIR/enrichment_report.csv"
+OUT_GAPS="$TMP_DIR/gaps.csv"
+
+"${PYTHON_CMD[@]}" - "$PRIMARY" "$ENRICH" <<'PY'
+import sys
+from openpyxl import Workbook
+
+primary_path, enrich_path = sys.argv[1:3]
+
+wb = Workbook()
+ws = wb.active
+ws.title = "AKBAR WAVE 1 AND 2"
+ws["A1"] = "MEDTEST24-00001"
+ws["A2"] = "MEDTEST24-00002"
+po = wb.create_sheet("PO 1")
+po["A1"] = "wts001opr001"
+po["B1"] = "MEDTEST24-00003"
+po["A2"] = "wts001opr002"
+po["B2"] = "MEDTEST24-00004"
+wb.save(primary_path)
+
+ewb = Workbook()
+dep = ewb.active
+dep.title = "Deployments"
+dep.append(["Device Type", "Cybernet Hostname", "Cybernet Serial", "Cybernet MAC"])
+dep.append(["Cybernet-Neuron", "WTS001OPR001", "MEDTEST24-00001", "000D050AA58D"])
+dep.append(["Cybernet-Neuron", "WTS001OPR002", "MEDTEST24-00002", "000D050AA58E"])
+host = ewb.create_sheet("SSUH Host")
+host["A1"] = "WTS001OPR099"
+ewb.save(enrich_path)
+PY
+
+bash "$RUNNER" \
+  --workbook "$PRIMARY" \
+  --enrichment "$ENRICH" \
+  --output "$OUT_MANIFEST" \
+  --report "$OUT_REPORT" \
+  --gaps "$OUT_GAPS" \
+  --device-type Cybernet >/dev/null
+
+for path in "$OUT_MANIFEST" "$OUT_REPORT" "$OUT_GAPS"; do
+  [[ -f "$path" ]] || { echo "missing output: $path"; exit 1; }
+done
+
+manifest_rows="$(($(wc -l < "$OUT_MANIFEST") - 1))"
+report_rows="$(($(wc -l < "$OUT_REPORT") - 1))"
+gap_rows="$(($(wc -l < "$OUT_GAPS") - 1))"
+
+[[ "$manifest_rows" -gt 0 ]] || { echo "expected manifest rows > 0"; exit 1; }
+[[ "$report_rows" -gt 0 ]] || { echo "expected report rows > 0"; exit 1; }
+
+head -n 1 "$OUT_MANIFEST" | grep -q 'IdentifierType'
+head -n 1 "$OUT_REPORT" | grep -q 'ResolutionStatus'
+grep -qE 'FULL|PARTIAL|MINIMAL' "$OUT_REPORT"
+
+printf 'Cybernet xlsx target ingester contracts passed (manifest=%s report=%s gaps=%s).\n' \
+  "$manifest_rows" "$report_rows" "$gap_rows"

--- a/docs/CYBERNET_XLSX_TARGET_INGESTION.md
+++ b/docs/CYBERNET_XLSX_TARGET_INGESTION.md
@@ -1,0 +1,94 @@
+# Cybernet XLSX Target Ingestion
+
+Read-only, offline ingester that converts Alejandro-style Cybernet workbooks plus optional enrichment trackers into the normalized survey manifest schema used by SysAdminSuite Bash tooling.
+
+## Prerequisites
+
+- Python 3 with `openpyxl` (`pip install openpyxl`)
+- Git Bash or MSYS2 Bash on Windows (wrapper is Bash-first)
+
+## Primary workbook (Alejandro list)
+
+Expected sheets:
+
+| Sheet pattern | Columns | Notes |
+|---|---|---|
+| `AKBAR WAVE …` | A = serial | Serial-only wave rows |
+| `PO …` | A = hostname, B = serial | Blank rows skipped |
+
+## Enrichment workbooks (optional, repeatable)
+
+Recognized sheets:
+
+| Sheet | Purpose |
+|---|---|
+| `Deployments` | Cybernet hostname, serial, MAC from deployment tracker |
+| `SSUH Configs` | Configured Cybernet / Neuron identity pairs |
+| `configured cybernets*` | Hostname-centric configured Cybernet rows |
+| `CDW Stock` | Serial numbers from stock tab |
+| `SSUH Host` | Hostname list (column A) |
+| `Neuron Cybernet` | PC name + Cybernet serial (+ Neuron MAC when present) |
+
+Pass each enrichment file with `--enrichment`. The ingester merges by normalized serial or hostname.
+
+## Command
+
+```bash
+bash survey/sas-cybernet-xlsx-targets.sh \
+  --workbook /path/to/local/alejandro-workbook.xlsx \
+  --enrichment /path/to/local/active-deployment-tracker.xlsx \
+  --enrichment /path/to/local/all-wave-anesthesia-machines.xlsx \
+  --output survey/output/cybernet_alejandro_targets.csv \
+  --report survey/output/cybernet_alejandro_enrichment_report.csv \
+  --gaps survey/output/cybernet_alejandro_gaps.csv \
+  --device-type Cybernet
+```
+
+Defaults write to `survey/output/cybernet_alejandro_*.csv` when `--output`, `--report`, or `--gaps` are omitted.
+
+## Outputs
+
+### Manifest CSV
+
+Schema (handoff to `sas-survey-targets.sh` and field survey scripts):
+
+```text
+Identifier,IdentifierType,DeviceType,HostName,Serial,MACAddress,Source
+```
+
+### Enrichment report
+
+Per-target resolution after cross-source merge:
+
+- `ResolutionStatus`: `FULL` (host + serial + MAC), `PARTIAL` (two of three), `MINIMAL` (one or none)
+- Input vs resolved hostname, serial, and MAC columns
+- `GapNote` when fields remain missing
+
+### Gap CSV
+
+Subset of targets that did not reach `FULL` resolution, with `GapReason` (for example `missing:HostName,MACAddress`).
+
+## Next step — survey manifest resolver
+
+After ingestion, optionally pass the manifest through the Bash resolver:
+
+```bash
+bash survey/sas-survey-targets.sh \
+  --device-type Cybernet \
+  --csv survey/output/cybernet_alejandro_targets.csv \
+  --output survey/output/cybernet_targets_resolved.csv
+```
+
+## Contract test
+
+```bash
+bash Tests/bash/test-cybernet-xlsx-targets-contracts.sh
+```
+
+Builds tiny fixture workbooks, runs the wrapper, and verifies manifest/report/gap outputs.
+
+## Safety
+
+- Read-only: does not modify source `.xlsx` files
+- Offline: no network calls
+- Treat output CSVs as operational data; keep them out of git (repo ignores `*.csv` / `survey/output/*`)

--- a/docs/CYBERNET_XLSX_TARGET_INGESTION.md
+++ b/docs/CYBERNET_XLSX_TARGET_INGESTION.md
@@ -2,6 +2,20 @@
 
 Read-only, offline ingester that converts Alejandro-style Cybernet workbooks plus optional enrichment trackers into the normalized survey manifest schema used by SysAdminSuite Bash tooling.
 
+## Targets intake doctrine
+
+| Location | Role |
+|----------|------|
+| `targets/` | Official tracked intake hub (docs, schemas, sanitized fixtures only) |
+| `targets/local/` | Preferred **gitignored** local intake beside the hub |
+| `logs/targets/` | Preserved historical local evidence — **do not delete, move, or commit** |
+| `survey/input/` | Runtime staging (gitignored) |
+| `survey/output/` | Generated manifests and reports (gitignored) |
+
+- The ingester reads **explicit workbook paths** wherever they live locally.
+- You do **not** need to migrate existing `logs/targets/` files; point `--workbook` and `--enrichment` at their current paths.
+- Outputs are target **manifests**, not network evidence. Do not treat them as proof of reachability.
+
 ## Prerequisites
 
 - Python 3 with `openpyxl` (`pip install openpyxl`)
@@ -33,15 +47,26 @@ Pass each enrichment file with `--enrichment`. The ingester merges by normalized
 
 ## Command
 
+Example using ignored local intake under `targets/local/` (preferred for new work):
+
 ```bash
 bash survey/sas-cybernet-xlsx-targets.sh \
-  --workbook /path/to/local/alejandro-workbook.xlsx \
-  --enrichment /path/to/local/active-deployment-tracker.xlsx \
-  --enrichment /path/to/local/all-wave-anesthesia-machines.xlsx \
+  --workbook "targets/local/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
+  --enrichment "targets/local/Cybernet sources/Active Deployment Tracker 2026-05-17 (1).xlsx" \
+  --enrichment "targets/local/Cybernet sources/ALL WAVE ANESTHESIA MACHINES (1).xlsx" \
   --output survey/output/cybernet_alejandro_targets.csv \
   --report survey/output/cybernet_alejandro_enrichment_report.csv \
   --gaps survey/output/cybernet_alejandro_gaps.csv \
   --device-type Cybernet
+```
+
+Historical local evidence under `logs/targets/` remains valid — pass those paths instead if you have not migrated:
+
+```bash
+bash survey/sas-cybernet-xlsx-targets.sh \
+  --workbook "/path/to/logs/targets/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
+  --enrichment "/path/to/logs/targets/Cybernet sources/Active Deployment Tracker 2026-05-17 (1).xlsx" \
+  --output survey/output/cybernet_alejandro_targets.csv
 ```
 
 Defaults write to `survey/output/cybernet_alejandro_*.csv` when `--output`, `--report`, or `--gaps` are omitted.

--- a/survey/sas-cybernet-xlsx-targets.py
+++ b/survey/sas-cybernet-xlsx-targets.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Read-only Cybernet xlsx target ingester for SysAdminSuite (offline, openpyxl)."""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+try:
+    from openpyxl import load_workbook
+except ImportError:
+    print("[sas-cybernet-xlsx] ERROR: openpyxl required (pip install openpyxl)", file=sys.stderr)
+    sys.exit(1)
+
+MANIFEST_FIELDS = ["Identifier", "IdentifierType", "DeviceType", "HostName", "Serial", "MACAddress", "Source"]
+REPORT_FIELDS = [
+    "InputSerial", "InputHostName", "ResolvedHostName", "ResolvedSerial",
+    "ResolvedMACAddress", "ResolutionStatus", "Source", "GapNote",
+]
+GAP_FIELDS = [
+    "Identifier", "IdentifierType", "HostName", "Serial", "MACAddress",
+    "ResolutionStatus", "GapReason", "Source",
+]
+Rec = dict[str, str]
+EMPTY = {"", "N/A", "NA", "NONE", "NULL", "-", "--", "TBD", "UNKNOWN", "#N/A", "#REF!"}
+HOSTNAME_RE = re.compile(r"^[A-Za-z]{2,6}\d{2,}[A-Za-z0-9_-]*$|^[A-Za-z0-9]+[-_][A-Za-z0-9]+")
+MAC_RE = re.compile(r"(?i)(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}")
+HOST_HEADERS = ("cybernet hostname", "pc name", "hostname", "host name", "host", "computer name")
+SERIAL_HEADERS = ("cybernet serial", "pc / cybernet serial no", "cybernet serial number", "serial number", "serial", "service tag")
+MAC_HEADERS = ("cybernet mac", "mac address", "mac")
+NEURON_MAC_HEADERS = ("neuron mac",)
+
+
+def clean(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return "" if text.upper() in EMPTY else text
+
+
+def norm_serial(value: object) -> str:
+    text = re.sub(r"\s+", "", clean(value)).upper()
+    return text if len(text) >= 3 else ""
+
+
+def norm_host(value: object) -> str:
+    text = re.sub(r"\s+", "", clean(value)).upper()
+    return text if text and HOSTNAME_RE.search(text) else ""
+
+
+def norm_mac(value: object) -> str:
+    text = clean(value)
+    if not text:
+        return ""
+    match = MAC_RE.search(text)
+    if not match:
+        return ""
+    raw = re.sub(r"[^0-9A-Fa-f]", "", match.group(0)).upper()
+    return ":".join(raw[i : i + 2] for i in range(0, 12, 2)) if len(raw) == 12 else ""
+
+
+def identifier_type(value: str) -> str:
+    value = clean(value)
+    if not value:
+        return "Unknown"
+    hexv = re.sub(r"[^0-9A-Fa-f]", "", value)
+    if len(hexv) == 12 and re.search(r"[:\-.]|^[0-9A-Fa-f]{12}$", value):
+        return "MAC"
+    return "HostName" if HOSTNAME_RE.search(value) else "Serial"
+
+
+def merge_source(*parts: str) -> str:
+    seen: list[str] = []
+    for part in parts:
+        for item in str(part or "").split(";"):
+            item = item.strip()
+            if item and item not in seen:
+                seen.append(item)
+    return ";".join(seen)
+
+
+def merge_pair(left: Rec, right: Rec) -> Rec:
+    out = left.copy()
+    for field in ("host", "serial", "mac"):
+        if not out.get(field) and right.get(field):
+            out[field] = right[field]
+    out["source"] = merge_source(out.get("source", ""), right.get("source", ""))
+    return out
+
+
+def records_overlap(left: Rec, right: Rec) -> bool:
+    return any(left.get(k) and left[k] == right.get(k) for k in ("serial", "host"))
+
+
+def merge_records(records: list[Rec]) -> list[Rec]:
+    merged = [rec.copy() for rec in records if any(rec.get(k) for k in ("host", "serial", "mac"))]
+    changed = True
+    while changed:
+        changed, groups, used = False, [], [False] * len(merged)
+        for index, rec in enumerate(merged):
+            if used[index]:
+                continue
+            current, used[index] = rec.copy(), True
+            for other_index in range(index + 1, len(merged)):
+                if used[other_index] or not records_overlap(current, merged[other_index]):
+                    continue
+                current = merge_pair(current, merged[other_index])
+                used[other_index] = changed = True
+            groups.append(current)
+        merged = groups
+    return merged
+
+
+def resolution_status(rec: Rec) -> str:
+    count = sum(1 for key in ("host", "serial", "mac") if rec.get(key))
+    return "FULL" if count >= 3 else "PARTIAL" if count >= 2 else "MINIMAL"
+
+
+def gap_reason(rec: Rec) -> str:
+    if resolution_status(rec) == "FULL":
+        return ""
+    missing = [name for key, name in (("host", "HostName"), ("serial", "Serial"), ("mac", "MACAddress")) if not rec.get(key)]
+    return f"missing:{','.join(missing)}" if missing else "minimal_identity"
+
+
+def cell(row: tuple[object, ...], index: int | None) -> str:
+    return clean(row[index]) if index is not None and index < len(row) else ""
+
+
+def header_map(row: tuple[object, ...]) -> dict[str, int]:
+    return {
+        re.sub(r"\s+", " ", str(value or "").strip()).lower(): idx
+        for idx, value in enumerate(row)
+        if clean(value)
+    }
+
+
+def pick_column(headers: dict[str, int], names: tuple[str, ...]) -> int | None:
+    for name in names:
+        if name in headers:
+            return headers[name]
+    for key, idx in headers.items():
+        if any(name in key for name in names):
+            return idx
+    return None
+
+
+def record_from_row(row: tuple[object, ...], headers: dict[str, int], source: str, *, neuron_mac: bool = False) -> Rec | None:
+    host_idx = pick_column(headers, HOST_HEADERS)
+    serial_idx = pick_column(headers, SERIAL_HEADERS)
+    mac_idx = pick_column(headers, NEURON_MAC_HEADERS if neuron_mac else MAC_HEADERS)
+    if mac_idx is None and neuron_mac:
+        mac_idx = pick_column(headers, MAC_HEADERS)
+    host, serial, mac = norm_host(cell(row, host_idx)), norm_serial(cell(row, serial_idx)), norm_mac(cell(row, mac_idx))
+    return None if not (host or serial or mac) else {"host": host, "serial": serial, "mac": mac, "source": source}
+
+
+def parse_alejandro_workbook(path: Path) -> list[Rec]:
+    records: list[Rec] = []
+    wb = load_workbook(path, read_only=True, data_only=True)
+    try:
+        for ws in wb.worksheets:
+            title, upper = ws.title.strip(), ws.title.strip().upper()
+            source = f"Alejandro:{path.name}:{title}"
+            if "AKBAR WAVE" in upper:
+                records.extend({"host": "", "serial": s, "mac": "", "source": source}
+                               for row in ws.iter_rows(values_only=True)
+                               if (s := norm_serial(cell(row, 0))))
+            elif upper.startswith("PO"):
+                for row in ws.iter_rows(values_only=True):
+                    host, serial = norm_host(cell(row, 0)), norm_serial(cell(row, 1))
+                    if host or serial:
+                        records.append({"host": host, "serial": serial, "mac": "", "source": source})
+    finally:
+        wb.close()
+    return records
+
+
+def parse_enrichment_sheet(ws, path: Path, title: str) -> list[Rec]:
+    lower, source, records = title.lower(), f"Enrichment:{path.name}:{title}", []
+    if lower == "ssuh host":
+        return [{"host": h, "serial": "", "mac": "", "source": source}
+                for row in ws.iter_rows(values_only=True) if (h := norm_host(cell(row, 0)))]
+    headers, serial_idx = None, 1
+    for row in ws.iter_rows(values_only=True):
+        row_headers = header_map(row)
+        if lower == "cdw stock":
+            if "cybernet serial number" in row_headers:
+                headers, serial_idx = row_headers, row_headers["cybernet serial number"]
+                continue
+            if headers and (serial := norm_serial(cell(row, serial_idx))):
+                records.append({"host": "", "serial": serial, "mac": "", "source": source})
+            continue
+        if lower == "neuron cybernet":
+            if "pc name" in row_headers and "pc / cybernet serial no" in row_headers:
+                headers = row_headers
+                continue
+            if headers and (rec := record_from_row(row, headers, source, neuron_mac=True)):
+                records.append(rec)
+            continue
+        if any(name in row_headers for name in HOST_HEADERS + SERIAL_HEADERS + MAC_HEADERS):
+            headers = row_headers
+            continue
+        if headers and (rec := record_from_row(row, headers, source)):
+            records.append(rec)
+    return records
+
+
+def parse_enrichment_workbook(path: Path) -> list[Rec]:
+    records: list[Rec] = []
+    wb = load_workbook(path, read_only=True, data_only=True)
+    try:
+        for ws in wb.worksheets:
+            title, lower = ws.title.strip(), ws.title.strip().lower()
+            if lower in {"ssuh host", "cdw stock", "neuron cybernet", "deployments", "ssuh configs"} or lower.startswith("configured cybernets"):
+                records.extend(parse_enrichment_sheet(ws, path, title))
+    finally:
+        wb.close()
+    return records
+
+
+def enrich_records(base: list[Rec], enrichment: list[Rec]) -> list[Rec]:
+    by_serial, by_host = {}, {}
+    for rec in enrichment:
+        if rec.get("serial"):
+            by_serial.setdefault(rec["serial"], []).append(rec)
+        if rec.get("host"):
+            by_host.setdefault(rec["host"], []).append(rec)
+    enriched = []
+    for rec in base:
+        out = rec.copy()
+        matches = []
+        if out.get("serial"):
+            matches.extend(by_serial.get(out["serial"], []))
+        if out.get("host"):
+            matches.extend(by_host.get(out["host"], []))
+        for match in matches:
+            for field in ("host", "serial", "mac"):
+                if not out.get(field) and match.get(field):
+                    out[field] = match[field]
+            out["source"] = merge_source(out.get("source", ""), match.get("source", ""))
+        enriched.append(out)
+    return enriched
+
+
+def match_before_state(after: Rec, before: list[Rec]) -> Rec:
+    matched, hits = {"host": "", "serial": "", "mac": "", "source": ""}, 0
+    for candidate in before:
+        if records_overlap(after, candidate):
+            matched, hits = merge_pair(matched, candidate), hits + 1
+    return matched if hits else after.copy()
+
+
+def manifest_row(rec: Rec, device_type: str) -> Rec:
+    host, serial, mac = rec.get("host", ""), rec.get("serial", ""), rec.get("mac", "")
+    identifier = host or serial or mac
+    itype = identifier_type(identifier)
+    if not host and itype == "HostName":
+        host = norm_host(identifier)
+    if not serial and itype == "Serial":
+        serial = norm_serial(identifier)
+    if not mac and itype == "MAC":
+        mac = norm_mac(identifier)
+    return {
+        "Identifier": identifier, "IdentifierType": itype, "DeviceType": device_type,
+        "HostName": host, "Serial": serial, "MACAddress": mac, "Source": rec.get("source", ""),
+    }
+
+
+def write_csv(path: Path, fields: list[str], rows: list[Rec]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_reports(before: list[Rec], after: list[Rec], device_type: str) -> tuple[list[Rec], list[Rec]]:
+    report, gaps = [], []
+    for src, dst in zip(before, after):
+        status, note = resolution_status(dst), gap_reason(dst)
+        report.append({
+            "InputSerial": src.get("serial", ""), "InputHostName": src.get("host", ""),
+            "ResolvedHostName": dst.get("host", ""), "ResolvedSerial": dst.get("serial", ""),
+            "ResolvedMACAddress": dst.get("mac", ""), "ResolutionStatus": status,
+            "Source": dst.get("source", ""), "GapNote": note,
+        })
+        if status != "FULL":
+            manifest = manifest_row(dst, device_type)
+            gaps.append({
+                "Identifier": manifest["Identifier"], "IdentifierType": manifest["IdentifierType"],
+                "HostName": manifest["HostName"], "Serial": manifest["Serial"],
+                "MACAddress": manifest["MACAddress"], "ResolutionStatus": status,
+                "GapReason": note or "minimal_identity", "Source": manifest["Source"],
+            })
+    return report, gaps
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Read-only Cybernet xlsx target ingester")
+    parser.add_argument("--workbook", required=True, help="Primary Alejandro-style workbook")
+    parser.add_argument("--enrichment", action="append", default=[], help="Enrichment workbook (repeatable)")
+    parser.add_argument("--output", default="survey/output/cybernet_alejandro_targets.csv")
+    parser.add_argument("--report", default="survey/output/cybernet_alejandro_enrichment_report.csv")
+    parser.add_argument("--gaps", default="survey/output/cybernet_alejandro_gaps.csv")
+    parser.add_argument("--device-type", default="Cybernet")
+    args = parser.parse_args()
+
+    workbook = Path(args.workbook)
+    if not workbook.is_file():
+        print(f"[sas-cybernet-xlsx] ERROR: workbook not found: {workbook}", file=sys.stderr)
+        return 1
+
+    base = parse_alejandro_workbook(workbook)
+    if not base:
+        print(f"[sas-cybernet-xlsx] ERROR: no targets parsed from {workbook}", file=sys.stderr)
+        return 1
+
+    enrichment_rows: list[Rec] = []
+    for path_str in args.enrichment:
+        path = Path(path_str)
+        if not path.is_file():
+            print(f"[sas-cybernet-xlsx] ERROR: enrichment workbook not found: {path}", file=sys.stderr)
+            return 1
+        enrichment_rows.extend(parse_enrichment_workbook(path))
+
+    merged_before = merge_records(base)
+    enriched = enrich_records(merged_before, enrichment_rows) if enrichment_rows else [r.copy() for r in merged_before]
+    merged_after = merge_records(enriched)
+    manifest = [manifest_row(rec, args.device_type) for rec in merged_after]
+    report, gaps = build_reports([match_before_state(rec, merged_before) for rec in merged_after], merged_after, args.device_type)
+
+    output, report_path, gaps_path = Path(args.output), Path(args.report), Path(args.gaps)
+    write_csv(output, MANIFEST_FIELDS, manifest)
+    write_csv(report_path, REPORT_FIELDS, report)
+    write_csv(gaps_path, GAP_FIELDS, gaps)
+
+    full = sum(row["ResolutionStatus"] == "FULL" for row in report)
+    partial = sum(row["ResolutionStatus"] == "PARTIAL" for row in report)
+    minimal = sum(row["ResolutionStatus"] == "MINIMAL" for row in report)
+    print(f"[sas-cybernet-xlsx] manifest={len(manifest)} report={len(report)} gaps={len(gaps)} FULL={full} PARTIAL={partial} MINIMAL={minimal}")
+    print(f"[sas-cybernet-xlsx] wrote {output}")
+    print(f"[sas-cybernet-xlsx] wrote {report_path}")
+    print(f"[sas-cybernet-xlsx] wrote {gaps_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/survey/sas-cybernet-xlsx-targets.sh
+++ b/survey/sas-cybernet-xlsx-targets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SysAdminSuite Cybernet xlsx target ingester (Bash wrapper)
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Cybernet XLSX target ingester (read-only, offline)
+
+Usage:
+  ./survey/sas-cybernet-xlsx-targets.sh --workbook PATH.xlsx [options]
+
+Options:
+  --workbook PATH           Primary Alejandro-style workbook (required)
+  --enrichment PATH         Optional enrichment workbook (repeatable)
+  --output PATH             Manifest CSV (default: survey/output/cybernet_alejandro_targets.csv)
+  --report PATH             Enrichment report CSV
+  --gaps PATH               Gap report CSV
+  --device-type TYPE        Default: Cybernet
+  -h, --help                Show help
+USAGE
+}
+
+WORKBOOK=""
+ENRICHMENT=()
+OUTPUT="survey/output/cybernet_alejandro_targets.csv"
+REPORT="survey/output/cybernet_alejandro_enrichment_report.csv"
+GAPS="survey/output/cybernet_alejandro_gaps.csv"
+DEVICE_TYPE="Cybernet"
+PYTHON_CMD=()
+
+find_python() {
+  if [[ ${#PYTHON_CMD[@]} -gt 0 ]]; then return 0; fi
+  if command -v python3 >/dev/null 2>&1; then PYTHON_CMD=(python3); return 0; fi
+  if command -v python >/dev/null 2>&1; then PYTHON_CMD=(python); return 0; fi
+  if command -v py >/dev/null 2>&1; then PYTHON_CMD=(py -3); return 0; fi
+  echo "[sas-cybernet-xlsx] ERROR: Python 3 required" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workbook) WORKBOOK="${2:?}"; shift 2 ;;
+    --enrichment) ENRICHMENT+=("$2"); shift 2 ;;
+    --output) OUTPUT="${2:?}"; shift 2 ;;
+    --report) REPORT="${2:?}"; shift 2 ;;
+    --gaps) GAPS="${2:?}"; shift 2 ;;
+    --device-type) DEVICE_TYPE="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "[sas-cybernet-xlsx] ERROR: unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+[[ -n "$WORKBOOK" ]] || { echo "[sas-cybernet-xlsx] ERROR: --workbook required" >&2; exit 1; }
+find_python
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+args=(--workbook "$WORKBOOK" --output "$OUTPUT" --report "$REPORT" --gaps "$GAPS" --device-type "$DEVICE_TYPE")
+for e in "${ENRICHMENT[@]}"; do args+=(--enrichment "$e"); done
+"${PYTHON_CMD[@]}" "$SCRIPT_DIR/sas-cybernet-xlsx-targets.py" "${args[@]}"


### PR DESCRIPTION
## **User description**
## Summary
- Add Bash-first `survey/sas-cybernet-xlsx-targets.sh` + Python ingester for local Cybernet xlsx workbooks (read-only, offline).
- Outputs normalized manifest + enrichment report + gap CSV under `survey/output/` (gitignored).
- Contract test uses synthetic fixture only; no operational xlsx committed.

## Test plan
- [x] `bash Tests/bash/test-cybernet-xlsx-targets-contracts.sh`
- [x] Local offline run against Alejandro + enrichment workbooks (outputs gitignored)
- [ ] Review gap/coverage semantics before field use

## Notes
- Does not delete or commit `logs/targets/` source workbooks.
- No live network probes.


___

## **CodeAnt-AI Description**
**Add an offline Cybernet XLSX target ingester with enrichment reports**

### What Changed
- Added a Bash entrypoint and Python ingester that turn Cybernet workbook rows into a normalized manifest CSV.
- Supports optional enrichment workbooks to fill in missing hostnames, serials, and MAC addresses, then writes a resolution report and a gap report.
- Added a contract test that builds small fixture spreadsheets and verifies the generated CSV outputs.
- Added usage notes covering accepted sheet formats, command examples, and the expected outputs.

### Impact
`✅ Offline workbook processing`
`✅ Fewer manual target cleanup steps`
`✅ Clearer missing-field tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
