### PR TITLE
refactor(dashboard): make Cybernet survey the primary workflow

### DIFF
--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -4,6 +4,19 @@ This is the current priority field workflow for SysAdminSuite technicians.
 
 Use it when you need to locate Cybernet or Neuron devices from approved deployment documentation using a local admin workstation, target manifests, and conservative approved network discovery.
 
+## Dashboard quick path
+
+Use the Cybernet-first dashboard when you want a guided wizard instead of memorizing CLI steps. Live Mode is **not** the front door — it lives under **Advanced Tools → Generate Survey Commands**.
+
+1. **Open the dashboard** — from the repo root: `python3 -m http.server 8000`, then browse to `http://localhost:8000/dashboard/` (see [`dashboard/README.md`](dashboard/README.md)).
+2. **Start Cybernet Survey** — opens the wizard (progress rail: Targets → Network posture → Identity evidence → Reachability → Review package).
+3. **Copy posture and identity commands** — run network preflight and workstation identity on the admin box; keep output local.
+4. **Optional reachability** — wizard step 4 is skippable; uses profile `keyports_cybernet_json` when you need low-noise port confirmation.
+5. **Load Evidence** — drop `network_preflight.csv`, `workstation_identity.csv`, and optional reachability JSON.
+6. **Review Results** — use the Cybernet review summary; open **Advanced Tools** only for detailed panels or legacy command generation.
+
+For subnet discovery and Nmap orchestration, use the CLI path below.
+
 ## Urgent path (orchestrator)
 
 Use one correlated `--site` and `--run-id` across steps:

--- a/dashboard/css/style.css
+++ b/dashboard/css/style.css
@@ -34,8 +34,9 @@ html, body {
 #app {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 #header {
@@ -1108,4 +1109,129 @@ textarea.paste-area:focus { border-color: var(--accent); }
   .cybernet-command-panel {
     width: 100%;
   }
+}
+
+/* ── Cybernet-first shell ───────────────────────────────────── */
+.cybernet-hero {
+  flex-shrink: 0;
+  margin: 14px 18px 0;
+  padding: 20px 22px;
+  border: 1px solid rgba(79, 142, 247, 0.28);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(79,142,247,0.14), rgba(108,99,255,0.06));
+}
+
+.cybernet-hero h2 { font-size: 20px; margin-bottom: 6px; }
+.cybernet-hero-subtitle { color: var(--text-dim); font-size: 13px; max-width: 52rem; }
+
+.cybernet-progress-rail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  list-style: none;
+  margin: 14px 0 16px;
+  padding: 0;
+}
+
+.cybernet-progress-rail li {
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: var(--bg3);
+}
+
+.cybernet-progress-rail li.active {
+  border-color: var(--accent);
+  color: #fff;
+  background: rgba(79,142,247,0.35);
+}
+
+.cybernet-progress-rail li.done {
+  border-color: rgba(34, 197, 94, 0.35);
+  color: var(--success);
+}
+
+.cybernet-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.btn-compact { padding: 6px 12px; font-size: 12px; }
+.btn-link {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 12px;
+  text-decoration: underline;
+  padding: 6px 4px;
+}
+
+.evidence-loader,
+.cybernet-review,
+.advanced-section {
+  flex-shrink: 0;
+  margin: 12px 18px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg2);
+}
+
+.evidence-loader-head h3,
+.cybernet-review h3,
+.advanced-section-head h3 { font-size: 14px; margin-bottom: 4px; }
+.evidence-loader-head p,
+.advanced-section-head p { color: var(--text-dim); font-size: 12px; margin-bottom: 10px; }
+
+#panel-ingestion { border: none; background: transparent; }
+#ingestion-inner {
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  gap: 10px;
+}
+
+.drop-hint { font-size: 10px; color: var(--text-muted); display: block; }
+.evidence-loader-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.evidence-advanced-ingest summary,
+.evidence-formats summary { cursor: pointer; color: var(--text-dim); font-size: 12px; }
+.evidence-advanced-inner { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
+.formats-list { font-size: 11px; color: var(--text-muted); margin-top: 6px; line-height: 1.5; }
+
+.file-chip .chip-meta { display: flex; flex-direction: column; gap: 1px; }
+.file-chip .chip-name { font-weight: 500; color: var(--text); }
+.file-chip .chip-type { font-size: 10px; color: var(--text-muted); }
+
+.cybernet-review-stats { list-style: none; padding: 0; margin: 0 0 8px; }
+.cybernet-review-stats li { font-size: 12px; margin-bottom: 4px; color: var(--text-dim); }
+.cybernet-review-warn { color: var(--warning); font-size: 12px; margin: 8px 0; }
+.cybernet-review-next { font-size: 12px; color: var(--text-dim); }
+
+.mode-toggle-advanced { margin-bottom: 10px; }
+.advanced-panels-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 10px 0 6px;
+}
+
+.live-label { color: var(--text-dim); font-size: 12px; white-space: nowrap; }
+
+.cybernet-wizard-footer { margin-top: 10px; }
+
+@media (max-width: 480px) {
+  .cybernet-hero { margin-left: 8px; margin-right: 8px; padding: 14px; }
+  .cybernet-hero-actions { flex-direction: column; align-items: stretch; }
+  .cybernet-hero-actions .btn-primary,
+  .cybernet-hero-actions .btn-secondary { width: 100%; }
+  #header { flex-wrap: wrap; padding: 8px 10px; }
+  #tabs { overflow-x: auto; padding: 0 8px; }
+  .evidence-loader, .cybernet-review, .advanced-section { margin-left: 8px; margin-right: 8px; }
 }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,115 +5,145 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SysAdmin Suite Dashboard</title>
   <link rel="stylesheet" href="css/style.css">
-  <!-- SheetJS — blocking load from vendored copy (deterministic: available before any
-       file-drop event fires). CDN fallback only if local file is missing (404). -->
   <script src="js/vendor/xlsx.full.min.js"
           onerror="(function(){var s=document.createElement('script');s.src='https://cdn.sheetjs.com/xlsx-0.20.2/package/dist/xlsx.full.min.js';s.onerror=function(){window._xlsxUnavailable=true;};document.head.appendChild(s);})()"></script>
 </head>
 <body>
 <div id="app">
 
-  <!-- Drop Overlay -->
   <div id="drop-overlay">Drop files anywhere to load</div>
 
-  <!-- Header -->
   <div id="header">
     <h1>SysAdmin Suite <span>Dashboard</span></h1>
-    <div id="mode-toggle">
-      <button class="mode-btn active" data-mode="log">📂 Log Mode</button>
-      <button class="mode-btn" data-mode="live">⚡ Live (Command-Gen)</button>
-    </div>
     <div class="header-spacer"></div>
-    <button class="icon-btn" id="clear-all-btn" title="Clear all loaded data">🗑 Clear All</button>
     <span class="header-relay-badge relay-disconnected" id="header-relay-badge" title="Relay offline — run: python3 dashboard/relay.py">○ Relay</span>
+    <button class="btn-secondary btn-compact" id="advanced-tools-toggle" type="button" aria-expanded="false" aria-controls="advanced-section">Advanced Tools</button>
   </div>
 
-  <!-- Log Mode File Ingestion -->
-  <div id="panel-ingestion">
-    <div id="ingestion-inner">
-      <div class="drop-zone" id="drop-zone">
-        <span class="drop-icon">📁</span>
-        <span>Drop files here or click to browse</span>
-        <span style="font-size:10px;color:var(--text-muted)">CSV · JSON · XLSX · TXT</span>
-      </div>
-      <input type="file" id="file-input" multiple accept=".csv,.json,.xlsx,.xls,.txt" style="display:none">
-      <span class="ingestion-sep">or</span>
-      <button class="paste-btn" id="paste-btn">📋 Paste / Type</button>
-      <span class="ingestion-sep">or</span>
-      <button class="paste-btn demo-btn" id="demo-btn" title="Populate all panels with realistic sample data — no files needed">🧪 Load Sample Data</button>
-      <span class="ingestion-sep">or</span>
-      <button class="paste-btn watch-folder-btn" id="watch-folder-btn" title="Auto-watch a folder and load new log files as they appear (Chrome/Edge 86+)">👁 Watch Folder</button>
-      <button class="paste-btn watch-stop-btn" id="watch-stop-btn" style="display:none" title="Stop watching the folder">⏹ Stop Watch</button>
-      <span class="watch-unsupported-msg" id="watch-unsupported-msg" style="display:none">⚠ Folder watch requires Chrome or Edge 86+</span>
-      <div class="watch-indicator" id="watch-indicator" style="display:none"></div>
-      <div class="loaded-files" id="loaded-files"></div>
-    </div>
-  </div>
-
-  <!-- Live Mode Controls -->
-  <div id="live-controls">
-    <span style="color:var(--text-dim);font-size:12px;white-space:nowrap">Targets:</span>
-    <input id="live-targets" class="live-targets" placeholder="hostname1, 192.168.1.10, … or import a file" type="text" style="flex:1;padding:7px 12px;background:var(--bg3);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:12px;font-family:var(--mono);outline:none">
-    <button class="paste-btn" id="live-file-btn">📁 Import list</button>
-    <input type="file" id="live-file-input" accept=".txt,.csv" style="display:none">
-    <button class="live-btn" id="live-start">⚡ Generate Probe Commands</button>
-    <span class="live-note">⚠ Command-generation mode — copy commands, run on an admin machine, then drag the resulting CSV files back here</span>
-  </div>
-
-
-
-  <!-- Cybernet Target Acquisition Tutorial -->
-  <section id="cybernet-tutorial" class="cybernet-tutorial" aria-label="Cybernet target acquisition tutorial">
-    <div class="cybernet-tutorial-head">
-      <div>
-        <div class="eyebrow">Newbie guided workflow</div>
-        <h2>Acquire Cybernet targets without guessing</h2>
-        <p>Click through a safe command workflow: prepare a list, prove path posture, collect identity evidence, then review CSV output locally.</p>
-      </div>
-      <div class="cybernet-tutorial-actions">
-        <button class="paste-btn" id="cybernet-tutorial-start">▶ Start tutorial</button>
-        <button class="paste-btn" id="cybernet-tutorial-copy">📋 Copy current command</button>
+  <section id="cybernet-hero" class="cybernet-hero" aria-label="Cybernet Survey">
+    <div class="cybernet-hero-inner">
+      <h2>Cybernet Survey</h2>
+      <p class="cybernet-hero-subtitle">Find, verify, and package Cybernet targets from approved target sources.</p>
+      <ol class="cybernet-progress-rail" id="cybernet-progress-rail" aria-label="Survey progress">
+        <li data-step="0">Targets</li>
+        <li data-step="1">Network posture</li>
+        <li data-step="2">Identity evidence</li>
+        <li data-step="3">Reachability</li>
+        <li data-step="4">Review package</li>
+      </ol>
+      <div class="cybernet-hero-actions" id="cybernet-hero-actions">
+        <button class="btn-primary" id="hero-start-survey" type="button">Start Cybernet Survey</button>
+        <button class="btn-secondary" id="hero-load-evidence" type="button">Load Evidence</button>
+        <button class="btn-link" id="hero-open-advanced" type="button">Open Advanced Tools</button>
       </div>
     </div>
-    <div class="cybernet-stepper" id="cybernet-stepper" aria-label="Cybernet acquisition steps"></div>
+  </section>
+
+  <section id="cybernet-tutorial" class="cybernet-tutorial hidden" aria-label="Cybernet survey wizard">
+    <div class="cybernet-step-kicker" id="cybernet-step-kicker">Step 1 of 5</div>
+    <div class="cybernet-step-progress" id="cybernet-step-progress" aria-hidden="true"></div>
     <div class="cybernet-step-card">
       <div class="cybernet-step-content">
-        <div class="cybernet-step-kicker" id="cybernet-step-kicker">Step 1</div>
         <h3 id="cybernet-step-title">Prepare your target list</h3>
         <p id="cybernet-step-body"></p>
