### PR TITLE
docs(pester): triage 46 baseline failures vs feature lanes

### DIFF
--- a/docs/PESTER_BASELINE_TRIAGE_2026-06.md
+++ b/docs/PESTER_BASELINE_TRIAGE_2026-06.md
@@ -4,15 +4,16 @@ Read-only historical classification of the **46 failing tests** observed on the 
 
 ## Current status
 
-This triage is now historical. PR #46 was merged after the runs below and changed the Pester baseline materially.
+This triage is now historical. PR #46 was merged after the older runs below and changed the Pester baseline materially.
 
-Latest known post-PR #46 local validation:
+Latest known post-PR #46 validation:
 
 | Branch / context | Passed | Failed | Skipped | Source |
 |---|---:|---:|---:|---|
+| `main` (`9067787`) | 418 | **0** | 2 | Local Windows PowerShell run 2026-06-24 after fast-forward pull |
 | PR #46 branch, before merge | 418 | **0** | 2 | Local Windows PowerShell run 2026-06-24 |
 
-Do not use the old **46 failures** count as the current `main` baseline without rerunning the suite on current `main`.
+The old **46 failures** count is no longer the current `main` baseline. Current `main` is locally clean as of the run above.
 
 ## Entry point
 
@@ -30,7 +31,7 @@ Do not use the old **46 failures** count as the current `main` baseline without 
 
 **Historical conclusion:** The same **46 failures** appeared on old `main`, PR #61, and PR #62 at the time of this triage. They were **not introduced** by the Cybernet xlsx ingester (G) or targets-folder guard (X) when compared against that old baseline.
 
-**Current conclusion:** Rebase or refresh PR #61, PR #62, and PR #58 against current `main`, then rerun Pester before using this document as merge evidence.
+**Current conclusion:** Current `main` has since been locally validated clean. Rebase or refresh PR #61, PR #62, and PR #58 against current `main`, then rerun Pester before using their old CI results as merge evidence.
 
 ## Classification key
 
@@ -42,7 +43,7 @@ Do not use the old **46 failures** count as the current `main` baseline without 
 
 ## Historical failing tests (46)
 
-The following failures were observed before PR #46 merged. Treat this list as historical evidence only until it is remeasured on current `main`.
+The following failures were observed before PR #46 merged. Treat this list as historical evidence only.
 
 ### Deployment / mapping fixtures
 
@@ -117,7 +118,6 @@ The following failures were observed before PR #46 merged. Treat this list as hi
 
 ## Known gaps
 
-- This document has not yet been remeasured on current `main` after PR #46 merged.
 - PR #61 and PR #62 results cited here are pre-PR #46 measurements.
 - PR #58 may overlap with fixes already merged through PR #46 and must be reassessed before merge.
 - Bot review coverage on this PR was limited by external review rate limits.
@@ -125,16 +125,15 @@ The following failures were observed before PR #46 merged. Treat this list as hi
 ## Risks
 
 - Treating the historical **46 failures** count as current truth can create false blockers or hide newly introduced regressions.
-- Merging this document without the historical qualifier could mislead future PR review.
 - PR #58, PR #61, and PR #62 may need rebase/refresh work before their old validation claims remain valid.
+- This document preserves historical context only; it should not replace fresh validation for future feature PRs.
 
 ## Recommended next steps
 
-1. Pull current `main` and rerun `tools/Test-Pester5Suite.ps1`.
-2. Record the current `main` pass/fail/skip count in a new dated row or follow-up note.
-3. Rebase or update PR #58, PR #61, and PR #62 on current `main`.
-4. Rerun their validation after rebase.
-5. Use this document only as historical context unless those reruns confirm the same failures still exist.
+1. Rebase or update PR #58, PR #61, and PR #62 on current `main`.
+2. Rerun their validation after rebase.
+3. Use this document as historical context when explaining why old PR #61/#62 failures were not feature-caused.
+4. Do not use old pre-PR #46 CI counts as current merge evidence.
 
 ## Local reproduction
 

