### PR TITLE
feat(dashboard): parse Naabu reachability JSON evidence

### DIFF
--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -30,6 +30,7 @@ const TYPE_SECTION_LABELS = {
   'workstation-identity': 'Network review',
   'network-preflight': 'Network review',
   'smb-recon': 'Network review',
+  'naabu-reachability': 'Reachability evidence',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
   'software-superset': 'Software tracker',
@@ -52,6 +53,7 @@ const TYPE_TO_PANELS = {
   'remote-task':         ['tasks'],
   'network-preflight':   ['network'],
   'smb-recon':           ['network'],
+  'naabu-reachability':  ['network'],
   'software-tracker':    ['software'],
   'software-superset':   ['software'],
 };
@@ -344,6 +346,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'printer-probe': '🖨️', 'network-preflight': '📡', 'machine-info': '💻',
     'ram-info': '🧠', 'monitor-info': '🖥️', 'neuron-inventory': '🗂️',
     'smb-recon': '📂', 'status-json': '💚', 'remote-task': '⚡',
+    'naabu-reachability': '🔌',
     'software-tracker': '📦', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
@@ -1142,8 +1145,14 @@ function updateCybernetReview() {
   const preflightRows = store.networkPreflight?.length || 0;
   const identityRows = store.workstationIdentity?.length || 0;
   const targetCount = Math.max(_countUniqueTargets(store.networkPreflight), _countUniqueTargets(store.workstationIdentity));
-  const reachFiles = loadedFiles.filter(f => /naabu/i.test(f.name)).length;
-  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachFiles > 0 || loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity');
+  const reachRows = store.naabuReachability || [];
+  const reachabilityCount = reachRows.length;
+  const openPortsCount = reachRows.filter(r => {
+    const rv = (r.reachability || 'open').toLowerCase();
+    return rv === 'open' || rv === '';
+  }).length;
+  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachabilityCount > 0 ||
+    loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity' || f.type === 'naabu-reachability');
 
   if (!hasEvidence) {
     section.classList.add('hidden');
@@ -1162,7 +1171,8 @@ function updateCybernetReview() {
       <li><strong>Targets in evidence:</strong> ${targetCount || '—'}</li>
       <li><strong>Preflight rows:</strong> ${preflightRows}</li>
       <li><strong>Identity rows:</strong> ${identityRows}</li>
-      <li><strong>Reachability files:</strong> ${reachFiles || 'none loaded'}</li>
+      <li><strong>Open ports observed:</strong> ${reachabilityCount > 0 ? openPortsCount : '—'}</li>
+      <li><strong>Reachability rows:</strong> ${reachabilityCount > 0 ? reachabilityCount : '—'}</li>
     </ul>
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -229,11 +229,41 @@ var parseCSV = _exports.parseCSV, parseJSON = _exports.parseJSON, sanitize = _ex
 (function () {
 // parsers.js — file type detection and data normalization
 
+function isNaabuReachabilityObject(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+  const hasHost = !!(obj.host || obj.ip || obj.Host || obj.IP || obj.Ip);
+  const port = obj.port ?? obj.Port;
+  return hasHost && port !== undefined && port !== null && String(port).trim() !== '';
+}
+
+function contentLooksLikeNaabuReachability(content) {
+  if (typeof content !== 'string') return false;
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  const snip = trimmed.slice(0, 800).toLowerCase();
+  if (!snip.includes('port') || (!snip.includes('host') && !snip.includes('ip'))) return false;
+
+  try {
+    const data = JSON.parse(trimmed);
+    const items = Array.isArray(data) ? data : [data];
+    return items.some(isNaabuReachabilityObject);
+  } catch {
+    for (const raw of trimmed.split('\n')) {
+      const line = raw.trim();
+      if (!line) continue;
+      try {
+        if (isNaabuReachabilityObject(JSON.parse(line))) return true;
+      } catch { /* invalid JSONL line */ }
+    }
+  }
+  return false;
+}
+
 /**
  * Detect the log type from filename and/or CSV headers.
  * Returns one of: 'preflight', 'results', 'workstation-identity',
  *   'printer-probe', 'network-preflight', 'machine-info', 'ram-info',
- *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon', 'unknown'
+ *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon', 'naabu-reachability', 'unknown'
  */
 function detectFileType(filename, content) {
   const fn = filename.toLowerCase();
@@ -242,6 +272,11 @@ function detectFileType(filename, content) {
   if (fn.endsWith('.yaml') || fn.endsWith('.yml')) {
     if (fn.includes('sources')) return 'software-tracker';
     return 'software-tracker'; // treat all YAML drops as tracker
+  }
+
+  // Naabu reachability JSON / JSONL — filename hint
+  if ((fn.endsWith('.json') || fn.endsWith('.jsonl')) && fn.includes('naabu')) {
+    return 'naabu-reachability';
   }
 
   // JSON detection — check filename hints first, then probe content
@@ -259,7 +294,13 @@ function detectFileType(filename, content) {
       if (snip.includes('"taskname"') || snip.includes('"outcome"') ||
           snip.includes('"taskid"') || snip.includes('"events"')) return 'remote-task';
     }
+    if (contentLooksLikeNaabuReachability(content)) return 'naabu-reachability';
     return 'status-json'; // fallback: attempt parse as status snapshot
+  }
+
+  if (fn.endsWith('.jsonl')) {
+    if (contentLooksLikeNaabuReachability(content)) return 'naabu-reachability';
+    return 'unknown';
   }
 
   // XLSX detection
@@ -323,8 +364,69 @@ function parseFileContent(type, content, filename) {
     case 'remote-task': return parseRemoteTask(content);
     case 'software-tracker': return parseSoftwareTracker(content, filename);
     case 'software-superset': return parseSoftwareSuperset(content);
+    case 'naabu-reachability': return parseNaabuReachability(content, filename);
     default: return { type: 'unknown', rows: [], meta: {} };
   }
+}
+
+function normalizeNaabuRow(item, sourceFile) {
+  const host = String(item.host || item.Host || '').trim();
+  const ip = String(item.ip || item.IP || item.Ip || '').trim();
+  const portRaw = item.port ?? item.Port;
+  const port = portRaw !== undefined && portRaw !== null ? String(portRaw).trim() : '';
+  const reachRaw = item.reachability ?? item.Reachability ?? 'open';
+  return {
+    host: host || ip,
+    ip: ip || host,
+    port,
+    protocol: String(item.protocol || item.Protocol || 'tcp').trim() || 'tcp',
+    timestamp: String(item.timestamp || item.Timestamp || item.time || '').trim(),
+    tls: !!(item.tls ?? item.TLS),
+    service: String(item.service || item.Service || '').trim(),
+    sourceFile: sourceFile || '',
+    reachability: String(reachRaw).trim().toLowerCase() || 'open',
+  };
+}
+
+function parseNaabuReachability(content, filename) {
+  const warnings = [];
+  const rows = [];
+  const sourceFile = filename || '';
+  const trimmed = (content || '').replace(/^\uFEFF/, '').trim();
+
+  if (!trimmed) {
+    return { type: 'naabu-reachability', rows, meta: { count: 0, warnings } };
+  }
+
+  const ingestItem = (item, lineNo) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      if (lineNo != null) warnings.push(`Line ${lineNo}: not a JSON object`);
+      return;
+    }
+    if (!isNaabuReachabilityObject(item)) {
+      if (lineNo != null) warnings.push(`Line ${lineNo}: missing host/ip or port`);
+      return;
+    }
+    rows.push(normalizeNaabuRow(item, sourceFile));
+  };
+
+  try {
+    const data = JSON.parse(trimmed);
+    const items = Array.isArray(data) ? data : [data];
+    items.forEach((item, i) => ingestItem(item, items.length > 1 ? i + 1 : null));
+  } catch {
+    trimmed.split('\n').forEach((raw, idx) => {
+      const line = raw.trim();
+      if (!line) return;
+      try {
+        ingestItem(JSON.parse(line), idx + 1);
+      } catch {
+        warnings.push(`Line ${idx + 1}: invalid JSON`);
+      }
+    });
+  }
+
+  return { type: 'naabu-reachability', rows, meta: { count: rows.length, warnings } };
 }
 
 function parsePreflight(content) {
@@ -673,6 +775,9 @@ function mergeDataStore(existing, incoming) {
     case 'software-superset':
       store.softwareInventory = (store.softwareInventory || []).concat(rows);
       break;
+    case 'naabu-reachability':
+      store.naabuReachability = (store.naabuReachability || []).concat(rows);
+      break;
   }
 
   return store;
@@ -926,6 +1031,19 @@ function buildProtocolRows(store) {
     if (hostMap[t].steps.Ping === 'success' && !row.MAC && !row.Serial) {
       if (!hostMap[t].steps.SNMP) hostMap[t].steps.SNMP = 'failed';
     }
+  }
+
+  // Naabu reachability — merge open ports only; never set identity fields from reachability alone
+  for (const row of (store.naabuReachability || [])) {
+    const t = row.host || row.ip || '';
+    if (!t) continue;
+    if (!hostMap[t]) {
+      hostMap[t] = { Target: t, ports: {}, steps: {} };
+    }
+    const port = String(row.port || '').trim();
+    if (!port) continue;
+    const reach = (row.reachability || 'open').toLowerCase();
+    hostMap[t].ports[port] = reach === 'open' ? 'Open' : reach;
   }
 
   return Object.values(hostMap).sort((a, b) => (a.Target || '').localeCompare(b.Target || ''));
@@ -3484,6 +3602,7 @@ const TYPE_SECTION_LABELS = {
   'workstation-identity': 'Network review',
   'network-preflight': 'Network review',
   'smb-recon': 'Network review',
+  'naabu-reachability': 'Reachability evidence',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
   'software-superset': 'Software tracker',
@@ -3506,6 +3625,7 @@ const TYPE_TO_PANELS = {
   'remote-task':         ['tasks'],
   'network-preflight':   ['network'],
   'smb-recon':           ['network'],
+  'naabu-reachability':  ['network'],
   'software-tracker':    ['software'],
   'software-superset':   ['software'],
 };
@@ -3798,6 +3918,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'printer-probe': '🖨️', 'network-preflight': '📡', 'machine-info': '💻',
     'ram-info': '🧠', 'monitor-info': '🖥️', 'neuron-inventory': '🗂️',
     'smb-recon': '📂', 'status-json': '💚', 'remote-task': '⚡',
+    'naabu-reachability': '🔌',
     'software-tracker': '📦', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
@@ -4596,8 +4717,14 @@ function updateCybernetReview() {
   const preflightRows = store.networkPreflight?.length || 0;
   const identityRows = store.workstationIdentity?.length || 0;
   const targetCount = Math.max(_countUniqueTargets(store.networkPreflight), _countUniqueTargets(store.workstationIdentity));
-  const reachFiles = loadedFiles.filter(f => /naabu/i.test(f.name)).length;
-  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachFiles > 0 || loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity');
+  const reachRows = store.naabuReachability || [];
+  const reachabilityCount = reachRows.length;
+  const openPortsCount = reachRows.filter(r => {
+    const rv = (r.reachability || 'open').toLowerCase();
+    return rv === 'open' || rv === '';
+  }).length;
+  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachabilityCount > 0 ||
+    loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity' || f.type === 'naabu-reachability');
 
   if (!hasEvidence) {
     section.classList.add('hidden');
@@ -4616,7 +4743,8 @@ function updateCybernetReview() {
       <li><strong>Targets in evidence:</strong> ${targetCount || '—'}</li>
       <li><strong>Preflight rows:</strong> ${preflightRows}</li>
       <li><strong>Identity rows:</strong> ${identityRows}</li>
-      <li><strong>Reachability files:</strong> ${reachFiles || 'none loaded'}</li>
+      <li><strong>Open ports observed:</strong> ${reachabilityCount > 0 ? openPortsCount : '—'}</li>
+      <li><strong>Reachability rows:</strong> ${reachabilityCount > 0 ? reachabilityCount : '—'}</li>
     </ul>
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>

--- a/dashboard/js/parsers.js
+++ b/dashboard/js/parsers.js
@@ -2,11 +2,41 @@
 
 import { parseCSV, parseJSON, pingToStep } from './utils.js';
 
+function isNaabuReachabilityObject(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+  const hasHost = !!(obj.host || obj.ip || obj.Host || obj.IP || obj.Ip);
+  const port = obj.port ?? obj.Port;
+  return hasHost && port !== undefined && port !== null && String(port).trim() !== '';
+}
+
+function contentLooksLikeNaabuReachability(content) {
+  if (typeof content !== 'string') return false;
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  const snip = trimmed.slice(0, 800).toLowerCase();
+  if (!snip.includes('port') || (!snip.includes('host') && !snip.includes('ip'))) return false;
+
+  try {
+    const data = JSON.parse(trimmed);
+    const items = Array.isArray(data) ? data : [data];
+    return items.some(isNaabuReachabilityObject);
+  } catch {
+    for (const raw of trimmed.split('\n')) {
+      const line = raw.trim();
+      if (!line) continue;
+      try {
+        if (isNaabuReachabilityObject(JSON.parse(line))) return true;
+      } catch { /* invalid JSONL line */ }
+    }
+  }
+  return false;
+}
+
 /**
  * Detect the log type from filename and/or CSV headers.
  * Returns one of: 'preflight', 'results', 'workstation-identity',
  *   'printer-probe', 'network-preflight', 'machine-info', 'ram-info',
- *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon', 'unknown'
+ *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon', 'naabu-reachability', 'unknown'
  */
 export function detectFileType(filename, content) {
   const fn = filename.toLowerCase();
@@ -15,6 +45,11 @@ export function detectFileType(filename, content) {
   if (fn.endsWith('.yaml') || fn.endsWith('.yml')) {
     if (fn.includes('sources')) return 'software-tracker';
     return 'software-tracker'; // treat all YAML drops as tracker
+  }
+
+  // Naabu reachability JSON / JSONL — filename hint
+  if ((fn.endsWith('.json') || fn.endsWith('.jsonl')) && fn.includes('naabu')) {
+    return 'naabu-reachability';
   }
 
   // JSON detection — check filename hints first, then probe content
@@ -32,7 +67,13 @@ export function detectFileType(filename, content) {
       if (snip.includes('"taskname"') || snip.includes('"outcome"') ||
           snip.includes('"taskid"') || snip.includes('"events"')) return 'remote-task';
     }
+    if (contentLooksLikeNaabuReachability(content)) return 'naabu-reachability';
     return 'status-json'; // fallback: attempt parse as status snapshot
+  }
+
+  if (fn.endsWith('.jsonl')) {
+    if (contentLooksLikeNaabuReachability(content)) return 'naabu-reachability';
+    return 'unknown';
   }
 
   // XLSX detection
@@ -96,8 +137,69 @@ export function parseFileContent(type, content, filename) {
     case 'remote-task': return parseRemoteTask(content);
     case 'software-tracker': return parseSoftwareTracker(content, filename);
     case 'software-superset': return parseSoftwareSuperset(content);
+    case 'naabu-reachability': return parseNaabuReachability(content, filename);
     default: return { type: 'unknown', rows: [], meta: {} };
   }
+}
+
+function normalizeNaabuRow(item, sourceFile) {
+  const host = String(item.host || item.Host || '').trim();
+  const ip = String(item.ip || item.IP || item.Ip || '').trim();
+  const portRaw = item.port ?? item.Port;
+  const port = portRaw !== undefined && portRaw !== null ? String(portRaw).trim() : '';
+  const reachRaw = item.reachability ?? item.Reachability ?? 'open';
+  return {
+    host: host || ip,
+    ip: ip || host,
+    port,
+    protocol: String(item.protocol || item.Protocol || 'tcp').trim() || 'tcp',
+    timestamp: String(item.timestamp || item.Timestamp || item.time || '').trim(),
+    tls: !!(item.tls ?? item.TLS),
+    service: String(item.service || item.Service || '').trim(),
+    sourceFile: sourceFile || '',
+    reachability: String(reachRaw).trim().toLowerCase() || 'open',
+  };
+}
+
+function parseNaabuReachability(content, filename) {
+  const warnings = [];
+  const rows = [];
+  const sourceFile = filename || '';
+  const trimmed = (content || '').replace(/^\uFEFF/, '').trim();
+
+  if (!trimmed) {
+    return { type: 'naabu-reachability', rows, meta: { count: 0, warnings } };
+  }
+
+  const ingestItem = (item, lineNo) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      if (lineNo != null) warnings.push(`Line ${lineNo}: not a JSON object`);
+      return;
+    }
+    if (!isNaabuReachabilityObject(item)) {
+      if (lineNo != null) warnings.push(`Line ${lineNo}: missing host/ip or port`);
+      return;
+    }
+    rows.push(normalizeNaabuRow(item, sourceFile));
+  };
+
+  try {
+    const data = JSON.parse(trimmed);
+    const items = Array.isArray(data) ? data : [data];
+    items.forEach((item, i) => ingestItem(item, items.length > 1 ? i + 1 : null));
+  } catch {
+    trimmed.split('\n').forEach((raw, idx) => {
+      const line = raw.trim();
+      if (!line) return;
+      try {
+        ingestItem(JSON.parse(line), idx + 1);
+      } catch {
+        warnings.push(`Line ${idx + 1}: invalid JSON`);
+      }
+    });
+  }
+
+  return { type: 'naabu-reachability', rows, meta: { count: rows.length, warnings } };
 }
 
 function parsePreflight(content) {
@@ -446,6 +548,9 @@ export function mergeDataStore(existing, incoming) {
     case 'software-superset':
       store.softwareInventory = (store.softwareInventory || []).concat(rows);
       break;
+    case 'naabu-reachability':
+      store.naabuReachability = (store.naabuReachability || []).concat(rows);
+      break;
   }
 
   return store;
@@ -699,6 +804,19 @@ export function buildProtocolRows(store) {
     if (hostMap[t].steps.Ping === 'success' && !row.MAC && !row.Serial) {
       if (!hostMap[t].steps.SNMP) hostMap[t].steps.SNMP = 'failed';
     }
+  }
+
+  // Naabu reachability — merge open ports only; never set identity fields from reachability alone
+  for (const row of (store.naabuReachability || [])) {
+    const t = row.host || row.ip || '';
+    if (!t) continue;
+    if (!hostMap[t]) {
+      hostMap[t] = { Target: t, ports: {}, steps: {} };
+    }
+    const port = String(row.port || '').trim();
+    if (!port) continue;
+    const reach = (row.reachability || 'open').toLowerCase();
+    hostMap[t].ports[port] = reach === 'open' ? 'Open' : reach;
   }
 
   return Object.values(hostMap).sort((a, b) => (a.Target || '').localeCompare(b.Target || ''));

--- a/dashboard/samples/cybernet_naabu.invalid.sample.jsonl
+++ b/dashboard/samples/cybernet_naabu.invalid.sample.jsonl
@@ -1,0 +1,2 @@
+{"host":"10.42.1.10","ip":"10.42.1.10","port":443,"protocol":"tcp","reachability":"open"}
+{not valid json garbage line}

--- a/dashboard/samples/cybernet_naabu.sample.json
+++ b/dashboard/samples/cybernet_naabu.sample.json
@@ -1,0 +1,5 @@
+[
+  {"host":"10.42.1.10","ip":"10.42.1.10","port":443,"protocol":"tcp","timestamp":"2026-06-24T10:00:00Z","tls":true,"service":"","reachability":"open"},
+  {"host":"10.42.1.11","ip":"10.42.1.11","port":445,"protocol":"tcp","timestamp":"2026-06-24T10:00:01Z","tls":false,"service":"","reachability":"open"},
+  {"host":"10.42.1.12","ip":"10.42.1.12","port":5985,"protocol":"tcp","timestamp":"2026-06-24T10:00:02Z","reachability":"open"}
+]

--- a/dashboard/samples/cybernet_naabu.sample.jsonl
+++ b/dashboard/samples/cybernet_naabu.sample.jsonl
@@ -1,0 +1,3 @@
+{"host":"10.42.1.10","ip":"10.42.1.10","port":443,"protocol":"tcp","timestamp":"2026-06-24T10:00:00Z","tls":true,"service":"","reachability":"open"}
+{"host":"10.42.1.11","ip":"10.42.1.11","port":445,"protocol":"tcp","timestamp":"2026-06-24T10:00:01Z","tls":false,"service":"","reachability":"open"}
+{"host":"10.42.1.12","ip":"10.42.1.12","port":5985,"protocol":"tcp","timestamp":"2026-06-24T10:00:02Z","reachability":"open"}

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -30,6 +30,14 @@ const cases = [
   { file: 'RunControl_events.json',                expectedType: 'remote-task',         minRows: 3 },
 ];
 
+// ── Naabu reachability parser cases (synthetic samples only) ────────────────
+
+const naabuCases = [
+  { file: 'cybernet_naabu.sample.jsonl',          expectedType: 'naabu-reachability', minRows: 3 },
+  { file: 'cybernet_naabu.sample.json',           expectedType: 'naabu-reachability', minRows: 3 },
+  { file: 'cybernet_naabu.invalid.sample.jsonl',  expectedType: 'naabu-reachability', minRows: 1, minWarnings: 1 },
+];
+
 let passed = 0;
 let failed = 0;
 
@@ -59,6 +67,35 @@ for (const { file, expectedType, minRows } of cases) {
   }
 
   console.log(`PASS [${file}]: type="${detected}"${parsed.rows ? ', rows=' + parsed.rows.length : ''}`);
+  passed++;
+}
+
+for (const { file, expectedType, minRows, minWarnings } of naabuCases) {
+  const content = readFileSync(join(samplesDir, file), 'utf8');
+  const detected = detectFileType(file, content);
+
+  if (detected !== expectedType) {
+    console.error(`FAIL [${file}]: expected type="${expectedType}" got="${detected}"`);
+    failed++;
+    continue;
+  }
+
+  const parsed = parseFileContent(detected, content, file);
+
+  if (minRows !== null && (parsed.rows?.length ?? 0) < minRows) {
+    console.error(`FAIL [${file}]: expected >= ${minRows} rows, got ${parsed.rows?.length ?? 0}`);
+    failed++;
+    continue;
+  }
+
+  if (minWarnings != null && (parsed.meta?.warnings?.length ?? 0) < minWarnings) {
+    console.error(`FAIL [${file}]: expected >= ${minWarnings} warnings, got ${parsed.meta?.warnings?.length ?? 0}`);
+    failed++;
+    continue;
+  }
+
+  const warnNote = parsed.meta?.warnings?.length ? `, warnings=${parsed.meta.warnings.length}` : '';
+  console.log(`PASS [${file}]: type="${detected}"${parsed.rows ? ', rows=' + parsed.rows.length : ''}${warnNote}`);
   passed++;
 }
 
@@ -127,6 +164,16 @@ const contractChecks = [
   ['not a dashboard import yet', 'no false manifest import claim'],
 ];
 
+// ── Naabu reachability Cybernet review contracts (app.js) ───────────────────
+
+const naabuContractChecks = [
+  ['naabu-reachability', 'naabu reachability file type'],
+  ['Reachability evidence', 'reachability section label'],
+  ['Open ports observed:', 'cybernet review open ports metric'],
+  ['Reachability rows:', 'cybernet review reachability rows metric'],
+  ['store.naabuReachability', 'parsed naabu store wiring'],
+];
+
 let shellPassed = 0;
 let shellFailed = 0;
 
@@ -147,6 +194,16 @@ for (const [needle, label] of contractChecks) {
     shellFailed++;
   } else {
     console.log(`PASS [wizard-contract:${label}]`);
+    shellPassed++;
+  }
+}
+
+for (const [needle, label] of naabuContractChecks) {
+  if (!appJs.includes(needle)) {
+    console.error(`FAIL [naabu-contract:${label}]: missing "${needle}"`);
+    shellFailed++;
+  } else {
+    console.log(`PASS [naabu-contract:${label}]`);
     shellPassed++;
   }
 }


### PR DESCRIPTION
## Summary
- Add naabu-reachability parser for JSON/JSONL evidence (host/ip + port rows, invalid-line warnings)
- Wire parsed reachability into network panel (buildProtocolRows) and Cybernet review summary (open ports + row counts)
- Add synthetic dashboard samples and smoke-test parser/contract coverage
- No live scan output committed; preserves low-noise survey doctrine (reachability evidence only, not device confirmation)

## Test plan
- [x] node --check dashboard/js/parsers.js app.js bundle.js
- [x] node dashboard/build-bundle.js
- [x] node dashboard/smoke-test.js (parser + naabu contract checks)
- [x] git diff --check
- [ ] Manual: drop cybernet_naabu.sample.jsonl in dashboard Load Evidence and confirm Network panel + Cybernet review stats

Made with [Cursor](https://cursor.com)