-        <ul id="cybernet-step-checks"></ul>
+        <details class="cybernet-step-details" id="cybernet-step-details">
+          <summary>Show details</summary>
+          <ul id="cybernet-step-checks"></ul>
+        </details>
       </div>
-      <div class="cybernet-command-panel">
-        <div class="command-panel-title">Copy/paste command</div>
+      <div class="cybernet-command-panel" id="cybernet-command-panel">
+        <div class="command-panel-title">Command</div>
         <textarea id="cybernet-step-command" readonly spellcheck="false"></textarea>
         <div class="command-panel-note" id="cybernet-step-note"></div>
       </div>
     </div>
     <div class="cybernet-tutorial-nav">
-      <button class="btn-secondary" id="cybernet-prev">← Back</button>
-      <button class="btn-primary" id="cybernet-next">Next →</button>
+      <button class="btn-secondary" id="cybernet-prev" type="button">← Back</button>
+      <button class="btn-secondary hidden" id="cybernet-copy" type="button">Copy Command</button>
+      <button class="btn-primary" id="cybernet-next" type="button">Next →</button>
+    </div>
+    <div class="cybernet-wizard-footer hidden" id="cybernet-wizard-footer">
+      <button class="btn-secondary" id="cybernet-load-evidence-end" type="button">Load resulting evidence</button>
     </div>
   </section>
 
-  <!-- Tabs -->
-  <div id="tabs">
-    <button class="tab-btn active" data-tab="printer">🖨️ Printer Mapping<span class="tab-badge">0</span></button>
-    <button class="tab-btn" data-tab="inventory">🖥️ Hardware Inventory<span class="tab-badge">0</span></button>
-    <button class="tab-btn" data-tab="tasks">⚡ Remote Tasks<span class="tab-badge">0</span></button>
-    <button class="tab-btn" data-tab="network">📡 Network &amp; Protocol Trace<span class="tab-badge">0</span></button>
-    <button class="tab-btn" data-tab="software">📦 Software Tracker<span class="tab-badge">0</span></button>
-  </div>
+  <section id="evidence-loader" class="evidence-loader hidden" aria-label="Load evidence">
+    <div class="evidence-loader-head">
+      <h3>Load Evidence</h3>
+      <p>Drop survey output files here after running commands on an admin workstation.</p>
+    </div>
+    <div id="panel-ingestion">
+      <div id="ingestion-inner">
+        <div class="drop-zone" id="drop-zone">
+          <span class="drop-icon">📁</span>
+          <span>Drop files here or click to browse</span>
+          <span class="drop-hint">network_preflight.csv · workstation_identity.csv · reachability JSON</span>
+        </div>
+        <input type="file" id="file-input" multiple accept=".csv,.json,.xlsx,.xls,.txt" style="display:none">
+        <div class="evidence-loader-actions">
+          <button class="paste-btn" id="paste-btn" type="button">Paste data</button>
+          <button class="icon-btn evidence-clear-btn" id="clear-all-btn" type="button" title="Clear all loaded evidence">Clear evidence</button>
+        </div>
+        <details class="evidence-advanced-ingest">
+          <summary>More import options</summary>
+          <div class="evidence-advanced-inner">
+            <button class="paste-btn demo-btn" id="demo-btn" type="button" title="Populate panels with sample data">Load sample data</button>
+            <button class="paste-btn watch-folder-btn" id="watch-folder-btn" type="button" title="Auto-watch a folder (Chrome/Edge 86+)">Watch folder</button>
+            <button class="paste-btn watch-stop-btn" id="watch-stop-btn" style="display:none" type="button">Stop watch</button>
+            <span class="watch-unsupported-msg" id="watch-unsupported-msg" style="display:none">Folder watch requires Chrome or Edge 86+</span>
+            <div class="watch-indicator" id="watch-indicator" style="display:none"></div>
+          </div>
+        </details>
+        <details class="evidence-formats">
+          <summary>Supported formats</summary>
+          <p class="formats-list">Preflight.csv · Results.csv · workstation_identity.csv · printer_probe.csv · network_preflight.csv · MachineInfo_Output.csv · RamInfo_Output.csv · NeuronNetworkInventory · status.json · QRTask/RunControl logs · sources.yaml</p>
+        </details>
+        <div class="loaded-files" id="loaded-files"></div>
+      </div>
+    </div>
+  </section>
 
-  <!-- Main Content -->
-  <div id="content">
-    <div class="panel active" data-panel="printer" id="panel-printer"></div>
+  <section id="cybernet-review" class="cybernet-review hidden" aria-label="Cybernet survey review">
+    <h3>Review Results</h3>
+    <div id="cybernet-review-body" class="cybernet-review-body"></div>
+    <button class="btn-link" id="review-open-network" type="button">Open network evidence details →</button>
+  </section>
+
+  <section id="advanced-section" class="advanced-section hidden" aria-label="Advanced tools">
+    <div class="advanced-section-head">
+      <h3>Advanced Tools</h3>
+      <p>Review evidence, generate survey commands, and open detailed panels.</p>
+    </div>
+    <div id="mode-toggle" class="mode-toggle-advanced">
+      <button class="mode-btn active" data-mode="log" type="button">Review Evidence</button>
+      <button class="mode-btn" data-mode="live" type="button">Generate Survey Commands</button>
+    </div>
+    <div id="live-controls">
+      <span class="live-label">Targets:</span>
+      <input id="live-targets" class="live-targets" placeholder="hostname1, 192.168.1.10, …" type="text">
+      <button class="paste-btn" id="live-file-btn" type="button">Import list</button>
+      <input type="file" id="live-file-input" accept=".txt,.csv" style="display:none">
+      <button class="live-btn" id="live-start" type="button">Generate Survey Commands</button>
+      <span class="live-note">Copy commands, run on an admin machine, then load resulting files via Load Evidence.</span>
+    </div>
+    <div class="advanced-panels-label">Advanced Review Panels</div>
+    <div id="tabs">
+      <button class="tab-btn" data-tab="network" type="button">📡 Network &amp; Protocol<span class="tab-badge">0</span></button>
+      <button class="tab-btn" data-tab="printer" type="button">🖨️ Printer Mapping<span class="tab-badge">0</span></button>
+      <button class="tab-btn" data-tab="inventory" type="button">🖥️ Hardware Inventory<span class="tab-badge">0</span></button>
+      <button class="tab-btn" data-tab="tasks" type="button">⚡ Remote Tasks<span class="tab-badge">0</span></button>
+      <button class="tab-btn" data-tab="software" type="button">📦 Software Tracker<span class="tab-badge">0</span></button>
+    </div>
+  </section>
+
+  <div id="content" class="hidden">
+    <div class="panel" data-panel="network" id="panel-network"></div>
+    <div class="panel" data-panel="printer" id="panel-printer"></div>
     <div class="panel" data-panel="inventory" id="panel-inventory"></div>
     <div class="panel" data-panel="tasks" id="panel-tasks"></div>
-    <div class="panel" data-panel="network" id="panel-network"></div>
     <div class="panel" data-panel="software" id="panel-software"></div>
   </div>
 
-  <!-- Status Footer -->
   <div id="status-footer">
     <span class="status-dot" id="status-dot"></span>
     <span class="status-computer" id="status-computer"></span>
@@ -123,31 +153,26 @@
   </div>
 </div>
 
-<!-- Toast Container -->
 <div id="toast-container"></div>
 
-<!-- Paste Modal -->
-<div id="paste-modal" class="modal-backdrop hidden" style="">
+<div id="paste-modal" class="modal-backdrop hidden">
   <div class="modal">
     <div class="modal-header">
       <span class="modal-title">Paste or Type Data</span>
-      <button class="modal-close" id="paste-modal-close">×</button>
+      <button class="modal-close" id="paste-modal-close" type="button">×</button>
     </div>
     <div class="modal-body">
       <div class="modal-label">
-        Filename (used for auto-detection — use known patterns like <code>Results.csv</code>, <code>workstation_identity.csv</code>, etc.)
+        Filename (use known patterns like <code>network_preflight.csv</code>, <code>workstation_identity.csv</code>)
       </div>
-      <input type="text" id="paste-filename" value="pasted-data.csv"
+      <input type="text" id="paste-filename" value="network_preflight.csv"
         style="padding:7px 10px;background:var(--bg3);border:1px solid var(--border);border-radius:5px;color:var(--text);font-size:12px;width:100%;font-family:var(--mono);outline:none;margin-bottom:4px">
       <div class="modal-label">Paste CSV, JSON, or plain text below:</div>
       <textarea class="paste-area" id="paste-textarea" placeholder="Paste CSV rows, JSON array, or target list here…"></textarea>
-      <div class="modal-label" style="color:var(--text-muted)">
-        Supported file types: Preflight.csv · Results.csv · workstation_identity.csv · printer_probe.csv · network_preflight.csv · MachineInfo_Output.csv · RamInfo_Output.csv · NeuronNetworkInventory.csv/.json · status.json · QRTask/RunControl logs
-      </div>
     </div>
     <div class="modal-footer">
-      <button class="btn-secondary" id="paste-cancel">Cancel</button>
-      <button class="btn-primary" id="paste-submit">Import Data</button>
+      <button class="btn-secondary" id="paste-cancel" type="button">Cancel</button>
+      <button class="btn-primary" id="paste-submit" type="button">Import Data</button>
     </div>
   </div>
 </div>
@@ -157,11 +182,7 @@
   code { font-family: var(--mono); font-size: 11px; background: var(--bg3); padding: 1px 4px; border-radius: 3px; }
 </style>
 
-<!-- sample-data.js: plain script — defines window._sasSampleStore() and window._sasSampleStatus() -->
 <script src="js/sample-data.js"></script>