--- a/docs/PESTER_BASELINE_TRIAGE_2026-06.md
+++ b/docs/PESTER_BASELINE_TRIAGE_2026-06.md
@@ -1,0 +1,118 @@
+# Pester Baseline Triage — June 2026
+
+Read-only classification of the **46 failing tests** observed on `main` and feature lanes. This document does **not** modify any `.ps1` test or product files.
+
+## Entry point
+
+- Runner: [`tools/Test-Pester5Suite.ps1`](../tools/Test-Pester5Suite.ps1) (Pester 5.7+ required)
+- Baseline restoration lane: **PR #58** (`feature/pester-fixture-maintenance`)
+
+## Summary counts
+
+| Branch / tip | Passed | Failed | Skipped | Source |
+|---|---:|---:|---:|---|
+| `main` (`51155e7`) | 373 | **46** | 1 | Local run 2026-06-24 |
+| `feature/cybernet-xlsx-target-ingester-2026-06` (PR #61) | 372 | **46** | 2 | CI run `28134037338` |
+| `feature/targets-folder-guard-2026-06` (PR #62) | 372 | **46** | 2 | CI run `28134034486` |
+| `feature/pester-fixture-maintenance` (PR #58) | — | — | — | Open baseline-fix lane |
+
+**Conclusion:** The same **46 failures** appear on `main`, PR #61, and PR #62. They are **not introduced** by the Cybernet xlsx ingester (G) or targets-folder guard (X). Treat as pre-existing baseline/fixture debt tracked by PR #58.
+
+## Classification key
+
+| Tag | Meaning |
+|---|---|
+| `baseline` | Missing fixture, reference file, or script artifact expected by the test harness |
+| `environment` | Requires corporate network, AD, or machine state not present in local/CI smoke |
+| `feature` | Regression caused by an open feature branch — **none observed in this triage** |
+
+## Failing tests (46) — all classified `baseline`
+
+### Deployment / mapping fixtures
+
+| Test | Classification | Notes |
+|---|---|---|
+| `Compare-DeploymentToAd.ps1 (CSV, -SkipAd).Runs against fixtures and writes CSV` | baseline | AD/deployment fixture path |
+| `Mapping/Config CSV files.host-mappings.csv loads without error and exposes the expected columns` | baseline | Missing `host-mappings.csv` fixture |
+| `Mapping/Config CSV files.wcc_printers.csv loads with at least one row` | baseline | Missing `wcc_printers.csv` fixture |
+
+### Neuron maintenance / software reference
+
+| Test | Classification | Notes |
+|---|---|---|
+| `Get-NeuronMaintenanceSnapshot.ps1 -- script contract.Captures the main maintenance-console inspired sections` | baseline | Snapshot script fixture contract |
+| `QR task dispatcher registration -- NeuronMaintenance.Registers the NeuronMaintenance task name` | baseline | Task registration fixture |
+| `Neuron maintenance baseline and documentation.Baseline config exists` | baseline | Missing baseline JSON |
+| `Neuron maintenance baseline and documentation.Baseline config is valid JSON` | baseline | Missing baseline JSON |
+| `Neuron maintenance baseline and documentation.Documentation exists` | baseline | Missing doc artifact |
+| `Neuron maintenance baseline and documentation.Documentation includes survey and remote emulation intent` | baseline | Missing doc content |
+| `NeuronTargets.example.csv -- template contract.Template file exists` | baseline | Missing template CSV |
+| `NeuronTargets.example.csv -- template contract.Provides the expected columns` | baseline | Missing template CSV |
+| `Neuron software reference baseline -- 11.8.0.328.Reference JSON exists` | baseline | Missing reference JSON |
+| `Neuron software reference baseline -- 11.8.0.328.Reference JSON is valid and has firmware plus DDI sections` | baseline | Missing reference JSON |
+| `Neuron software reference baseline -- 11.8.0.328.Includes key DDI packages visible in the console reference` | baseline | Missing reference JSON |
+| `Observed package example and docs.Observed package example exists with expected header` | baseline | Missing observed package fixture |
+| `Observed package example and docs.Documentation exists and explains survey usage` | baseline | Missing doc artifact |
+
+### Registry install-diff pipeline
+
+| Test | Classification | Notes |
+|---|---|---|
+| `Compare-RegistrySnapshots script.exists` | baseline | Script/fixture path |
+| `Compare-RegistrySnapshots script.contains comment-based help sections` | baseline | Script/fixture path |
+| `Compare-RegistrySnapshots script.does not include forbidden registry mutation or remote registry commands` | baseline | Script/fixture path |
+| `Compare-RegistrySnapshots script.classifies created/deleted/modified and applies rules and writes outputs` | baseline | Fixture-driven diff test |
+| `Registry Install Diff Orchestrator.exists` | baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.has comment based help synopsis` | baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.blocks approved remediation as unsupported` | baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.does not contain forbidden registry write or remoting patterns` | baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.recononly runs or records missing dependency gracefully` | baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.analyzeinstall dry-run emits manifest and summary` | baseline | Orchestrator script missing |
+| `Get-RegistrySnapshot Script.script exists` | baseline | Script missing |
+| `Get-RegistrySnapshot Script.has comment-based help synopsis` | baseline | Script missing |
+| `Get-RegistrySnapshot Script.accepts localhost invocation with narrow key and parses output` | baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.creates output JSON when OutputPath is supplied` | baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.handles missing paths without fatal crash` | baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.accepts exclude patterns array` | baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.does not include forbidden write or remoting commands` | baseline | Script/fixture |
+
+### Repo-wide standards
+
+| Test | Classification | Notes |
+|---|---|---|
+| `Repo-wide BOM compliance.All .ps1 files in the repo have UTF-8 BOM` | baseline | Repo-wide encoding debt |
+| `Dollar-sign escaping standards.No repo scripts use unescaped dollar signs in Write-Host string literals that would fail` | baseline | Repo-wide escaping debt |
+
+### Target readiness / tracked install
+
+| Test | Classification | Notes |
+|---|---|---|
+| `Test-TargetReadiness script.exists` | baseline | Script/fixture |
+| `Test-TargetReadiness script.contains comment-based help sections` | baseline | Script/fixture |
+| `Test-TargetReadiness script.can run localhost mode without remote dependency` | baseline | Script/fixture |
+| `Test-TargetReadiness script.parses CSV targets with common column names` | baseline | Script/fixture |
+| `Test-TargetReadiness script.returns structured statuses for unreachable targets without crashing batch` | baseline | Script/fixture |
+| `Test-TargetReadiness script.does not contain forbidden registry or remoting mutation commands` | baseline | Script/fixture |
+| `Invoke-TrackedInstall.dry-run works with direct InstallerPath and does not execute installer` | baseline | Script/fixture |
+| `Invoke-TrackedInstall.creates output JSON when OutputPath is supplied and JSON parses` | baseline | Script/fixture |
+| `Invoke-TrackedInstall.non-localhost target returns Unsupported with RemoteInstallNotImplemented` | baseline | Script/fixture |
+| `Invoke-TrackedInstall.missing installer path in execution mode fails safely` | baseline | Script/fixture |
+| `Invoke-TrackedInstall.attempts source config lookup or reports parser/config issue gracefully` | baseline | Script/fixture |
+
+## Feature-caused failures
+
+**None.** PR #61 and PR #62 CI both report **46 failed** — identical baseline set.
+
+## Recommended next steps
+
+1. Merge or continue **PR #58** to restore missing fixtures and resolve baseline failures.
+2. Do **not** block PR #61 (G) or PR #62 (X) on these 46 failures — triage confirms they pre-exist on `main`.
+3. Re-run `tools/Test-Pester5Suite.ps1` after PR #58 merges to measure delta.
+
+## Local reproduction
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File tools/Test-Pester5Suite.ps1
+```
+
+Raw log (local `main`): `_out/pester-main-baseline.log` (worktree artifact, not committed).

--- a/docs/PESTER_BASELINE_TRIAGE_2026-06.md
+++ b/docs/PESTER_BASELINE_TRIAGE_2026-06.md
@@ -1,118 +1,145 @@
 # Pester Baseline Triage — June 2026
 
-Read-only classification of the **46 failing tests** observed on `main` and feature lanes. This document does **not** modify any `.ps1` test or product files.
+Read-only historical classification of the **46 failing tests** observed on the pre-PR #46 `main` baseline and selected feature lanes. This document does **not** modify any `.ps1` test or product files.
+
+## Current status
+
+This triage is now historical. PR #46 was merged after the runs below and changed the Pester baseline materially.
+
+Latest known post-PR #46 local validation:
+
+| Branch / context | Passed | Failed | Skipped | Source |
+|---|---:|---:|---:|---|
+| PR #46 branch, before merge | 418 | **0** | 2 | Local Windows PowerShell run 2026-06-24 |
+
+Do not use the old **46 failures** count as the current `main` baseline without rerunning the suite on current `main`.
 
 ## Entry point
 
 - Runner: [`tools/Test-Pester5Suite.ps1`](../tools/Test-Pester5Suite.ps1) (Pester 5.7+ required)
-- Baseline restoration lane: **PR #58** (`feature/pester-fixture-maintenance`)
+- Historical baseline restoration lane: **PR #58** (`feature/pester-fixture-maintenance`)
 
-## Summary counts
+## Historical summary counts
 
 | Branch / tip | Passed | Failed | Skipped | Source |
 |---|---:|---:|---:|---|
-| `main` (`51155e7`) | 373 | **46** | 1 | Local run 2026-06-24 |
-| `feature/cybernet-xlsx-target-ingester-2026-06` (PR #61) | 372 | **46** | 2 | CI run `28134037338` |
-| `feature/targets-folder-guard-2026-06` (PR #62) | 372 | **46** | 2 | CI run `28134034486` |
+| `main` (`51155e7`) | 373 | **46** | 1 | Local run 2026-06-24, before PR #46 merge |
+| `feature/cybernet-xlsx-target-ingester-2026-06` (PR #61) | 372 | **46** | 2 | CI run `28134037338`, before PR #46 merge |
+| `feature/targets-folder-guard-2026-06` (PR #62) | 372 | **46** | 2 | CI run `28134034486`, before PR #46 merge |
 | `feature/pester-fixture-maintenance` (PR #58) | — | — | — | Open baseline-fix lane |
 
-**Conclusion:** The same **46 failures** appear on `main`, PR #61, and PR #62. They are **not introduced** by the Cybernet xlsx ingester (G) or targets-folder guard (X). Treat as pre-existing baseline/fixture debt tracked by PR #58.
+**Historical conclusion:** The same **46 failures** appeared on old `main`, PR #61, and PR #62 at the time of this triage. They were **not introduced** by the Cybernet xlsx ingester (G) or targets-folder guard (X) when compared against that old baseline.
+
+**Current conclusion:** Rebase or refresh PR #61, PR #62, and PR #58 against current `main`, then rerun Pester before using this document as merge evidence.
 
 ## Classification key
 
 | Tag | Meaning |
 |---|---|
-| `baseline` | Missing fixture, reference file, or script artifact expected by the test harness |
+| `historical-baseline` | Missing fixture, reference file, or script artifact expected by the old test harness |
 | `environment` | Requires corporate network, AD, or machine state not present in local/CI smoke |
-| `feature` | Regression caused by an open feature branch — **none observed in this triage** |
+| `feature` | Regression caused by an open feature branch — **none observed in this historical triage** |
 
-## Failing tests (46) — all classified `baseline`
+## Historical failing tests (46)
+
+The following failures were observed before PR #46 merged. Treat this list as historical evidence only until it is remeasured on current `main`.
 
 ### Deployment / mapping fixtures
 
 | Test | Classification | Notes |
 |---|---|---|
-| `Compare-DeploymentToAd.ps1 (CSV, -SkipAd).Runs against fixtures and writes CSV` | baseline | AD/deployment fixture path |
-| `Mapping/Config CSV files.host-mappings.csv loads without error and exposes the expected columns` | baseline | Missing `host-mappings.csv` fixture |
-| `Mapping/Config CSV files.wcc_printers.csv loads with at least one row` | baseline | Missing `wcc_printers.csv` fixture |
+| `Compare-DeploymentToAd.ps1 (CSV, -SkipAd).Runs against fixtures and writes CSV` | historical-baseline | AD/deployment fixture path |
+| `Mapping/Config CSV files.host-mappings.csv loads without error and exposes the expected columns` | historical-baseline | Missing `host-mappings.csv` fixture |
+| `Mapping/Config CSV files.wcc_printers.csv loads with at least one row` | historical-baseline | Missing `wcc_printers.csv` fixture |
 
 ### Neuron maintenance / software reference
 
 | Test | Classification | Notes |
 |---|---|---|
-| `Get-NeuronMaintenanceSnapshot.ps1 -- script contract.Captures the main maintenance-console inspired sections` | baseline | Snapshot script fixture contract |
-| `QR task dispatcher registration -- NeuronMaintenance.Registers the NeuronMaintenance task name` | baseline | Task registration fixture |
-| `Neuron maintenance baseline and documentation.Baseline config exists` | baseline | Missing baseline JSON |
-| `Neuron maintenance baseline and documentation.Baseline config is valid JSON` | baseline | Missing baseline JSON |
-| `Neuron maintenance baseline and documentation.Documentation exists` | baseline | Missing doc artifact |
-| `Neuron maintenance baseline and documentation.Documentation includes survey and remote emulation intent` | baseline | Missing doc content |
-| `NeuronTargets.example.csv -- template contract.Template file exists` | baseline | Missing template CSV |
-| `NeuronTargets.example.csv -- template contract.Provides the expected columns` | baseline | Missing template CSV |
-| `Neuron software reference baseline -- 11.8.0.328.Reference JSON exists` | baseline | Missing reference JSON |
-| `Neuron software reference baseline -- 11.8.0.328.Reference JSON is valid and has firmware plus DDI sections` | baseline | Missing reference JSON |
-| `Neuron software reference baseline -- 11.8.0.328.Includes key DDI packages visible in the console reference` | baseline | Missing reference JSON |
-| `Observed package example and docs.Observed package example exists with expected header` | baseline | Missing observed package fixture |
-| `Observed package example and docs.Documentation exists and explains survey usage` | baseline | Missing doc artifact |
+| `Get-NeuronMaintenanceSnapshot.ps1 -- script contract.Captures the main maintenance-console inspired sections` | historical-baseline | Snapshot script fixture contract |
+| `QR task dispatcher registration -- NeuronMaintenance.Registers the NeuronMaintenance task name` | historical-baseline | Task registration fixture |
+| `Neuron maintenance baseline and documentation.Baseline config exists` | historical-baseline | Missing baseline JSON |
+| `Neuron maintenance baseline and documentation.Baseline config is valid JSON` | historical-baseline | Missing baseline JSON |
+| `Neuron maintenance baseline and documentation.Documentation exists` | historical-baseline | Missing doc artifact |
+| `Neuron maintenance baseline and documentation.Documentation includes survey and remote emulation intent` | historical-baseline | Missing doc content |
+| `NeuronTargets.example.csv -- template contract.Template file exists` | historical-baseline | Missing template CSV |
+| `NeuronTargets.example.csv -- template contract.Provides the expected columns` | historical-baseline | Missing template CSV |
+| `Neuron software reference baseline -- 11.8.0.328.Reference JSON exists` | historical-baseline | Missing reference JSON |
+| `Neuron software reference baseline -- 11.8.0.328.Reference JSON is valid and has firmware plus DDI sections` | historical-baseline | Missing reference JSON |
+| `Neuron software reference baseline -- 11.8.0.328.Includes key DDI packages visible in the console reference` | historical-baseline | Missing reference JSON |
+| `Observed package example and docs.Observed package example exists with expected header` | historical-baseline | Missing observed package fixture |
+| `Observed package example and docs.Documentation exists and explains survey usage` | historical-baseline | Missing doc artifact |
 
 ### Registry install-diff pipeline
 
 | Test | Classification | Notes |
 |---|---|---|
-| `Compare-RegistrySnapshots script.exists` | baseline | Script/fixture path |
-| `Compare-RegistrySnapshots script.contains comment-based help sections` | baseline | Script/fixture path |
-| `Compare-RegistrySnapshots script.does not include forbidden registry mutation or remote registry commands` | baseline | Script/fixture path |
-| `Compare-RegistrySnapshots script.classifies created/deleted/modified and applies rules and writes outputs` | baseline | Fixture-driven diff test |
-| `Registry Install Diff Orchestrator.exists` | baseline | Orchestrator script missing |
-| `Registry Install Diff Orchestrator.has comment based help synopsis` | baseline | Orchestrator script missing |
-| `Registry Install Diff Orchestrator.blocks approved remediation as unsupported` | baseline | Orchestrator script missing |
-| `Registry Install Diff Orchestrator.does not contain forbidden registry write or remoting patterns` | baseline | Orchestrator script missing |
-| `Registry Install Diff Orchestrator.recononly runs or records missing dependency gracefully` | baseline | Orchestrator script missing |
-| `Registry Install Diff Orchestrator.analyzeinstall dry-run emits manifest and summary` | baseline | Orchestrator script missing |
-| `Get-RegistrySnapshot Script.script exists` | baseline | Script missing |
-| `Get-RegistrySnapshot Script.has comment-based help synopsis` | baseline | Script missing |
-| `Get-RegistrySnapshot Script.accepts localhost invocation with narrow key and parses output` | baseline | Script/fixture |
-| `Get-RegistrySnapshot Script.creates output JSON when OutputPath is supplied` | baseline | Script/fixture |
-| `Get-RegistrySnapshot Script.handles missing paths without fatal crash` | baseline | Script/fixture |
-| `Get-RegistrySnapshot Script.accepts exclude patterns array` | baseline | Script/fixture |
-| `Get-RegistrySnapshot Script.does not include forbidden write or remoting commands` | baseline | Script/fixture |
+| `Compare-RegistrySnapshots script.exists` | historical-baseline | Script/fixture path |
+| `Compare-RegistrySnapshots script.contains comment-based help sections` | historical-baseline | Script/fixture path |
+| `Compare-RegistrySnapshots script.does not include forbidden registry mutation or remote registry commands` | historical-baseline | Script/fixture path |
+| `Compare-RegistrySnapshots script.classifies created/deleted/modified and applies rules and writes outputs` | historical-baseline | Fixture-driven diff test |
+| `Registry Install Diff Orchestrator.exists` | historical-baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.has comment based help synopsis` | historical-baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.blocks approved remediation as unsupported` | historical-baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.does not contain forbidden registry write or remoting patterns` | historical-baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.recononly runs or records missing dependency gracefully` | historical-baseline | Orchestrator script missing |
+| `Registry Install Diff Orchestrator.analyzeinstall dry-run emits manifest and summary` | historical-baseline | Orchestrator script missing |
+| `Get-RegistrySnapshot Script.script exists` | historical-baseline | Script missing |
+| `Get-RegistrySnapshot Script.has comment-based help synopsis` | historical-baseline | Script missing |
+| `Get-RegistrySnapshot Script.accepts localhost invocation with narrow key and parses output` | historical-baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.creates output JSON when OutputPath is supplied` | historical-baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.handles missing paths without fatal crash` | historical-baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.accepts exclude patterns array` | historical-baseline | Script/fixture |
+| `Get-RegistrySnapshot Script.does not include forbidden write or remoting commands` | historical-baseline | Script/fixture |
 
 ### Repo-wide standards
 
 | Test | Classification | Notes |
 |---|---|---|
-| `Repo-wide BOM compliance.All .ps1 files in the repo have UTF-8 BOM` | baseline | Repo-wide encoding debt |
-| `Dollar-sign escaping standards.No repo scripts use unescaped dollar signs in Write-Host string literals that would fail` | baseline | Repo-wide escaping debt |
+| `Repo-wide BOM compliance.All .ps1 files in the repo have UTF-8 BOM` | historical-baseline | Repo-wide encoding debt |
+| `Dollar-sign escaping standards.No repo scripts use unescaped dollar signs in Write-Host string literals that would fail` | historical-baseline | Repo-wide escaping debt |
 
 ### Target readiness / tracked install
 
 | Test | Classification | Notes |
 |---|---|---|
-| `Test-TargetReadiness script.exists` | baseline | Script/fixture |
-| `Test-TargetReadiness script.contains comment-based help sections` | baseline | Script/fixture |
-| `Test-TargetReadiness script.can run localhost mode without remote dependency` | baseline | Script/fixture |
-| `Test-TargetReadiness script.parses CSV targets with common column names` | baseline | Script/fixture |
-| `Test-TargetReadiness script.returns structured statuses for unreachable targets without crashing batch` | baseline | Script/fixture |
-| `Test-TargetReadiness script.does not contain forbidden registry or remoting mutation commands` | baseline | Script/fixture |
-| `Invoke-TrackedInstall.dry-run works with direct InstallerPath and does not execute installer` | baseline | Script/fixture |
-| `Invoke-TrackedInstall.creates output JSON when OutputPath is supplied and JSON parses` | baseline | Script/fixture |
-| `Invoke-TrackedInstall.non-localhost target returns Unsupported with RemoteInstallNotImplemented` | baseline | Script/fixture |
-| `Invoke-TrackedInstall.missing installer path in execution mode fails safely` | baseline | Script/fixture |
-| `Invoke-TrackedInstall.attempts source config lookup or reports parser/config issue gracefully` | baseline | Script/fixture |
+| `Test-TargetReadiness script.exists` | historical-baseline | Script/fixture |
+| `Test-TargetReadiness script.contains comment-based help sections` | historical-baseline | Script/fixture |
+| `Test-TargetReadiness script.can run localhost mode without remote dependency` | historical-baseline | Script/fixture |
+| `Test-TargetReadiness script.parses CSV targets with common column names` | historical-baseline | Script/fixture |
+| `Test-TargetReadiness script.returns structured statuses for unreachable targets without crashing batch` | historical-baseline | Script/fixture |
+| `Test-TargetReadiness script.does not contain forbidden registry or remoting mutation commands` | historical-baseline | Script/fixture |
+| `Invoke-TrackedInstall.dry-run works with direct InstallerPath and does not execute installer` | historical-baseline | Script/fixture |
+| `Invoke-TrackedInstall.creates output JSON when OutputPath is supplied and JSON parses` | historical-baseline | Script/fixture |
+| `Invoke-TrackedInstall.non-localhost target returns Unsupported with RemoteInstallNotImplemented` | historical-baseline | Script/fixture |
+| `Invoke-TrackedInstall.missing installer path in execution mode fails safely` | historical-baseline | Script/fixture |
+| `Invoke-TrackedInstall.attempts source config lookup or reports parser/config issue gracefully` | historical-baseline | Script/fixture |
 
-## Feature-caused failures
+## Known gaps
 
-**None.** PR #61 and PR #62 CI both report **46 failed** — identical baseline set.
+- This document has not yet been remeasured on current `main` after PR #46 merged.
+- PR #61 and PR #62 results cited here are pre-PR #46 measurements.
+- PR #58 may overlap with fixes already merged through PR #46 and must be reassessed before merge.
+- Bot review coverage on this PR was limited by external review rate limits.
+
+## Risks
+
+- Treating the historical **46 failures** count as current truth can create false blockers or hide newly introduced regressions.
+- Merging this document without the historical qualifier could mislead future PR review.
+- PR #58, PR #61, and PR #62 may need rebase/refresh work before their old validation claims remain valid.
 
 ## Recommended next steps
 
-1. Merge or continue **PR #58** to restore missing fixtures and resolve baseline failures.
-2. Do **not** block PR #61 (G) or PR #62 (X) on these 46 failures — triage confirms they pre-exist on `main`.
-3. Re-run `tools/Test-Pester5Suite.ps1` after PR #58 merges to measure delta.
+1. Pull current `main` and rerun `tools/Test-Pester5Suite.ps1`.
+2. Record the current `main` pass/fail/skip count in a new dated row or follow-up note.
+3. Rebase or update PR #58, PR #61, and PR #62 on current `main`.
+4. Rerun their validation after rebase.
+5. Use this document only as historical context unless those reruns confirm the same failures still exist.
 
 ## Local reproduction
 
 ```powershell
-pwsh -NoProfile -ExecutionPolicy Bypass -File tools/Test-Pester5Suite.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools/Test-Pester5Suite.ps1
 ```
 
-Raw log (local `main`): `_out/pester-main-baseline.log` (worktree artifact, not committed).
+Raw historical log (old local `main`): `_out/pester-main-baseline.log` (worktree artifact, not committed).


### PR DESCRIPTION
## Summary
- Refreshes `docs/PESTER_BASELINE_TRIAGE_2026-06.md` so it no longer presents the old 46-failure result as the current `main` baseline.
- Marks the 46-failure triage as historical evidence from before PR #46 merged.
- Records the fresh current-main validation from Alejandro's local run: `418 passed / 0 failed / 2 skipped` on `main` after pulling `9067787`.
- Keeps the document read-only: no test or product files are changed.

## Known gaps
- PR #61, PR #62, and PR #58 still need to be rebased/refreshed against current `main` before their old validation claims can be trusted.
- CodeRabbit review coverage was limited by external review-rate limits.
- This PR preserves documentation/history only; it does not change product behavior or tests.

## Risks
- The document is useful as historical context, but it should not replace fresh validation for future feature PRs.
- PR #58 may now overlap with fixes already merged through PR #46, so blindly merging it could duplicate or conflict with newer baseline fixes.
- PR #61 and PR #62 may show different Pester results after rebase because the base branch changed.

## Next steps
1. Wait for GitHub checks on this PR head to stay green.
2. Merge this PR only if you want the historical Pester triage preserved as documentation.
3. Rebase/update PR #58, PR #61, and PR #62 against current `main`.
4. Rerun their validations after rebase.
5. Use this document only as historical context when explaining why old PR #61/#62 failures were not feature-caused.