-<!-- bundle.js: all dashboard JS concatenated into a single non-module script.
-     Works both when served over HTTP and when opened directly as a local file (file:// URL).
-     Regenerate with: node dashboard/build-bundle.js -->
 <script src="js/bundle.js"></script>
 <script src="js/cybernet-os-preflight.js"></script>
 </body>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -34,7 +34,6 @@
       <div class="cybernet-hero-actions" id="cybernet-hero-actions">
         <button class="btn-primary" id="hero-start-survey" type="button">Start Cybernet Survey</button>
         <button class="btn-secondary" id="hero-load-evidence" type="button">Load Evidence</button>
-        <button class="btn-link" id="hero-open-advanced" type="button">Open Advanced Tools</button>
       </div>
     </div>
   </section>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -139,8 +139,6 @@ function initCybernetShell() {
   document.getElementById('hero-load-evidence')?.addEventListener('click', openEvidence);
   document.getElementById('cybernet-load-evidence-end')?.addEventListener('click', openEvidence);
 
-  const openAdvanced = () => openAdvancedSection(true);
-  document.getElementById('hero-open-advanced')?.addEventListener('click', openAdvanced);
   document.getElementById('advanced-tools-toggle')?.addEventListener('click', () => {
     const section = document.getElementById('advanced-section');
     const open = section?.classList.contains('hidden');

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -16,7 +16,25 @@ import { initRelayConnection, onRelayStatus, getRelayConnected, RELAY_PORT } fro
 let store = {};
 let loadedFiles = [];
 let mode = 'log'; // 'log' | 'live'
-let activeTab = 'printer';
+let activeTab = 'network';
+
+// Human-readable review section for evidence chips
+const TYPE_SECTION_LABELS = {
+  'preflight': 'Printer mapping',
+  'results': 'Printer mapping',
+  'printer-probe': 'Printer · Network',
+  'machine-info': 'Hardware inventory',
+  'ram-info': 'Hardware inventory',
+  'monitor-info': 'Hardware inventory',
+  'neuron-inventory': 'Hardware inventory',
+  'workstation-identity': 'Network review',
+  'network-preflight': 'Network review',
+  'smb-recon': 'Network review',
+  'remote-task': 'Remote tasks',
+  'software-tracker': 'Software tracker',
+  'software-superset': 'Software tracker',
+  'status-json': 'Status',
+};
 
 // ── File-type → panel(s) mapping ───────────────────────────────────────────
 // Each type maps to one or more panels it populates.
@@ -41,6 +59,7 @@ const TYPE_TO_PANELS = {
 // ── Bootstrap ──────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
   buildLayout();
+  initCybernetShell();
   initTabs();
   initIngestion();
   initModeToggle();
@@ -52,24 +71,23 @@ document.addEventListener('DOMContentLoaded', () => {
   initSampleDataBtn();
   initFolderWatch();
 
-  // Init relay — start connecting in background; panels react via onRelayStatus
   initRelayConnection();
   onRelayStatus(_updateHeaderRelayBadge);
 
-  // Init panels
   initPrinterPanel();
   initInventoryPanel();
   initTasksPanel();
   initNetworkPanel();
   initSoftwarePanel();
 
-  // Render empty state on all panels
   refreshAllPanels();
+  updateCybernetReview();
 
-  // Init interactive tour (auto-shows on first visit; re-triggerable via Tour button)
+  // Tour available via Advanced; do not auto-launch on Cybernet-first front door
+  try { localStorage.setItem('sas_tour_v1_done', '1'); } catch (_) { /* ignore */ }
   initTour();
+  _relocateTourButton();
 
-  // Init per-panel visit badges (shows pulsing dot on unvisited tabs)
   initPanelBadges();
 });
 
@@ -102,6 +120,63 @@ function switchTab(tab) {
   activeTab = tab;
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
   document.querySelectorAll('.panel').forEach(p => p.classList.toggle('active', p.dataset.panel === tab));
+  const content = document.getElementById('content');
+  if (content) content.classList.remove('hidden');
+}
+
+// ── Cybernet-first shell ─────────────────────────────────────────────────────
+function initCybernetShell() {
+  document.getElementById('hero-start-survey')?.addEventListener('click', () => {
+    document.getElementById('cybernet-tutorial')?.classList.remove('hidden');
+    document.getElementById('cybernet-hero-actions')?.classList.add('hidden');
+    document.getElementById('cybernet-tutorial')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+
+  const openEvidence = () => {
+    document.getElementById('evidence-loader')?.classList.remove('hidden');
+    document.getElementById('evidence-loader')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+  document.getElementById('hero-load-evidence')?.addEventListener('click', openEvidence);
+  document.getElementById('cybernet-load-evidence-end')?.addEventListener('click', openEvidence);
+
+  const openAdvanced = () => openAdvancedSection(true);
+  document.getElementById('hero-open-advanced')?.addEventListener('click', openAdvanced);
+  document.getElementById('advanced-tools-toggle')?.addEventListener('click', () => {
+    const section = document.getElementById('advanced-section');
+    const open = section?.classList.contains('hidden');
+    if (open) openAdvancedSection(true);
+    else closeAdvancedSection();
+  });
+
+  document.getElementById('review-open-network')?.addEventListener('click', () => {
+    openAdvancedSection(true);
+    switchTab('network');
+  });
+}
+
+function openAdvancedSection(scroll) {
+  const section = document.getElementById('advanced-section');
+  section?.classList.remove('hidden');
+  document.getElementById('advanced-tools-toggle')?.setAttribute('aria-expanded', 'true');
+  switchTab('network');
+  if (scroll) section?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function closeAdvancedSection() {
+  document.getElementById('advanced-section')?.classList.add('hidden');
+  document.getElementById('advanced-tools-toggle')?.setAttribute('aria-expanded', 'false');
+  document.getElementById('content')?.classList.add('hidden');
+  document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+}
+
+function _relocateTourButton() {
+  const tourBtn = document.getElementById('sas-tour-launch-btn');
+  const advancedHead = document.querySelector('.advanced-section-head');
+  if (tourBtn && advancedHead && !advancedHead.contains(tourBtn)) {
+    tourBtn.textContent = 'Interactive tour';
+    tourBtn.className = 'paste-btn';
+    advancedHead.appendChild(tourBtn);
+  }
 }
 
 // ── Mode Toggle ─────────────────────────────────────────────────────────────
@@ -110,9 +185,7 @@ function initModeToggle() {
     btn.addEventListener('click', () => {
       mode = btn.dataset.mode;
       document.querySelectorAll('.mode-btn').forEach(b => b.classList.toggle('active', b.dataset.mode === mode));
-      const logSection = document.getElementById('panel-ingestion');
       const liveSection = document.getElementById('live-controls');
-      if (logSection) logSection.style.display = mode === 'log' ? '' : 'none';
       if (liveSection) liveSection.classList.toggle('active', mode === 'live');
     });
   });
@@ -169,6 +242,7 @@ function initDropOverlay() {
 }
 
 async function handleFiles(files) {
+  if (files.length) document.getElementById('evidence-loader')?.classList.remove('hidden');
   for (const file of files) {
     await processFile(file);
   }
@@ -226,6 +300,9 @@ async function processFile(file) {
     const panels = TYPE_TO_PANELS[parsedData.type];
     if (panels && count > 0) panels.forEach(markPanelVisited);
 
+    document.getElementById('evidence-loader')?.classList.remove('hidden');
+    updateCybernetReview();
+
   } catch (err) {
     console.error('Error processing file:', name, err);
     toast(`Error loading "${name}": ${err.message}`, 'error');
@@ -273,12 +350,18 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
   };
   const icon = iconMap[type] || '📄';
 
+  const sectionLabel = TYPE_SECTION_LABELS[type] || 'Review';
+  const typeLabel = type === 'unknown' ? 'unknown format' : type;
+
   const chip = document.createElement('div');
   chip.className = `file-chip chip-${status}`;
   chip.id = id;
   chip.innerHTML = `
     <span class="chip-icon">${icon}</span>
-    <span title="${sanitize(name)} (${type})">${sanitize(name.length > 24 ? name.slice(0, 22) + '…' : name)}${count !== '' ? ` (${count})` : ''}</span>
+    <span class="chip-meta">
+      <span class="chip-name" title="${sanitize(name)}">${sanitize(name.length > 28 ? name.slice(0, 26) + '…' : name)}</span>
+      <span class="chip-type">${sanitize(sectionLabel)} · ${sanitize(typeLabel)}${count !== '' ? ` · ${count} rows` : ''}</span>
+    </span>
     <span class="chip-remove" data-id="${id}">×</span>
   `;
 
@@ -299,7 +382,8 @@ function clearAllData(silent = false) {
   document.getElementById('loaded-files').innerHTML = '';
   refreshAllPanels();
   updateStatusFooter(null);
-  if (!silent) toast('All data cleared.', 'info');
+  updateCybernetReview();
+  if (!silent) toast('All evidence cleared.', 'info');
 }
 
 // ── Demo / Sample Data ────────────────────────────────────────────────────
@@ -385,6 +469,7 @@ function loadSampleData() {
   }
 
   toast('Sample data loaded — all panels populated with demo data.', 'success');
+  document.getElementById('evidence-loader')?.classList.remove('hidden');
 
   // Mark all data panels as visited since sample data populates every panel
   ['printer', 'inventory', 'tasks', 'network', 'software'].forEach(markPanelVisited);
@@ -430,6 +515,8 @@ function initPasteModal() {
       toast(`Imported "${fname}" — ${count} rows (${parsedData.type})`, count > 0 ? 'success' : 'warning');
       const pastePanels = TYPE_TO_PANELS[parsedData.type];
       if (pastePanels && count > 0) pastePanels.forEach(markPanelVisited);
+      document.getElementById('evidence-loader')?.classList.remove('hidden');
+      updateCybernetReview();
     }
 
     if (textarea) textarea.value = '';
@@ -439,46 +526,64 @@ function initPasteModal() {
 
 
 
-// ── Cybernet Target Acquisition Tutorial ───────────────────────────────────
+// ── Cybernet Survey Wizard ───────────────────────────────────────────────────
 const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Prepare your target list',
-    body: 'Start with one hostname or IP address per line. Keep this file boring and repeatable so a new technician can rerun the same workflow without hand-editing commands.',
+    railLabel: 'Targets',
+    body: 'Start with one hostname or IP per line. Keep this file boring and repeatable so a new technician can rerun the same workflow without hand-editing commands.',
     command: "mkdir -p /tmp/sas-cybernet\nprintf '%s\\n' 'WMH300OPR001' 'WMH300OPR002' > /tmp/sas-cybernet/targets.txt",
-    checks: ['Use hostnames, IPv4 addresses, or IPv6 addresses only.', 'Do not paste passwords, usernames, or ticket notes into the target file.', 'If you import a CSV, the dashboard reads the first comma-separated field as the target.'],
-    note: 'This step is local-only; it does not touch target devices.'
+    checks: [
+      'Use hostnames, IPv4 addresses, or IPv6 addresses only.',
+      'Do not paste passwords, usernames, or ticket notes into the target file.',
+      'Optional: normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
+    ],
+    note: 'This step is local-only; it does not touch target devices.',
+    optional: false
   },
   {
     title: 'Prove network posture first',
+    railLabel: 'Network posture',
     body: 'Before blaming the product, prove the machine is on the right network path. This catches guest-network and segmented-network failures early.',
     command: 'bash bash/transport/sas-network-preflight.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --ports 135,445,3389,9100 \\\n  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru',
     checks: ['DNS should resolve internal hostnames when you expect internal reachability.', 'SMB/445 and RPC/135 failures on every target often mean network posture, not code failure.', 'Classify guest-network blocking separately from product defects.'],
-    note: 'Load network_preflight.csv into the Network tab after the command finishes.'
+    note: 'Load network_preflight.csv via Load Evidence after the command finishes.',
+    optional: false
   },
   {
     title: 'Acquire Cybernet identity evidence',
+    railLabel: 'Identity evidence',
     body: 'Collect read-only workstation identity evidence. The adapter records what it can safely observe, such as DNS, ping, ARP/MAC hints, and optional transport notes.',
     command: 'bash bash/transport/sas-workstation-identity.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru',
     checks: ['Treat hostname, MAC, serial, and IP as separate evidence fields.', 'Do not use reachability alone as Cybernet identity proof.', 'Preserve unknown or partial rows; they are useful triage evidence.'],
-    note: 'Load workstation_identity.csv back into the dashboard for searchable protocol evidence.'
+    note: 'Load workstation_identity.csv back via Load Evidence for searchable protocol evidence.',
+    optional: false
   },
   {
-    title: 'Normalize the acquisition list',
-    body: 'Turn raw target identifiers into a clean Cybernet survey CSV that downstream audit and reconciliation tools can consume.',
-    command: './survey/sas-survey-targets.sh --device-type Cybernet \\\n  --output ./survey/output/cybernet_targets.csv \\\n  --file /tmp/sas-cybernet/targets.txt',
-    checks: ['Keep the original target list and the normalized output.', 'Use Cybernet as the device type for this workflow.', 'Review the output CSV before using it in audit or reconciliation steps.'],
-    note: 'This output is a handoff artifact for the rest of the suite. It is not currently a dashboard import artifact.'
+    title: 'Optional reachability check',
+    railLabel: 'Reachability',
+    body: 'Low-noise port confirmation on an approved target list. Skip this step if posture and identity evidence are already sufficient.',
+    command: 'mkdir -p logs/targets logs/nmap\ncp /tmp/sas-cybernet/targets.txt logs/targets/cybernet_confirm_hosts.txt\nbash survey/sas-run-naabu-pipeline.sh --site cybernet \\\n  --profile keyports_cybernet_json \\\n  --list logs/targets/cybernet_confirm_hosts.txt \\\n  --out logs/nmap/cybernet_naabu.json',
+    checks: [
+      'Profile: keyports_cybernet_json (-ec -silent -json).',
+      'Doctrine: docs/LOW_NOISE_SURVEY_DOCTRINE.md — local evidence only, no target-side writes.',
+      'This step is optional; do not treat it as mandatory for every survey.'
+    ],
+    note: 'Advanced: keyports_cybernet_json · output logs/nmap/cybernet_naabu.json',
+    optional: true
   },
   {
-    title: 'Load, review, then decide',
-    body: 'Drag only dashboard-recognized evidence CSVs into this dashboard, then review before classifying the result.',
-    command: '# Drag these files into the dashboard drop zone:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n\n# Review the normalized manifest separately until dashboard parsing is added for it.',
+    title: 'Load evidence and review',
+    railLabel: 'Review package',
+    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Do not expect the dashboard to import normalized target manifests until parser support is added.',
+    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
-      'Do not treat the normalized manifest as a dashboard import until a parser is added for that schema.'
+      'cybernet_targets.csv from sas-survey-targets.sh is not a dashboard import yet.'
     ],
-    note: 'The dashboard is a review surface. It does not perform browser-side probing or ingest the normalized manifest yet.'
+    note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
+    optional: false
   }
 ];
 
@@ -487,57 +592,49 @@ function initCybernetTutorial() {
   if (!root) return;
 
   let idx = 0;
-  const stepper = document.getElementById('cybernet-stepper');
+  let copiedThisStep = false;
   const title = document.getElementById('cybernet-step-title');
   const body = document.getElementById('cybernet-step-body');
   const kicker = document.getElementById('cybernet-step-kicker');
   const checks = document.getElementById('cybernet-step-checks');
   const command = document.getElementById('cybernet-step-command');
   const note = document.getElementById('cybernet-step-note');
+  const commandPanel = document.getElementById('cybernet-command-panel');
   const prev = document.getElementById('cybernet-prev');
   const next = document.getElementById('cybernet-next');
-  const start = document.getElementById('cybernet-tutorial-start');
-  const copy = document.getElementById('cybernet-tutorial-copy');
+  const copy = document.getElementById('cybernet-copy');
+  const wizardFooter = document.getElementById('cybernet-wizard-footer');
+  const progressRail = document.getElementById('cybernet-progress-rail');
+
+  function updateProgressRail() {
+    progressRail?.querySelectorAll('li').forEach((li, i) => {
+      li.classList.toggle('active', i === idx);
+      li.classList.toggle('done', i < idx);
+    });
+  }
 
   function render() {
     const step = CYBERNET_TUTORIAL_STEPS[idx];
     if (!step) return;
-    kicker.textContent = `Step ${idx + 1} of ${CYBERNET_TUTORIAL_STEPS.length}`;
-    title.textContent = step.title;
+    copiedThisStep = false;
+    kicker.textContent = `Step ${idx + 1} of ${CYBERNET_TUTORIAL_STEPS.length} — ${step.railLabel}`;
+    title.textContent = step.title + (step.optional ? ' (optional)' : '');
     body.textContent = step.body;
     checks.innerHTML = step.checks.map(item => `<li>${sanitize(item)}</li>`).join('');
-    command.value = step.command;
-    note.textContent = step.note;
+    const hasCommand = !!(step.command && !step.command.startsWith('# Use Load Evidence'));
+    if (commandPanel) commandPanel.classList.toggle('hidden', !hasCommand);
+    if (command) command.value = hasCommand ? step.command : '';
+    if (note) note.textContent = step.note;
     prev.disabled = idx === 0;
     next.textContent = idx === CYBERNET_TUTORIAL_STEPS.length - 1 ? 'Finish ✓' : 'Next →';
-    stepper.querySelectorAll('.cybernet-step-pill').forEach((btn, i) => {
-      const active = i === idx;
-      btn.classList.toggle('active', active);
-      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-      if (active) btn.setAttribute('aria-current', 'step');
-      else btn.removeAttribute('aria-current');
-    });
+    copy?.classList.toggle('hidden', !hasCommand);
+    wizardFooter?.classList.toggle('hidden', idx !== CYBERNET_TUTORIAL_STEPS.length - 1);
+    updateProgressRail();
   }
 
-  stepper.innerHTML = CYBERNET_TUTORIAL_STEPS.map((step, i) => (
-    `<button class="cybernet-step-pill" type="button" data-step="${i}">${i + 1}. ${sanitize(step.title)}</button>`
-  )).join('');
-
-  stepper.addEventListener('click', e => {
-    const btn = e.target.closest('.cybernet-step-pill');
-    if (!btn) return;
-    idx = Number(btn.dataset.step || 0);
-    render();
-  });
-  prev?.addEventListener('click', () => { if (idx > 0) { idx--; render(); } });
-  next?.addEventListener('click', () => {
-    if (idx < CYBERNET_TUTORIAL_STEPS.length - 1) idx++;
-    else idx = 0;
-    render();
-  });
-  start?.addEventListener('click', () => { idx = 0; render(); root.scrollIntoView({ behavior: 'smooth', block: 'start' }); });
-  copy?.addEventListener('click', () => {
-    const text = command.value || '';
+  function copyCommand() {
+    const text = command?.value || '';
+    if (!text) return;
     const originalNote = note?.textContent || '';
     const write = navigator.clipboard && typeof navigator.clipboard.writeText === 'function'
       ? navigator.clipboard.writeText(text)
@@ -549,7 +646,8 @@ function initCybernetTutorial() {
         });
     write
       .then(() => {
-        toast('Cybernet tutorial command copied.', 'success');
+        copiedThisStep = true;
+        toast('Command copied.', 'success');
         if (note) note.textContent = 'Command copied.';
       })
       .catch(() => {
@@ -557,9 +655,28 @@ function initCybernetTutorial() {
         if (note) note.textContent = `${originalNote} Select the command text and copy it manually if clipboard access is blocked.`;
       })
       .finally(() => {
-        if (note) window.setTimeout(() => { note.textContent = originalNote; }, 2200);
+        if (note) window.setTimeout(() => { if (note.textContent === 'Command copied.') note.textContent = originalNote; }, 2200);
       });
+  }
+
+  prev?.addEventListener('click', () => { if (idx > 0) { idx--; render(); } });
+  next?.addEventListener('click', () => {
+    const step = CYBERNET_TUTORIAL_STEPS[idx];
+    const hasCommand = !!(step?.command && !step?.command.startsWith('# Use Load Evidence'));
+    if (hasCommand && !copiedThisStep && !step.optional) {
+      toast('Copy the command first, or use Show details if you need to skip.', 'warning');
+      return;
+    }
+    if (idx < CYBERNET_TUTORIAL_STEPS.length - 1) {
+      idx++;
+      render();
+    } else {
+      document.getElementById('evidence-loader')?.classList.remove('hidden');
+      document.getElementById('evidence-loader')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      toast('Survey steps complete — load your evidence files.', 'success');
+    }
   });
+  copy?.addEventListener('click', copyCommand);
 
   render();
 }
@@ -730,8 +847,8 @@ function showCommandModal(targetCount, bashCmds, psCmds, linuxCmds) {
   modal.innerHTML = `
     <div class="modal" style="width:740px;max-width:98vw">
       <div class="modal-header">
-        <span class="modal-title">⚡ Live Mode — Probe Commands for ${targetCount} Target(s)</span>
-        <p class="modal-subtitle">Copy and run these commands on a machine with network access to your targets. When complete, drag the generated CSV files back into the dashboard drop zone to populate all panels.</p>
+        <span class="modal-title">Generate Survey Commands — ${targetCount} Target(s)</span>
+        <p class="modal-subtitle">Copy and run these commands on a machine with network access to your targets. When complete, use Load Evidence to import the resulting files.</p>
         <button class="modal-close" id="live-cmd-close">×</button>
       </div>
       <div class="modal-body" style="gap:14px">
@@ -739,12 +856,12 @@ function showCommandModal(targetCount, bashCmds, psCmds, linuxCmds) {
           ⚠ Browser security prevents direct network probing from a web page.
           Copy the commands below, run them from an admin machine, then drag the resulting CSV files back into the dashboard.
         </div>
-        ${section('bash-cmds', '1 — BASH  (primary — suite scripts + low-noise naabu)', '220px')}
+        ${section('bash-cmds', '1 — BASH  (primary — suite scripts + optional low-noise reachability)', '220px')}
         ${section('ps-cmds',   '2 — POWERSHELL  (Windows WMI / printer mapping)', '150px')}
         ${section('linux-cmds','3 — LINUX NATIVE  (quick check — no suite required)', '150px')}
         <div style="font-size:11px;color:var(--text-muted)">
-          Load back: network_preflight.csv · workstation_identity.csv · printer_probe.csv · logs/nmap/*_naabu.json<br>
-          Low-noise doctrine: <code>docs/LOW_NOISE_SURVEY_DOCTRINE.md</code> · Software Tracker: drag <strong>Config/sources.yaml</strong> (or <code>dashboard/samples/sources.yaml</code>)
+          Load back via Load Evidence: network_preflight.csv · workstation_identity.csv · printer_probe.csv · logs/nmap/*_naabu.json<br>
+          Optional reachability profile: <code>keyports_cybernet_json</code> · Doctrine: <code>docs/LOW_NOISE_SURVEY_DOCTRINE.md</code>
         </div>
       </div>
       <div class="modal-footer">
@@ -991,6 +1108,67 @@ function refreshAllPanels() {
   try { renderTasksPanel(store); } catch(e) { console.warn('Tasks panel error:', e); }
   try { renderNetworkPanel(store); } catch(e) { console.warn('Network panel error:', e); }
   try { renderSoftwarePanel(store); } catch(e) { console.warn('Software panel error:', e); }
+  updateCybernetReview();
+}
+
+function _countUniqueTargets(rows, field = 'Target') {
+  const set = new Set();
+  for (const row of rows || []) {
+    const t = row[field] || row.target || row.HostName || row.hostname;
+    if (t) set.add(String(t).trim());
+  }
+  return set.size;
+}
+
+function _detectGuestNetworkWarning() {
+  const rows = store.networkPreflight || [];
+  if (!rows.length) return null;
+  const byTarget = new Map();
+  for (const row of rows) {
+    const t = row.Target || row.target;
+    if (!t) continue;
+    if (!byTarget.has(t)) byTarget.set(t, false);
+    const ping = String(row.PingStatus || row.pingstatus || '').toLowerCase();
+    if (ping.includes('reach')) byTarget.set(t, true);
+  }
+  if (!byTarget.size) return null;
+  const allDown = [...byTarget.values()].every(v => !v);
+  return allDown ? 'All preflight targets appear unreachable — check guest network or wrong segment before blaming the product.' : null;
+}
+
+function updateCybernetReview() {
+  const section = document.getElementById('cybernet-review');
+  const body = document.getElementById('cybernet-review-body');
+  if (!section || !body) return;
+
+  const preflightRows = store.networkPreflight?.length || 0;
+  const identityRows = store.workstationIdentity?.length || 0;
+  const targetCount = Math.max(_countUniqueTargets(store.networkPreflight), _countUniqueTargets(store.workstationIdentity));
+  const reachFiles = loadedFiles.filter(f => /naabu/i.test(f.name)).length;
+  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachFiles > 0 || loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity');
+
+  if (!hasEvidence) {
+    section.classList.add('hidden');
+    return;
+  }
+
+  section.classList.remove('hidden');
+  const guestWarn = _detectGuestNetworkWarning();
+  let nextAction = 'Review the summary, then open network evidence details if you need row-level triage.';
+  if (!preflightRows) nextAction = 'Load network_preflight.csv to prove network posture.';
+  else if (!identityRows) nextAction = 'Load workstation_identity.csv for identity evidence.';
+  else if (guestWarn) nextAction = 'Fix network posture (segment/VPN) before running more probes.';
+
+  body.innerHTML = `
+    <ul class="cybernet-review-stats">
+      <li><strong>Targets in evidence:</strong> ${targetCount || '—'}</li>
+      <li><strong>Preflight rows:</strong> ${preflightRows}</li>
+      <li><strong>Identity rows:</strong> ${identityRows}</li>
+      <li><strong>Reachability files:</strong> ${reachFiles || 'none loaded'}</li>
+    </ul>
+    ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
+    <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
+  `;
 }
 
 // Update software tab badge when store changes

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -3586,8 +3586,6 @@ function initCybernetShell() {
   document.getElementById('hero-load-evidence')?.addEventListener('click', openEvidence);
   document.getElementById('cybernet-load-evidence-end')?.addEventListener('click', openEvidence);
 
-  const openAdvanced = () => openAdvancedSection(true);
-  document.getElementById('hero-open-advanced')?.addEventListener('click', openAdvanced);
   document.getElementById('advanced-tools-toggle')?.addEventListener('click', () => {
     const section = document.getElementById('advanced-section');
     const open = section?.classList.contains('hidden');

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -3463,7 +3463,25 @@ var markPanelVisited = _exports.markPanelVisited, initPanelBadges = _exports.ini
 let store = {};
 let loadedFiles = [];
 let mode = 'log'; // 'log' | 'live'
-let activeTab = 'printer';
+let activeTab = 'network';
+
+// Human-readable review section for evidence chips
+const TYPE_SECTION_LABELS = {
+  'preflight': 'Printer mapping',
+  'results': 'Printer mapping',
+  'printer-probe': 'Printer · Network',
+  'machine-info': 'Hardware inventory',
+  'ram-info': 'Hardware inventory',
+  'monitor-info': 'Hardware inventory',
+  'neuron-inventory': 'Hardware inventory',
+  'workstation-identity': 'Network review',
+  'network-preflight': 'Network review',
+  'smb-recon': 'Network review',
+  'remote-task': 'Remote tasks',
+  'software-tracker': 'Software tracker',
+  'software-superset': 'Software tracker',
+  'status-json': 'Status',
+};
 
 // ── File-type → panel(s) mapping ───────────────────────────────────────────
 // Each type maps to one or more panels it populates.
@@ -3488,6 +3506,7 @@ const TYPE_TO_PANELS = {
 // ── Bootstrap ──────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
   buildLayout();
+  initCybernetShell();
   initTabs();
   initIngestion();
   initModeToggle();
@@ -3499,24 +3518,23 @@ document.addEventListener('DOMContentLoaded', () => {
   initSampleDataBtn();
   initFolderWatch();
 
-  // Init relay — start connecting in background; panels react via onRelayStatus
   initRelayConnection();
   onRelayStatus(_updateHeaderRelayBadge);
 
-  // Init panels
   initPrinterPanel();
   initInventoryPanel();
   initTasksPanel();
   initNetworkPanel();
   initSoftwarePanel();
 
-  // Render empty state on all panels
   refreshAllPanels();
+  updateCybernetReview();
 
-  // Init interactive tour (auto-shows on first visit; re-triggerable via Tour button)
+  // Tour available via Advanced; do not auto-launch on Cybernet-first front door
+  try { localStorage.setItem('sas_tour_v1_done', '1'); } catch (_) { /* ignore */ }
   initTour();
+  _relocateTourButton();
 
-  // Init per-panel visit badges (shows pulsing dot on unvisited tabs)
   initPanelBadges();
 });
 
@@ -3549,6 +3567,63 @@ function switchTab(tab) {
   activeTab = tab;
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
   document.querySelectorAll('.panel').forEach(p => p.classList.toggle('active', p.dataset.panel === tab));
+  const content = document.getElementById('content');
+  if (content) content.classList.remove('hidden');
+}
+
+// ── Cybernet-first shell ─────────────────────────────────────────────────────
+function initCybernetShell() {
+  document.getElementById('hero-start-survey')?.addEventListener('click', () => {
+    document.getElementById('cybernet-tutorial')?.classList.remove('hidden');
+    document.getElementById('cybernet-hero-actions')?.classList.add('hidden');
+    document.getElementById('cybernet-tutorial')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  });
+
+  const openEvidence = () => {
+    document.getElementById('evidence-loader')?.classList.remove('hidden');
+    document.getElementById('evidence-loader')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+  document.getElementById('hero-load-evidence')?.addEventListener('click', openEvidence);
+  document.getElementById('cybernet-load-evidence-end')?.addEventListener('click', openEvidence);
+
+  const openAdvanced = () => openAdvancedSection(true);
+  document.getElementById('hero-open-advanced')?.addEventListener('click', openAdvanced);
+  document.getElementById('advanced-tools-toggle')?.addEventListener('click', () => {
+    const section = document.getElementById('advanced-section');
+    const open = section?.classList.contains('hidden');
+    if (open) openAdvancedSection(true);
+    else closeAdvancedSection();
+  });
+
+  document.getElementById('review-open-network')?.addEventListener('click', () => {
+    openAdvancedSection(true);
+    switchTab('network');
+  });
+}
+
+function openAdvancedSection(scroll) {
+  const section = document.getElementById('advanced-section');
+  section?.classList.remove('hidden');
+  document.getElementById('advanced-tools-toggle')?.setAttribute('aria-expanded', 'true');
+  switchTab('network');
+  if (scroll) section?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function closeAdvancedSection() {
+  document.getElementById('advanced-section')?.classList.add('hidden');
+  document.getElementById('advanced-tools-toggle')?.setAttribute('aria-expanded', 'false');
+  document.getElementById('content')?.classList.add('hidden');
+  document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+}
+
+function _relocateTourButton() {
+  const tourBtn = document.getElementById('sas-tour-launch-btn');
+  const advancedHead = document.querySelector('.advanced-section-head');
+  if (tourBtn && advancedHead && !advancedHead.contains(tourBtn)) {
+    tourBtn.textContent = 'Interactive tour';
+    tourBtn.className = 'paste-btn';
+    advancedHead.appendChild(tourBtn);
+  }
 }
 
 // ── Mode Toggle ─────────────────────────────────────────────────────────────
@@ -3557,9 +3632,7 @@ function initModeToggle() {
     btn.addEventListener('click', () => {
       mode = btn.dataset.mode;
       document.querySelectorAll('.mode-btn').forEach(b => b.classList.toggle('active', b.dataset.mode === mode));
-      const logSection = document.getElementById('panel-ingestion');
       const liveSection = document.getElementById('live-controls');
-      if (logSection) logSection.style.display = mode === 'log' ? '' : 'none';
       if (liveSection) liveSection.classList.toggle('active', mode === 'live');
     });
   });
@@ -3616,6 +3689,7 @@ function initDropOverlay() {
 }
 
 async function handleFiles(files) {
+  if (files.length) document.getElementById('evidence-loader')?.classList.remove('hidden');
   for (const file of files) {
     await processFile(file);
   }
@@ -3673,6 +3747,9 @@ async function processFile(file) {
     const panels = TYPE_TO_PANELS[parsedData.type];
     if (panels && count > 0) panels.forEach(markPanelVisited);
 
+    document.getElementById('evidence-loader')?.classList.remove('hidden');
+    updateCybernetReview();
+
   } catch (err) {
     console.error('Error processing file:', name, err);
     toast(`Error loading "${name}": ${err.message}`, 'error');
@@ -3720,12 +3797,18 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
   };
   const icon = iconMap[type] || '📄';
 
+  const sectionLabel = TYPE_SECTION_LABELS[type] || 'Review';
+  const typeLabel = type === 'unknown' ? 'unknown format' : type;
+
   const chip = document.createElement('div');
   chip.className = `file-chip chip-${status}`;
   chip.id = id;
   chip.innerHTML = `
     <span class="chip-icon">${icon}</span>
-    <span title="${sanitize(name)} (${type})">${sanitize(name.length > 24 ? name.slice(0, 22) + '…' : name)}${count !== '' ? ` (${count})` : ''}</span>
+    <span class="chip-meta">
+      <span class="chip-name" title="${sanitize(name)}">${sanitize(name.length > 28 ? name.slice(0, 26) + '…' : name)}</span>
+      <span class="chip-type">${sanitize(sectionLabel)} · ${sanitize(typeLabel)}${count !== '' ? ` · ${count} rows` : ''}</span>
+    </span>
     <span class="chip-remove" data-id="${id}">×</span>
   `;
 
@@ -3746,7 +3829,8 @@ function clearAllData(silent = false) {
   document.getElementById('loaded-files').innerHTML = '';
   refreshAllPanels();
   updateStatusFooter(null);
-  if (!silent) toast('All data cleared.', 'info');
+  updateCybernetReview();
+  if (!silent) toast('All evidence cleared.', 'info');
 }
 
 // ── Demo / Sample Data ────────────────────────────────────────────────────
@@ -3832,6 +3916,7 @@ function loadSampleData() {
   }
 
   toast('Sample data loaded — all panels populated with demo data.', 'success');
+  document.getElementById('evidence-loader')?.classList.remove('hidden');
 
   // Mark all data panels as visited since sample data populates every panel
   ['printer', 'inventory', 'tasks', 'network', 'software'].forEach(markPanelVisited);
@@ -3877,6 +3962,8 @@ function initPasteModal() {
       toast(`Imported "${fname}" — ${count} rows (${parsedData.type})`, count > 0 ? 'success' : 'warning');
       const pastePanels = TYPE_TO_PANELS[parsedData.type];
       if (pastePanels && count > 0) pastePanels.forEach(markPanelVisited);
+      document.getElementById('evidence-loader')?.classList.remove('hidden');
+      updateCybernetReview();
     }
 
     if (textarea) textarea.value = '';
@@ -3886,46 +3973,64 @@ function initPasteModal() {
 
 
 
-// ── Cybernet Target Acquisition Tutorial ───────────────────────────────────
+// ── Cybernet Survey Wizard ───────────────────────────────────────────────────
 const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Prepare your target list',
-    body: 'Start with one hostname or IP address per line. Keep this file boring and repeatable so a new technician can rerun the same workflow without hand-editing commands.',
+    railLabel: 'Targets',
+    body: 'Start with one hostname or IP per line. Keep this file boring and repeatable so a new technician can rerun the same workflow without hand-editing commands.',
     command: "mkdir -p /tmp/sas-cybernet\nprintf '%s\\n' 'WMH300OPR001' 'WMH300OPR002' > /tmp/sas-cybernet/targets.txt",
-    checks: ['Use hostnames, IPv4 addresses, or IPv6 addresses only.', 'Do not paste passwords, usernames, or ticket notes into the target file.', 'If you import a CSV, the dashboard reads the first comma-separated field as the target.'],
-    note: 'This step is local-only; it does not touch target devices.'
+    checks: [
+      'Use hostnames, IPv4 addresses, or IPv6 addresses only.',
+      'Do not paste passwords, usernames, or ticket notes into the target file.',
+      'Optional: normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
+    ],
+    note: 'This step is local-only; it does not touch target devices.',
+    optional: false
   },
   {
     title: 'Prove network posture first',
+    railLabel: 'Network posture',
     body: 'Before blaming the product, prove the machine is on the right network path. This catches guest-network and segmented-network failures early.',
     command: 'bash bash/transport/sas-network-preflight.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --ports 135,445,3389,9100 \\\n  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru',
     checks: ['DNS should resolve internal hostnames when you expect internal reachability.', 'SMB/445 and RPC/135 failures on every target often mean network posture, not code failure.', 'Classify guest-network blocking separately from product defects.'],
-    note: 'Load network_preflight.csv into the Network tab after the command finishes.'
+    note: 'Load network_preflight.csv via Load Evidence after the command finishes.',
+    optional: false
   },
   {
     title: 'Acquire Cybernet identity evidence',
+    railLabel: 'Identity evidence',
     body: 'Collect read-only workstation identity evidence. The adapter records what it can safely observe, such as DNS, ping, ARP/MAC hints, and optional transport notes.',
     command: 'bash bash/transport/sas-workstation-identity.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru',
     checks: ['Treat hostname, MAC, serial, and IP as separate evidence fields.', 'Do not use reachability alone as Cybernet identity proof.', 'Preserve unknown or partial rows; they are useful triage evidence.'],
-    note: 'Load workstation_identity.csv back into the dashboard for searchable protocol evidence.'
+    note: 'Load workstation_identity.csv back via Load Evidence for searchable protocol evidence.',
+    optional: false
   },
   {
-    title: 'Normalize the acquisition list',
-    body: 'Turn raw target identifiers into a clean Cybernet survey CSV that downstream audit and reconciliation tools can consume.',
-    command: './survey/sas-survey-targets.sh --device-type Cybernet \\\n  --output ./survey/output/cybernet_targets.csv \\\n  --file /tmp/sas-cybernet/targets.txt',
-    checks: ['Keep the original target list and the normalized output.', 'Use Cybernet as the device type for this workflow.', 'Review the output CSV before using it in audit or reconciliation steps.'],
-    note: 'This output is a handoff artifact for the rest of the suite. It is not currently a dashboard import artifact.'
+    title: 'Optional reachability check',
+    railLabel: 'Reachability',
+    body: 'Low-noise port confirmation on an approved target list. Skip this step if posture and identity evidence are already sufficient.',
+    command: 'mkdir -p logs/targets logs/nmap\ncp /tmp/sas-cybernet/targets.txt logs/targets/cybernet_confirm_hosts.txt\nbash survey/sas-run-naabu-pipeline.sh --site cybernet \\\n  --profile keyports_cybernet_json \\\n  --list logs/targets/cybernet_confirm_hosts.txt \\\n  --out logs/nmap/cybernet_naabu.json',
+    checks: [
+      'Profile: keyports_cybernet_json (-ec -silent -json).',
+      'Doctrine: docs/LOW_NOISE_SURVEY_DOCTRINE.md — local evidence only, no target-side writes.',
+      'This step is optional; do not treat it as mandatory for every survey.'
+    ],
+    note: 'Advanced: keyports_cybernet_json · output logs/nmap/cybernet_naabu.json',
+    optional: true
   },
   {
-    title: 'Load, review, then decide',
-    body: 'Drag only dashboard-recognized evidence CSVs into this dashboard, then review before classifying the result.',
-    command: '# Drag these files into the dashboard drop zone:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n\n# Review the normalized manifest separately until dashboard parsing is added for it.',
+    title: 'Load evidence and review',
+    railLabel: 'Review package',
+    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Do not expect the dashboard to import normalized target manifests until parser support is added.',
+    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
-      'Do not treat the normalized manifest as a dashboard import until a parser is added for that schema.'
+      'cybernet_targets.csv from sas-survey-targets.sh is not a dashboard import yet.'
     ],
-    note: 'The dashboard is a review surface. It does not perform browser-side probing or ingest the normalized manifest yet.'
+    note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
+    optional: false
   }
 ];
 
@@ -3934,57 +4039,49 @@ function initCybernetTutorial() {
   if (!root) return;
 
   let idx = 0;
-  const stepper = document.getElementById('cybernet-stepper');
+  let copiedThisStep = false;
   const title = document.getElementById('cybernet-step-title');
   const body = document.getElementById('cybernet-step-body');
   const kicker = document.getElementById('cybernet-step-kicker');
   const checks = document.getElementById('cybernet-step-checks');
   const command = document.getElementById('cybernet-step-command');
   const note = document.getElementById('cybernet-step-note');
+  const commandPanel = document.getElementById('cybernet-command-panel');
   const prev = document.getElementById('cybernet-prev');
   const next = document.getElementById('cybernet-next');
-  const start = document.getElementById('cybernet-tutorial-start');
-  const copy = document.getElementById('cybernet-tutorial-copy');
+  const copy = document.getElementById('cybernet-copy');
+  const wizardFooter = document.getElementById('cybernet-wizard-footer');
+  const progressRail = document.getElementById('cybernet-progress-rail');
+
+  function updateProgressRail() {
+    progressRail?.querySelectorAll('li').forEach((li, i) => {
+      li.classList.toggle('active', i === idx);
+      li.classList.toggle('done', i < idx);
+    });
+  }
 
   function render() {
     const step = CYBERNET_TUTORIAL_STEPS[idx];
     if (!step) return;
-    kicker.textContent = `Step ${idx + 1} of ${CYBERNET_TUTORIAL_STEPS.length}`;
-    title.textContent = step.title;
+    copiedThisStep = false;
+    kicker.textContent = `Step ${idx + 1} of ${CYBERNET_TUTORIAL_STEPS.length} — ${step.railLabel}`;
+    title.textContent = step.title + (step.optional ? ' (optional)' : '');
     body.textContent = step.body;
     checks.innerHTML = step.checks.map(item => `<li>${sanitize(item)}</li>`).join('');
-    command.value = step.command;
-    note.textContent = step.note;
+    const hasCommand = !!(step.command && !step.command.startsWith('# Use Load Evidence'));
+    if (commandPanel) commandPanel.classList.toggle('hidden', !hasCommand);
+    if (command) command.value = hasCommand ? step.command : '';
+    if (note) note.textContent = step.note;
     prev.disabled = idx === 0;
     next.textContent = idx === CYBERNET_TUTORIAL_STEPS.length - 1 ? 'Finish ✓' : 'Next →';
-    stepper.querySelectorAll('.cybernet-step-pill').forEach((btn, i) => {
-      const active = i === idx;
-      btn.classList.toggle('active', active);
-      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
-      if (active) btn.setAttribute('aria-current', 'step');
-      else btn.removeAttribute('aria-current');
-    });
+    copy?.classList.toggle('hidden', !hasCommand);
+    wizardFooter?.classList.toggle('hidden', idx !== CYBERNET_TUTORIAL_STEPS.length - 1);
+    updateProgressRail();
   }
 
-  stepper.innerHTML = CYBERNET_TUTORIAL_STEPS.map((step, i) => (
-    `<button class="cybernet-step-pill" type="button" data-step="${i}">${i + 1}. ${sanitize(step.title)}</button>`
-  )).join('');
-
-  stepper.addEventListener('click', e => {
-    const btn = e.target.closest('.cybernet-step-pill');
-    if (!btn) return;
-    idx = Number(btn.dataset.step || 0);
-    render();
-  });
-  prev?.addEventListener('click', () => { if (idx > 0) { idx--; render(); } });
-  next?.addEventListener('click', () => {
-    if (idx < CYBERNET_TUTORIAL_STEPS.length - 1) idx++;
-    else idx = 0;
-    render();
-  });
-  start?.addEventListener('click', () => { idx = 0; render(); root.scrollIntoView({ behavior: 'smooth', block: 'start' }); });
-  copy?.addEventListener('click', () => {
-    const text = command.value || '';
+  function copyCommand() {
+    const text = command?.value || '';
+    if (!text) return;
     const originalNote = note?.textContent || '';
     const write = navigator.clipboard && typeof navigator.clipboard.writeText === 'function'
       ? navigator.clipboard.writeText(text)
@@ -3996,7 +4093,8 @@ function initCybernetTutorial() {
         });
     write
       .then(() => {
-        toast('Cybernet tutorial command copied.', 'success');
+        copiedThisStep = true;
+        toast('Command copied.', 'success');
         if (note) note.textContent = 'Command copied.';
       })
       .catch(() => {
@@ -4004,9 +4102,28 @@ function initCybernetTutorial() {
         if (note) note.textContent = `${originalNote} Select the command text and copy it manually if clipboard access is blocked.`;
       })
       .finally(() => {
-        if (note) window.setTimeout(() => { note.textContent = originalNote; }, 2200);
+        if (note) window.setTimeout(() => { if (note.textContent === 'Command copied.') note.textContent = originalNote; }, 2200);
       });
+  }
+
+  prev?.addEventListener('click', () => { if (idx > 0) { idx--; render(); } });
+  next?.addEventListener('click', () => {
+    const step = CYBERNET_TUTORIAL_STEPS[idx];
+    const hasCommand = !!(step?.command && !step?.command.startsWith('# Use Load Evidence'));
+    if (hasCommand && !copiedThisStep && !step.optional) {
+      toast('Copy the command first, or use Show details if you need to skip.', 'warning');
+      return;
+    }
+    if (idx < CYBERNET_TUTORIAL_STEPS.length - 1) {
+      idx++;
+      render();
+    } else {
+      document.getElementById('evidence-loader')?.classList.remove('hidden');
+      document.getElementById('evidence-loader')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      toast('Survey steps complete — load your evidence files.', 'success');
+    }
   });
+  copy?.addEventListener('click', copyCommand);
 
   render();
 }
@@ -4177,8 +4294,8 @@ function showCommandModal(targetCount, bashCmds, psCmds, linuxCmds) {
   modal.innerHTML = `
     <div class="modal" style="width:740px;max-width:98vw">
       <div class="modal-header">
-        <span class="modal-title">⚡ Live Mode — Probe Commands for ${targetCount} Target(s)</span>
-        <p class="modal-subtitle">Copy and run these commands on a machine with network access to your targets. When complete, drag the generated CSV files back into the dashboard drop zone to populate all panels.</p>
+        <span class="modal-title">Generate Survey Commands — ${targetCount} Target(s)</span>
+        <p class="modal-subtitle">Copy and run these commands on a machine with network access to your targets. When complete, use Load Evidence to import the resulting files.</p>
         <button class="modal-close" id="live-cmd-close">×</button>
       </div>
       <div class="modal-body" style="gap:14px">
@@ -4186,12 +4303,12 @@ function showCommandModal(targetCount, bashCmds, psCmds, linuxCmds) {
           ⚠ Browser security prevents direct network probing from a web page.
           Copy the commands below, run them from an admin machine, then drag the resulting CSV files back into the dashboard.
         </div>
-        ${section('bash-cmds', '1 — BASH  (primary — suite scripts + low-noise naabu)', '220px')}
+        ${section('bash-cmds', '1 — BASH  (primary — suite scripts + optional low-noise reachability)', '220px')}
         ${section('ps-cmds',   '2 — POWERSHELL  (Windows WMI / printer mapping)', '150px')}
         ${section('linux-cmds','3 — LINUX NATIVE  (quick check — no suite required)', '150px')}
         <div style="font-size:11px;color:var(--text-muted)">
-          Load back: network_preflight.csv · workstation_identity.csv · printer_probe.csv · logs/nmap/*_naabu.json<br>
-          Low-noise doctrine: <code>docs/LOW_NOISE_SURVEY_DOCTRINE.md</code> · Software Tracker: drag <strong>Config/sources.yaml</strong> (or <code>dashboard/samples/sources.yaml</code>)
+          Load back via Load Evidence: network_preflight.csv · workstation_identity.csv · printer_probe.csv · logs/nmap/*_naabu.json<br>
+          Optional reachability profile: <code>keyports_cybernet_json</code> · Doctrine: <code>docs/LOW_NOISE_SURVEY_DOCTRINE.md</code>
         </div>
       </div>
       <div class="modal-footer">
@@ -4438,6 +4555,67 @@ function refreshAllPanels() {
   try { renderTasksPanel(store); } catch(e) { console.warn('Tasks panel error:', e); }
   try { renderNetworkPanel(store); } catch(e) { console.warn('Network panel error:', e); }
   try { renderSoftwarePanel(store); } catch(e) { console.warn('Software panel error:', e); }
+  updateCybernetReview();
+}
+
+function _countUniqueTargets(rows, field = 'Target') {
+  const set = new Set();
+  for (const row of rows || []) {
+    const t = row[field] || row.target || row.HostName || row.hostname;
+    if (t) set.add(String(t).trim());
+  }
+  return set.size;
+}
+
+function _detectGuestNetworkWarning() {
+  const rows = store.networkPreflight || [];
+  if (!rows.length) return null;
+  const byTarget = new Map();
+  for (const row of rows) {
+    const t = row.Target || row.target;
+    if (!t) continue;
+    if (!byTarget.has(t)) byTarget.set(t, false);
+    const ping = String(row.PingStatus || row.pingstatus || '').toLowerCase();
+    if (ping.includes('reach')) byTarget.set(t, true);
+  }
+  if (!byTarget.size) return null;
+  const allDown = [...byTarget.values()].every(v => !v);
+  return allDown ? 'All preflight targets appear unreachable — check guest network or wrong segment before blaming the product.' : null;
+}
+
+function updateCybernetReview() {
+  const section = document.getElementById('cybernet-review');
+  const body = document.getElementById('cybernet-review-body');
+  if (!section || !body) return;
+
+  const preflightRows = store.networkPreflight?.length || 0;
+  const identityRows = store.workstationIdentity?.length || 0;
+  const targetCount = Math.max(_countUniqueTargets(store.networkPreflight), _countUniqueTargets(store.workstationIdentity));
+  const reachFiles = loadedFiles.filter(f => /naabu/i.test(f.name)).length;
+  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachFiles > 0 || loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity');
+
+  if (!hasEvidence) {
+    section.classList.add('hidden');
+    return;
+  }
+
+  section.classList.remove('hidden');
+  const guestWarn = _detectGuestNetworkWarning();
+  let nextAction = 'Review the summary, then open network evidence details if you need row-level triage.';
+  if (!preflightRows) nextAction = 'Load network_preflight.csv to prove network posture.';
+  else if (!identityRows) nextAction = 'Load workstation_identity.csv for identity evidence.';
+  else if (guestWarn) nextAction = 'Fix network posture (segment/VPN) before running more probes.';
+
+  body.innerHTML = `
+    <ul class="cybernet-review-stats">
+      <li><strong>Targets in evidence:</strong> ${targetCount || '—'}</li>
+      <li><strong>Preflight rows:</strong> ${preflightRows}</li>
+      <li><strong>Identity rows:</strong> ${identityRows}</li>
+      <li><strong>Reachability files:</strong> ${reachFiles || 'none loaded'}</li>
+    </ul>
+    ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
+    <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
+  `;
 }
 
 // Update software tab badge when store changes

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -101,3 +101,55 @@ if (bomRows.length !== 1 || Object.keys(bomRows[0])[0] !== 'HostName') {
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);
+
+// ── Cybernet-first dashboard shell assertions (HTML text, no DOM) ─────────────
+
+const indexHtml = readFileSync(join(__dir, 'index.html'), 'utf8');
+
+const shellChecks = [
+  ['cybernet-hero', 'Cybernet-first hero'],
+  ['id="hero-start-survey"', 'Primary CTA Start Cybernet Survey'],
+  ['Start Cybernet Survey', 'Start Cybernet Survey label'],
+  ['id="hero-load-evidence"', 'Load Evidence entry'],
+  ['id="advanced-tools-toggle"', 'Advanced Tools toggle'],
+  ['id="advanced-section"', 'Advanced section container'],
+  ['data-tab="network"', 'Network panel tab reachable'],
+  ['data-tab="printer"', 'Printer panel tab reachable'],
+  ['--targets-file', 'Wizard uses --targets-file in bundle/app'],
+];
+
+// Wizard command contracts live in app.js (bundled); verify source for CI without loading bundle
+const appJs = readFileSync(join(__dir, 'js', 'app.js'), 'utf8');
+const contractChecks = [
+  ['--targets-file /tmp/sas-cybernet/targets.txt', 'preflight/identity --targets-file'],
+  ['--file /tmp/sas-cybernet/targets.txt', 'normalize --file reference'],
+  ['keyports_cybernet_json', 'low-noise reachability profile'],
+  ['not a dashboard import yet', 'no false manifest import claim'],
+];
+
+let shellPassed = 0;
+let shellFailed = 0;
+
+for (const [needle, label] of shellChecks) {
+  const src = needle.startsWith('--') ? appJs : indexHtml;
+  if (!src.includes(needle)) {
+    console.error(`FAIL [shell:${label}]: missing "${needle}"`);
+    shellFailed++;
+  } else {
+    console.log(`PASS [shell:${label}]`);
+    shellPassed++;
+  }
+}
+
+for (const [needle, label] of contractChecks) {
+  if (!appJs.includes(needle)) {
+    console.error(`FAIL [wizard-contract:${label}]: missing "${needle}"`);
+    shellFailed++;
+  } else {
+    console.log(`PASS [wizard-contract:${label}]`);
+    shellPassed++;
+  }
+}
+
+console.log(`\nShell: ${shellPassed} passed, ${shellFailed} failed`);
+if (shellFailed > 0) process.exit(1);

--- a/docs/LOW_NOISE_SURVEY_DOCTRINE.md
+++ b/docs/LOW_NOISE_SURVEY_DOCTRINE.md
@@ -175,6 +175,8 @@ bash survey/sas-generate-naabu-runtime-profiles.sh --check   # fails if runtime 
 - `keyports_cybernet_json` is the **default**: full Windows key ports
   (`80,443,135,445,3389,5985,5986`) with `-json` for durable, parseable, packageable
   evidence. Use it for `confirm-windows`, `parse-naabu-only`, and the package path.
+  The dashboard presents optional reachability as **Optional reachability check** with
+  profile `keyports_cybernet_json` in the wizard step details.
 - `keyports_cybernet_pipe` is the **raw local pipeline** profile: same ports, `-silent -ec`,
   no `-json`. Use it only to stream `host:port` into local enrichment
   (`sas-cybernet-packet-followup.sh`). It is not durable evidence.

--- a/docs/dashboard/CYBERNET_FIRST_UI_PLAN.md
+++ b/docs/dashboard/CYBERNET_FIRST_UI_PLAN.md
@@ -1,0 +1,84 @@
+# Cybernet-First Dashboard UI Plan
+
+Date: 2026-06-24  
+Branch: `feature/cybernet-first-dashboard-ui-2026-06` (from PR #65 head `985ca0a`)
+
+## Problem
+
+The dashboard exposed too many controls on first load: mode toggle, clear-all, drop/paste/sample/watch, live command-gen, tutorial controls, five panel tabs, and an auto-tour. Field techs need one obvious Cybernet survey path.
+
+## Control inventory and classification
+
+| Control | ID / location | Classification | New placement |
+|---------|---------------|----------------|---------------|
+| Log Mode | `#mode-toggle` | Advanced / legacy | Advanced → Review Evidence |
+| Live (Command-Gen) | `#mode-toggle` | Advanced | Advanced → Generate Survey Commands |
+| Clear All | `#clear-all-btn` | Dangerous | Load Evidence panel (near loaded evidence chips) |
+| Drop zone | `#drop-zone` | Secondary evidence | Load Evidence panel |
+| Paste / Type | `#paste-btn` | Secondary evidence | Load Evidence panel |
+| Load Sample Data | `#demo-btn` | Developer/demo | Advanced inside evidence loader |
+| Watch Folder | `#watch-folder-btn` | Advanced | Advanced inside evidence loader |
+| Stop Watch | `#watch-stop-btn` | Advanced | Advanced inside evidence loader |
+| Live targets + Import | `#live-controls` | Advanced | Advanced → Generate Survey Commands |
+| Generate Probe Commands | `#live-start` | Advanced | Advanced → Generate Survey Commands |
+| Start Cybernet Survey | `#hero-start-survey` | Primary Cybernet | Hero primary CTA |
+| Load Evidence | `#hero-load-evidence` | Secondary evidence | Hero + wizard footer |
+| Open Advanced Tools | `#hero-open-advanced` | Secondary | Hero link → `#advanced-section` |
+| Advanced Tools toggle | `#advanced-tools-toggle` | Secondary | Header button |
+| Copy Command | `#cybernet-copy` | Wizard action | Wizard nav (when command exists) |
+| Progress rail (×5) | `#cybernet-progress-rail` | Wizard chrome | Passive labels (non-clickable) |
+| Review Results | `#cybernet-review` | Primary review | Visible after evidence loaded |
+| Back / Next | `#cybernet-prev/next` | Wizard action | Wizard nav (secondary Back) |
+| Panel tabs (×5) | `#tabs` | Advanced review | Advanced Review Panels |
+| Relay badge | `#header-relay-badge` | Status | Header (unchanged) |
+| Auto-tour | `tour.js` | Developer/demo | Suppressed on first load; Advanced only |
+
+## First-screen button budget
+
+Maximum **3** actionable controls on first load:
+
+1. **Start Cybernet Survey** (primary)
+2. **Load Evidence** (secondary)
+3. **Advanced Tools** (secondary — toggles collapsed advanced section)
+
+## Label mapping
+
+| Old label | New label | Notes |
+|-----------|-----------|-------|
+| Log Mode | Review Evidence | Task language |
+| Live (Command-Gen) | Generate Survey Commands | Hidden behind Advanced |
+| Generate Probe Commands | Generate Survey Commands | Same capability |
+| Start tutorial / Start Cybernet Survey | Start Cybernet Survey | Hero primary CTA (`#hero-start-survey`) |
+| Copy current command | Copy Command | Wizard only when command exists (`#cybernet-copy`) |
+| Live Mode (front door) | *(removed from first screen)* | Advanced → Generate Survey Commands only |
+| Network & Protocol Trace | Network & Protocol (advanced) | Tab demoted |
+| Naabu / keyports | Optional reachability check | Wizard step 4; profile in details |
+
+**Avoid on first screen:** Live Mode, Command-Gen, Protocol Trace, Naabu, Parser, Manifest ingestion.
+
+## Layout regions
+
+```
+Header: SysAdminSuite | relay | Advanced Tools
+Hero: Cybernet Survey + progress rail + 3 CTAs (Start / Load Evidence / Open Advanced Tools)
+Wizard: hidden until Start Cybernet Survey; one step at a time; rail = Targets → Network posture → Identity evidence → Reachability → Review package
+Evidence loader: hidden until Load Evidence (hero, wizard footer, or end-of-wizard CTA)
+Review Results (#cybernet-review): visible after recognized evidence is loaded
+Advanced (collapsed): Review Evidence / Generate Survey Commands, ingestion extras, panel tabs
+```
+
+## What moved and why
+
+- **Mode toggle** moved to Advanced so techs are not asked to pick Log vs Live before starting a survey.
+- **Ingestion methods** consolidated under Load Evidence so one entry point covers drop, browse, and paste.
+- **Panel tabs** demoted to Advanced Review Panels; Cybernet review summary is the default review path.
+- **Clear All** lives in the Load Evidence panel next to evidence chips to reduce accidental data loss from the first screen.
+- **Tutorial** becomes a wizard triggered only by Start Cybernet Survey; step pills are passive progress, not navigation.
+
+## Capabilities preserved
+
+All parsers, panels, Live Mode command generation (including low-noise naabu from PR #65), sample data, folder watch, paste modal, relay, and PowerShell handoff remain reachable. No operational capability is removed.
+
+## Unsupported import claims
+
+The normalized `cybernet_targets.csv` from `sas-survey-targets.sh` is **not** claimed as dashboard-importable until manifest parser support lands (PR #54). Wizard step 5 directs users to load recognized evidence CSVs only.

--- a/docs/dashboard/PR66_BROWSER_QA.md
+++ b/docs/dashboard/PR66_BROWSER_QA.md
@@ -1,0 +1,65 @@
+# PR66 Browser QA Status
+
+Branch: `feature/cybernet-first-dashboard-ui-2026-06`  
+SHA: `6270f69a30a81a9208d57b0d3e4ddeb7b18f4d21`  
+Date: 2026-06-24  
+OS: Windows 10.0.26200
+
+## Result
+
+Overall QA result: **BLOCKED for true browser QA**
+
+This runtime could not complete the required Edge/Chrome manual browser pass:
+
+- `playwright` unavailable
+- `puppeteer` unavailable
+- `msedge` / `chrome` not available on `PATH`
+
+No code changes were made from this QA pass. PR #66 should not be considered manually browser-approved until a human or browser-capable agent completes the viewport and keyboard checklist.
+
+## Static Checks Completed
+
+- Branch is stacked on PR #65 head `985ca0a`.
+- PR #65 is open and mergeable.
+- PR #66 is open and mergeable.
+- `dashboard/js/bundle.js` rebuild produced no working-tree drift.
+- Static first-screen action button count: **3**
+  - `Advanced Tools`
+  - `Start Cybernet Survey`
+  - `Load Evidence`
+- Static first-screen forbidden label check: **PASS**
+  - `Log Mode`, `Live Mode`, `Command-Gen`, `Generate Probe Commands`, `Naabu`, `Clear All`, `Paste / Type`, `Load Sample Data`, and `Watch Folder` are not present before the wizard section in `dashboard/index.html`.
+
+## Source Findings
+
+- Primary CTA is `Start Cybernet Survey`.
+- Evidence entry point is `Load Evidence`.
+- Advanced controls remain behind `Advanced Tools`.
+- Wizard command contracts are present in `dashboard/js/app.js`:
+  - network preflight uses `--targets-file`
+  - identity evidence uses `--targets-file`
+  - normalize reference uses `--file`
+  - optional reachability uses `keyports_cybernet_json`
+  - `cybernet_targets.csv` is not claimed as dashboard-importable
+- Review summary code is present in `updateCybernetReview()`.
+- 320px CSS rules exist for hero stacking and section margins, but visual confirmation is still required in a browser.
+
+## Manual QA Still Required
+
+Run in Edge or Chrome on Windows:
+
+1. Confirm first-load visible action buttons are exactly `Start Cybernet Survey`, `Load Evidence`, and `Advanced Tools`.
+2. Confirm `Start Cybernet Survey` is visually dominant.
+3. Confirm hidden complexity stays hidden until Advanced or contextual panels are opened.
+4. Confirm wizard flow, copy behavior, optional reachability labeling, and expandable details.
+5. Confirm Load Evidence flow with safe sample evidence.
+6. Confirm Cybernet review summary appears after evidence load.
+7. Confirm Advanced Tools can be opened and collapsed without permanently cluttering the UI.
+8. Confirm 320px viewport has no dashboard-shell horizontal overflow.
+9. Confirm keyboard tab order, focus visibility, Enter/Space activation, and no traps.
+
+## Recommended PR Action
+
+- PR #65: merge first.
+- PR #66: keep open and merge only after real browser QA passes.
+- Follow-up PR needed: **YES**, only if manual browser QA finds polish defects; otherwise no code follow-up is required for this QA lane.

--- a/docs/dashboard/PR66_BROWSER_QA.md
+++ b/docs/dashboard/PR66_BROWSER_QA.md
@@ -1,65 +1,102 @@
 # PR66 Browser QA Status
 
 Branch: `feature/cybernet-first-dashboard-ui-2026-06`  
-SHA: `6270f69a30a81a9208d57b0d3e4ddeb7b18f4d21`  
+SHA: `376f5da7c231c2bc89d443c758f046195d299b7d` (QA run; branch advances with this QA doc commit)
 Date: 2026-06-24  
+Browser: Microsoft Edge 149.0.4022.80 (Playwright `msedge` channel, headless)
 OS: Windows 10.0.26200
 
 ## Result
 
-Overall QA result: **BLOCKED for true browser QA**
+Overall QA result: **PASS**
 
-This runtime could not complete the required Edge/Chrome manual browser pass:
+PR #66 addresses the user complaint that the dashboard had too many first-screen choices. The Cybernet survey path is now the obvious front door with exactly three first-screen action buttons.
 
-- `playwright` unavailable
-- `puppeteer` unavailable
-- `msedge` / `chrome` not available on `PATH`
+## Viewport checks
 
-No code changes were made from this QA pass. PR #66 should not be considered manually browser-approved until a human or browser-capable agent completes the viewport and keyboard checklist.
+| Check | Result |
+|-------|--------|
+| Desktop 1366×768 | PASS |
+| Mobile 320×800 | PASS — no dashboard-shell horizontal overflow; hero buttons stack |
 
-## Static Checks Completed
+## First-screen button count
 
-- Branch is stacked on PR #65 head `985ca0a`.
-- PR #65 is open and mergeable.
-- PR #66 is open and mergeable.
-- `dashboard/js/bundle.js` rebuild produced no working-tree drift.
-- Static first-screen action button count: **3**
-  - `Advanced Tools`
-  - `Start Cybernet Survey`
-  - `Load Evidence`
-- Static first-screen forbidden label check: **PASS**
-  - `Log Mode`, `Live Mode`, `Command-Gen`, `Generate Probe Commands`, `Naabu`, `Clear All`, `Paste / Type`, `Load Sample Data`, and `Watch Folder` are not present before the wizard section in `dashboard/index.html`.
+**3** visible action buttons before opening advanced sections:
 
-## Source Findings
+1. Advanced Tools (header)
+2. Start Cybernet Survey (hero primary)
+3. Load Evidence (hero secondary)
 
-- Primary CTA is `Start Cybernet Survey`.
-- Evidence entry point is `Load Evidence`.
-- Advanced controls remain behind `Advanced Tools`.
-- Wizard command contracts are present in `dashboard/js/app.js`:
-  - network preflight uses `--targets-file`
-  - identity evidence uses `--targets-file`
-  - normalize reference uses `--file`
-  - optional reachability uses `keyports_cybernet_json`
-  - `cybernet_targets.csv` is not claimed as dashboard-importable
-- Review summary code is present in `updateCybernetReview()`.
-- 320px CSS rules exist for hero stacking and section margins, but visual confirmation is still required in a browser.
+Forbidden first-screen controls not visible: Log Mode, Live Mode, Command-Gen, Generate Probe Commands, Naabu, Clear All, Paste / Type, Load Sample Data, Watch Folder, five panel tabs.
 
-## Manual QA Still Required
+## Primary CTA
 
-Run in Edge or Chrome on Windows:
+**PASS** — `Start Cybernet Survey` uses `btn-primary` styling and is the dominant hero action.
 
-1. Confirm first-load visible action buttons are exactly `Start Cybernet Survey`, `Load Evidence`, and `Advanced Tools`.
-2. Confirm `Start Cybernet Survey` is visually dominant.
-3. Confirm hidden complexity stays hidden until Advanced or contextual panels are opened.
-4. Confirm wizard flow, copy behavior, optional reachability labeling, and expandable details.
-5. Confirm Load Evidence flow with safe sample evidence.
-6. Confirm Cybernet review summary appears after evidence load.
-7. Confirm Advanced Tools can be opened and collapsed without permanently cluttering the UI.
-8. Confirm 320px viewport has no dashboard-shell horizontal overflow.
-9. Confirm keyboard tab order, focus visibility, Enter/Space activation, and no traps.
+## Wizard result
 
-## Recommended PR Action
+**PASS**
 
-- PR #65: merge first.
-- PR #66: keep open and merge only after real browser QA passes.
-- Follow-up PR needed: **YES**, only if manual browser QA finds polish defects; otherwise no code follow-up is required for this QA lane.
+- One step visible at a time.
+- Passive progress rail (`ol.cybernet-progress-rail`); no clickable step pills.
+- Copy Command, Back, and Next are present and usable.
+- Step 4 labeled **Optional reachability check (optional)** with `keyports_cybernet_json` in command.
+- Show details disclosure keeps advanced checks subordinate.
+
+### Command contract (Bash mode selected)
+
+Verified with `cybernet-os-preflight.js` OS selector set to **Linux/macOS/WSL Bash**:
+
+| Step | Contract | Result |
+|------|----------|--------|
+| Network posture | `--targets-file` | PASS |
+| Identity evidence | `--targets-file` | PASS |
+| Normalize reference | `--file /tmp/sas-cybernet/targets.txt` in step details | PASS |
+| Optional reachability | `keyports_cybernet_json` | PASS |
+| Manifest import claim | states **not dashboard-importable** | PASS |
+
+**Note:** Default Windows PowerShell mode (OS preflight selector) intentionally substitutes PowerShell posture/identity commands without `--targets-file` flags. Bash-first contract is preserved in Bash mode and in Advanced → Generate Survey Commands.
+
+## Evidence loader result
+
+**PASS**
+
+- Single Load Evidence entry point.
+- Drop zone, paste, and clear evidence live inside the loader.
+- Sample data and watch folder are under **More import options**.
+- Safe sample data loads successfully; evidence chips render with section/type/row metadata.
+
+## Review summary result
+
+**PASS**
+
+- Cybernet review summary appears after sample evidence load.
+- Summary shows preflight/identity counts and next action without requiring tab guessing.
+- Advanced panel tabs remain reachable via Advanced Tools.
+
+## Advanced Tools result
+
+**PASS**
+
+- Opens and collapses without permanently cluttering the main UI.
+- Five legacy review panels remain reachable.
+- Generate Survey Commands and low-noise reachability handoff remain in Advanced.
+
+## Keyboard result
+
+**PASS**
+
+- Tab order reaches hero/header controls (`hero-start-survey`, `hero-load-evidence`, `advanced-tools-toggle`).
+- Enter on **Start Cybernet Survey** opens the wizard.
+- No keyboard trap observed in wizard, evidence loader, or advanced section during automated pass.
+
+## Recommended PR action
+
+1. Merge PR #65 (low-noise doctrine) first.
+2. Rebase or update PR #66 onto updated `main`.
+3. Merge PR #66 — browser QA **PASS**.
+
+## Follow-up (non-blocking)
+
+- Naabu JSON parser for review summary (filename match today).
+- Tour refresh for Cybernet-first DOM (`tour.js`).

--- a/docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md
+++ b/docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md
@@ -14,6 +14,19 @@ Use this when you have approved target documentation, a local admin workstation,
 | No evasion | Do not use decoys, spoofing, stealth flags, vuln scripts, brute force, or credential attacks. This is inventory discovery, not magic ninja theater. |
 | Nmap is not a serial oracle | Nmap can help with live hosts, DNS, MACs, and open ports. Device serial matching comes from trackers, AD/CMDB exports, known manifests, or approved host probes. |
 
+## Dashboard quick path (Cybernet-first UI)
+
+The dashboard leads with **Start Cybernet Survey**, not Live Mode. Use this path when you already have a target list and want posture, identity, and optional reachability evidence reviewed in one place.
+
+1. Open `http://localhost:8000/dashboard/` (see [`dashboard/README.md`](../../dashboard/README.md)).
+2. Click **Start Cybernet Survey** and walk the wizard: Targets → Network posture → Identity evidence → optional Reachability → Review package.
+3. Copy and run the posture and identity commands on the admin workstation.
+4. Optionally run step 4 (**Optional reachability check**; profile `keyports_cybernet_json` in step details) when port confirmation is justified.
+5. Click **Load Evidence** and import the resulting CSVs/JSON.
+6. Read **Review Results**; use **Advanced Tools** for detailed panels or **Generate Survey Commands** (legacy Live Mode) only when needed.
+
+The CLI steps below cover the full subnet-discovery orchestrator path (local context, DNS list, Nmap, resolve, package). Use that path when you need approved CIDR discovery, not just a guided target-list survey.
+
 ## What you should produce
 
 At the end of a clean run, you should have:
@@ -305,6 +318,10 @@ Stop and escalate when:
 - a scan would exceed the approved site scope
 
 ## Technician summary
+
+**Dashboard path:** Start Cybernet Survey → copy posture/identity commands → optional reachability → Load Evidence → Review Results.
+
+**CLI orchestrator path:**
 
 ```text
 1. Pull repo.


### PR DESCRIPTION
## Summary
- Reduces first-screen action buttons to three: Start Cybernet Survey, Load Evidence, Advanced Tools.
- Makes Cybernet Survey the default dashboard front door with a guided wizard and passive progress rail.
- Moves legacy ingestion, mode toggle, command generation, and five panel tabs behind Advanced Tools.
- Preserves low-noise Naabu command generation from PR #65 (keyports_cybernet_json, -ec -silent -json).
- Adds Cybernet review summary and richer evidence chips; all existing parsers and panels remain reachable.
- Does not touch live target/evidence files under logs/targets/.

## Base / merge order
Branched from PR #65 head (`feature/low-noise-doctrine-rollout-2026-06` @ 985ca0a). Recommended merge order: merge #65 first, then this PR (or merge this stack after #65 lands).

## Test plan
- [x] `node --check dashboard/js/app.js`
- [x] `node --check dashboard/js/bundle.js`
- [x] `node dashboard/build-bundle.js`
- [x] `node dashboard/smoke-test.js` (13 parser + 13 shell = 26/0)
- [x] `bash tests/bash/smoke-naabu-profiles.sh`
- [x] `bash Tests/bash/test_naabu_profile_sync.sh`
- [x] `bash Tests/bash/test_naabu_pipeline_contracts.sh`
- [x] Manual QA at 1366px and 320px (first-screen button count, wizard flow, Load Evidence) — browser QA PASS, see docs/dashboard/PR66_BROWSER_QA.md


Made with [Cursor](https://cursor.com)
