### PR TITLE
fix(dashboard): harden Cybernet target manifest support

### DIFF
--- a/dashboard/css/style.css
+++ b/dashboard/css/style.css
@@ -1087,6 +1087,29 @@ textarea.paste-area:focus { border-color: var(--accent); }
 }
 .command-panel-note { margin-top: 6px; color: var(--warning); font-size: 11px; }
 .cybernet-tutorial-nav { margin-top: 10px; justify-content: flex-end; }
+.cybernet-manifest-summary {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(79, 142, 247, 0.08);
+}
+.cybernet-manifest-stats {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.cybernet-ad-population-summary {
+  flex-shrink: 0;
+  margin: 12px 18px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg2);
+}
+.cybernet-ad-population-note { color: var(--text-dim); font-size: 12px; margin: 0 0 8px; }
+.cybernet-ad-population-stats { font-size: 12px; color: var(--text-dim); line-height: 1.5; }
 
 @media (max-width: 900px) {
   .cybernet-tutorial-head, .cybernet-step-card { flex-direction: column; }
@@ -1173,7 +1196,6 @@ textarea.paste-area:focus { border-color: var(--accent); }
 
 .evidence-loader,
 .cybernet-review,
-.cybernet-ad-population-summary,
 .advanced-section {
   flex-shrink: 0;
   margin: 12px 18px;
@@ -1185,7 +1207,6 @@ textarea.paste-area:focus { border-color: var(--accent); }
 
 .evidence-loader-head h3,
 .cybernet-review h3,
-.cybernet-ad-population-summary h3,
 .advanced-section-head h3 { font-size: 14px; margin-bottom: 4px; }
 .evidence-loader-head p,
 .advanced-section-head p { color: var(--text-dim); font-size: 12px; margin-bottom: 10px; }
@@ -1213,9 +1234,6 @@ textarea.paste-area:focus { border-color: var(--accent); }
 .cybernet-review-stats li { font-size: 12px; margin-bottom: 4px; color: var(--text-dim); }
 .cybernet-review-warn { color: var(--warning); font-size: 12px; margin: 8px 0; }
 .cybernet-review-next { font-size: 12px; color: var(--text-dim); }
-
-.cybernet-ad-population-note { color: var(--text-dim); font-size: 12px; margin: 0 0 8px; }
-.cybernet-ad-population-stats { font-size: 12px; color: var(--text-dim); line-height: 1.5; }
 
 .mode-toggle-advanced { margin-bottom: 10px; }
 .advanced-panels-label {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -64,6 +64,10 @@
     <div class="cybernet-wizard-footer hidden" id="cybernet-wizard-footer">
       <button class="btn-secondary" id="cybernet-load-evidence-end" type="button">Load resulting evidence</button>
     </div>
+    <div id="cybernet-manifest-summary" class="cybernet-manifest-summary cybernet-manifest-summary-empty" role="status" aria-live="polite" aria-atomic="true">
+      <div class="eyebrow">Cybernet Target Manifest</div>
+      <div id="cybernet-manifest-stats" class="cybernet-manifest-stats"></div>
+    </div>
   </section>
 
   <section id="evidence-loader" class="evidence-loader hidden" aria-label="Load evidence">
@@ -185,10 +189,25 @@
 <style>
   .hidden { display: none !important; }
   code { font-family: var(--mono); font-size: 11px; background: var(--bg3); padding: 1px 4px; border-radius: 3px; }
+  .cybernet-manifest-summary-empty { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; margin: -1px; padding: 0; border: 0; }
 </style>
 
 <script src="js/sample-data.js"></script>
 <script src="js/bundle.js"></script>
+<script>
+(function(){
+  const root = document.getElementById('cybernet-manifest-summary');
+  const stats = document.getElementById('cybernet-manifest-stats');
+  if (!root || !stats) return;
+  const updateState = () => {
+    if (root.style.display === 'none') root.style.display = '';
+    root.classList.toggle('cybernet-manifest-summary-empty', !stats.textContent.trim());
+  };
+  updateState();
+  new MutationObserver(updateState).observe(stats, { childList: true, subtree: true, characterData: true });
+  new MutationObserver(updateState).observe(root, { attributes: true, attributeFilter: ['style'] });
+})();
+</script>
 <script src="js/cybernet-os-preflight.js"></script>
 </body>
 </html>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -31,6 +31,7 @@ const TYPE_SECTION_LABELS = {
   'network-preflight': 'Network review',
   'smb-recon': 'Network review',
   'naabu-reachability': 'Reachability evidence',
+  'cybernet-target-manifest': 'Target manifest',
   'ad-registered-population': 'AD registered population',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
@@ -55,9 +56,10 @@ const TYPE_TO_PANELS = {
   'network-preflight':   ['network'],
   'smb-recon':           ['network'],
   'naabu-reachability':  ['network'],
+  'cybernet-target-manifest': ['inventory'],
+  'ad-registered-population': ['inventory', 'network'],
   'software-tracker':    ['software'],
   'software-superset':   ['software'],
-  'ad-registered-population': ['inventory', 'network'],
 };
 
 // ── Bootstrap ──────────────────────────────────────────────────────────────
@@ -350,7 +352,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'smb-recon': '📂', 'status-json': '💚', 'remote-task': '⚡',
     'naabu-reachability': '🔌',
     'ad-registered-population': '🏢',
-    'software-tracker': '📦', 'unknown': '❓'
+    'software-tracker': '📦', 'cybernet-target-manifest': '🎯', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
 
@@ -579,12 +581,12 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Load evidence and review',
     railLabel: 'Review package',
-    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. AD registered population CSVs show candidate targets — not serial or reachability proof.',
-    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/ad_reconcile/<run>/ad_registered_normalized.csv',
+    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Normalized target manifests (cybernet_targets.csv) are imported separately from network or identity evidence.',
+    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/cybernet_*_targets.csv (manifest, not evidence)',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
-      'Treat AD rows as registered computer accounts, not confirmed Cybernet identity.'
+      'Treat manifest rows as target lists, not reachability or identity proof.'
     ],
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
@@ -1113,6 +1115,7 @@ function refreshAllPanels() {
   try { renderNetworkPanel(store); } catch(e) { console.warn('Network panel error:', e); }
   try { renderSoftwarePanel(store); } catch(e) { console.warn('Software panel error:', e); }
   updateCybernetReview();
+  updateCybernetManifestSummary();
   updateCybernetAdPopulationSummary();
 }
 
@@ -1181,6 +1184,35 @@ function updateCybernetReview() {
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
   `;
+}
+
+function updateCybernetManifestSummary() {
+  const root = document.getElementById('cybernet-manifest-summary');
+  const stats = document.getElementById('cybernet-manifest-stats');
+  if (!root || !stats) return;
+
+  const rows = store.cybernetTargetManifest || [];
+  if (!rows.length) {
+    root.style.display = 'none';
+    stats.textContent = '';
+    return;
+  }
+
+  const withHostname = rows.filter(r => r.hostname || r.dnsHostName).length;
+  const withSerial = rows.filter(r => r.serial).length;
+  const withMac = rows.filter(r => r.mac).length;
+  const missingDnsHost = rows.filter(r => !r.hostname && !r.dnsHostName).length;
+  const missingSerial = rows.filter(r => !r.serial).length;
+
+  stats.innerHTML = [
+    `<span><strong>${rows.length}</strong> manifest rows</span>`,
+    `<span><strong>${withHostname}</strong> with hostname/DNS</span>`,
+    `<span><strong>${withSerial}</strong> with serial</span>`,
+    `<span><strong>${withMac}</strong> with MAC</span>`,
+    `<span><strong>${missingDnsHost}</strong> missing hostname/DNS</span>`,
+    `<span><strong>${missingSerial}</strong> missing serial</span>`,
+  ].join(' · ');
+  root.style.display = '';
 }
 
 function updateCybernetAdPopulationSummary() {

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -263,9 +263,62 @@ function contentLooksLikeNaabuReachability(content) {
  * Detect the log type from filename and/or CSV headers.
  * Returns one of: 'preflight', 'results', 'workstation-identity',
  *   'printer-probe', 'network-preflight', 'machine-info', 'ram-info',
- *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon',
- *   'ad-registered-population', 'naabu-reachability', 'unknown'
+ *   'monitor-info', 'neuron-inventory', 'cybernet-target-manifest',
+ *   'ad-registered-population', 'status-json', 'smb-recon', 'naabu-reachability', 'unknown'
  */
+function csvBasename(filename) {
+  const parts = filename.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1].toLowerCase();
+}
+
+const CYBERNET_MANIFEST_FILENAMES = new Set([
+  'cybernet_targets.csv',
+  'cybernet-targets.csv',
+  'targets_resolved.csv',
+  'cybernet_targets_resolved.csv',
+]);
+
+function isCybernetManifestHeader(firstLine) {
+  const h = firstLine.toLowerCase();
+  const cybernetCols = [
+    'hostname', 'dnshostname', 'ipaddress', 'serial', 'serialnumber',
+    'site', 'location', 'neuron', 'workstation', 'mac',
+  ];
+  const hasCybernetCol = cybernetCols.some(c => h.includes(c));
+  if (!hasCybernetCol) return false;
+  if (h.includes('pingstatus') && (h.includes('port') || h.includes('mac'))) return false;
+  if (h.includes('transportused') && h.includes('identitystatus')) return false;
+  if (h.includes('targethost') && h.includes('matchexpected')) return false;
+  if (h.includes('driver') && h.includes('port') && h.includes('status')) return false;
+  if (h.includes('identifiertype') && h.includes('devicetype')) return true;
+  return hasCybernetCol;
+}
+
+function normalizeCybernetHost(value) {
+  const v = String(value || '').trim();
+  if (!v) return '';
+  return v.split('.')[0].toUpperCase();
+}
+
+function pickManifestField(row, names) {
+  const lowered = {};
+  for (const [k, v] of Object.entries(row)) {
+    const key = String(k).replace(/^\uFEFF/, '').toLowerCase();
+    lowered[key] = v;
+  }
+  for (const name of names) {
+    const val = lowered[name.toLowerCase()];
+    if (val != null && String(val).trim()) return String(val).trim();
+  }
+  return '';
+}
+
+function firstIpAddress(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  return raw.split(/[;,|\s]+/).map(s => s.trim()).find(Boolean) || '';
+}
+
 function detectFileType(filename, content) {
   const fn = filename.toLowerCase();
 
@@ -316,6 +369,7 @@ function detectFileType(filename, content) {
   if (fn.includes('machineinfo') || fn.includes('machine_info') || fn.includes('machine-info')) return 'machine-info';
   if (fn.includes('raminfo') || fn.includes('ram_info') || fn.includes('ram-info')) return 'ram-info';
   if (fn.includes('monitorinfo') || fn.includes('monitor_info') || fn.includes('monitor-info')) return 'monitor-info';
+  if (CYBERNET_MANIFEST_FILENAMES.has(csvBasename(filename))) return 'cybernet-target-manifest';
   if (fn.includes('neuron')) return 'neuron-inventory';
   if (fn.includes('smb')) return 'smb-recon';
   if (fn.includes('software_superset') || fn.includes('softwaresuperset') || fn.includes('software-superset')) return 'software-superset';
@@ -328,6 +382,7 @@ function detectFileType(filename, content) {
       fn.includes('ad_missing_dns') || fn.includes('ad_duplicates') || fn.includes('evidence_only')) {
     return 'ad-registered-population';
   }
+  if (fn.includes('wmi_identity') || fn.includes('wmi-identity')) return 'workstation-identity';
 
   // Detect by headers if content is provided
   if (typeof content === 'string' && content.includes(',')) {
@@ -341,8 +396,10 @@ function detectFileType(filename, content) {
     if (firstLine.includes('capacitygb') || firstLine.includes('memorytype')) return 'ram-info';
     if (firstLine.includes('displaynumber') || firstLine.includes('isprimary')) return 'monitor-info';
     if (firstLine.includes('targethost') && firstLine.includes('matchexpected')) return 'neuron-inventory';
+    if (isCybernetManifestHeader(firstLine)) return 'cybernet-target-manifest';
     if (firstLine.includes('share') && firstLine.includes('liststatus')) return 'smb-recon';
     if (firstLine.includes('taskname') || firstLine.includes('taskid') || firstLine.includes('outcome')) return 'remote-task';
+    if (firstLine.includes('publisher') && firstLine.includes('host') && firstLine.includes('name')) return 'software-superset';
     if (firstLine.includes('populationauthority') && firstLine.includes('reconcilebucket')) return 'ad-registered-population';
     if (firstLine.includes('populationauthority') && firstLine.includes('adstatus')) return 'ad-registered-population';
     if (firstLine.includes('reconcilebucket') && firstLine.includes('hostname')) return 'ad-registered-population';
@@ -366,6 +423,7 @@ function parseFileContent(type, content, filename) {
     case 'ram-info': return parseRamInfo(content);
     case 'monitor-info': return parseMonitorInfo(content);
     case 'neuron-inventory': return parseNeuronInventory(content);
+    case 'cybernet-target-manifest': return parseCybernetTargetManifest(content);
     case 'smb-recon': return parseSmbRecon(content);
     case 'status-json': return parseStatusJson(content);
     case 'remote-task': return parseRemoteTask(content);
@@ -435,6 +493,37 @@ function parseNaabuReachability(content, filename) {
   }
 
   return { type: 'naabu-reachability', rows, meta: { count: rows.length, warnings } };
+}
+
+/**
+ * Parse AD registered population reconcile CSVs.
+ */
+function parseAdRegisteredPopulation(content, filename) {
+  const rows = parseCSV(content);
+  const normalized = rows.map(r => ({
+    HostName:        r.HostName        || r.hostname        || r.ComputerName || '',
+    DNSHostName:     r.DNSHostName     || r.dnshostname     || r.FQDN         || '',
+    ADStatus:        r.ADStatus        || r.adstatus        || '',
+    Enabled:         r.Enabled         || r.enabled         || '',
+    OperatingSystem: r.OperatingSystem || r.operatingsystem || r.OS           || '',
+    LastLogonDate:   r.LastLogonDate   || r.lastlogondate   || '',
+    Description:     r.Description     || r.description     || '',
+    ReconcileBucket: r.ReconcileBucket || r.reconcilebucket || r.Bucket       || '',
+    PopulationAuthority: r.PopulationAuthority || r.populationauthority || 'ad_registered',
+    MatchStatus:     r.MatchStatus     || r.matchstatus     || '',
+    EvidenceSerial:  r.EvidenceSerial  || r.evidenceserial  || r.Serial       || '',
+    EvidenceSource:  r.EvidenceSource  || r.evidencesource  || r.Source       || '',
+    Reachability:    r.Reachability    || r.reachability    || '',
+    ProbeStatus:     r.ProbeStatus     || r.probestatus     || '',
+    Reason:          r.Reason          || r.reason          || '',
+    _sourceFile:     filename || '',
+  })).filter(r => r.HostName);
+  const buckets = {};
+  for (const row of normalized) {
+    const b = row.ReconcileBucket || 'registered';
+    buckets[b] = (buckets[b] || 0) + 1;
+  }
+  return { type: 'ad-registered-population', rows: normalized, meta: { count: normalized.length, buckets } };
 }
 
 function parsePreflight(content) {
@@ -513,6 +602,68 @@ function parseNeuronInventory(content) {
   return { type: 'neuron-inventory', rows, meta: { count: rows.length } };
 }
 
+/**
+ * Parse Cybernet target manifest CSV (sas-survey-targets output or resolved manifests).
+ * Distinct from network-preflight, workstation-identity, and AD population exports.
+ */
+function parseCybernetTargetManifest(content) {
+  const rawRows = parseCSV(content);
+  const rows = rawRows.map(row => {
+    const identifierType = pickManifestField(row, ['IdentifierType', 'Identifier Type']);
+    const identifier = pickManifestField(row, ['Identifier', 'Target', 'KnownIdentifier']);
+    let hostname = pickManifestField(row, [
+      'HostName', 'Hostname', 'Host', 'ComputerName', 'Computer', 'Name',
+    ]);
+    if (!hostname && identifierType.toLowerCase() === 'hostname') hostname = identifier;
+
+    const dnsHostName = pickManifestField(row, ['DNSHostName', 'DNS Host Name', 'FQDN']);
+    const ipAddress = firstIpAddress(pickManifestField(row, [
+      'IPAddress', 'IP Address', 'IPAddresses', 'IP', 'ResolvedAddress',
+    ]));
+    const serial = pickManifestField(row, [
+      'Serial', 'SerialNumber', 'Serial Number', 'ServiceTag', 'AssetSerial',
+    ]);
+    const site = pickManifestField(row, ['Site']);
+    const location = pickManifestField(row, ['Location', 'Room']);
+    const neuron = pickManifestField(row, [
+      'Neuron', 'Neuron Hostname', 'NeuronHostName', 'Neuron Host',
+    ]);
+    const workstation = pickManifestField(row, ['Workstation', 'Workstation Hostname']);
+    const mac = pickManifestField(row, [
+      'MAC', 'MACAddress', 'MacAddress', 'Mac', 'EthernetMAC', 'WifiMAC',
+    ]);
+    const normalizedHost = normalizeCybernetHost(hostname || dnsHostName);
+
+    return {
+      type: 'cybernet-target-manifest',
+      sourceType: 'cybernet-target-manifest',
+      hostname,
+      normalizedHost,
+      dnsHostName,
+      ipAddress,
+      serial,
+      site,
+      location,
+      neuron,
+      workstation,
+      mac,
+    };
+  }).filter(r =>
+    r.hostname || r.dnsHostName || r.ipAddress || r.serial || r.mac || r.neuron || r.workstation
+  );
+
+  return {
+    type: 'cybernet-target-manifest',
+    rows,
+    meta: {
+      count: rows.length,
+      withSerial: rows.filter(r => r.serial).length,
+      withIp: rows.filter(r => r.ipAddress).length,
+      missingDnsHost: rows.filter(r => !r.hostname && !r.dnsHostName).length,
+    },
+  };
+}
+
 function parseSmbRecon(content) {
   const rows = parseCSV(content);
   return { type: 'smb-recon', rows, meta: { count: rows.length } };
@@ -565,38 +716,6 @@ function parseRemoteTask(content) {
   }
 
   return { type: 'remote-task', rows: [], meta: { count: 0 } };
-}
-
-/**
- * Parse AD registered population reconcile CSVs.
- * Expected columns include HostName, PopulationAuthority, ReconcileBucket / Bucket.
- */
-function parseAdRegisteredPopulation(content, filename) {
-  const rows = parseCSV(content);
-  const normalized = rows.map(r => ({
-    HostName:        r.HostName        || r.hostname        || r.ComputerName || '',
-    DNSHostName:     r.DNSHostName     || r.dnshostname     || r.FQDN         || '',
-    ADStatus:        r.ADStatus        || r.adstatus        || '',
-    Enabled:         r.Enabled         || r.enabled         || '',
-    OperatingSystem: r.OperatingSystem || r.operatingsystem || r.OS           || '',
-    LastLogonDate:   r.LastLogonDate   || r.lastlogondate   || '',
-    Description:     r.Description     || r.description     || '',
-    ReconcileBucket: r.ReconcileBucket || r.reconcilebucket || r.Bucket       || '',
-    PopulationAuthority: r.PopulationAuthority || r.populationauthority || 'ad_registered',
-    MatchStatus:     r.MatchStatus     || r.matchstatus     || '',
-    EvidenceSerial:  r.EvidenceSerial  || r.evidenceserial  || r.Serial       || '',
-    EvidenceSource:  r.EvidenceSource  || r.evidencesource  || r.Source       || '',
-    Reachability:    r.Reachability    || r.reachability    || '',
-    ProbeStatus:     r.ProbeStatus     || r.probestatus     || '',
-    Reason:          r.Reason          || r.reason          || '',
-    _sourceFile:     filename || '',
-  })).filter(r => r.HostName);
-  const buckets = {};
-  for (const row of normalized) {
-    const b = row.ReconcileBucket || 'registered';
-    buckets[b] = (buckets[b] || 0) + 1;
-  }
-  return { type: 'ad-registered-population', rows: normalized, meta: { count: normalized.length, buckets } };
 }
 
 /**
@@ -789,6 +908,9 @@ function mergeDataStore(existing, incoming) {
       break;
     case 'neuron-inventory':
       store.neuronInventory = (store.neuronInventory || []).concat(rows);
+      break;
+    case 'cybernet-target-manifest':
+      store.cybernetTargetManifest = (store.cybernetTargetManifest || []).concat(rows);
       break;
     case 'smb-recon':
       store.smbRecon = (store.smbRecon || []).concat(rows);
@@ -1101,7 +1223,6 @@ function buildProtocolRows(store) {
     hostMap[t].ports[port] = reach === 'open' ? 'Open' : reach;
   }
 
-  // AD registered population — reconcile buckets; do not treat AD as serial or reachability proof
   for (const row of (store.adRegisteredPopulation || [])) {
     const t = row.HostName || '';
     if (!t) continue;
@@ -3680,6 +3801,7 @@ const TYPE_SECTION_LABELS = {
   'network-preflight': 'Network review',
   'smb-recon': 'Network review',
   'naabu-reachability': 'Reachability evidence',
+  'cybernet-target-manifest': 'Target manifest',
   'ad-registered-population': 'AD registered population',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
@@ -3704,9 +3826,10 @@ const TYPE_TO_PANELS = {
   'network-preflight':   ['network'],
   'smb-recon':           ['network'],
   'naabu-reachability':  ['network'],
+  'cybernet-target-manifest': ['inventory'],
+  'ad-registered-population': ['inventory', 'network'],
   'software-tracker':    ['software'],
   'software-superset':   ['software'],
-  'ad-registered-population': ['inventory', 'network'],
 };
 
 // ── Bootstrap ──────────────────────────────────────────────────────────────
@@ -3999,7 +4122,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'smb-recon': '📂', 'status-json': '💚', 'remote-task': '⚡',
     'naabu-reachability': '🔌',
     'ad-registered-population': '🏢',
-    'software-tracker': '📦', 'unknown': '❓'
+    'software-tracker': '📦', 'cybernet-target-manifest': '🎯', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
 
@@ -4228,12 +4351,12 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Load evidence and review',
     railLabel: 'Review package',
-    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. AD registered population CSVs show candidate targets — not serial or reachability proof.',
-    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/ad_reconcile/<run>/ad_registered_normalized.csv',
+    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Normalized target manifests (cybernet_targets.csv) are imported separately from network or identity evidence.',
+    command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/cybernet_*_targets.csv (manifest, not evidence)',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
-      'Treat AD rows as registered computer accounts, not confirmed Cybernet identity.'
+      'Treat manifest rows as target lists, not reachability or identity proof.'
     ],
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
@@ -4762,6 +4885,7 @@ function refreshAllPanels() {
   try { renderNetworkPanel(store); } catch(e) { console.warn('Network panel error:', e); }
   try { renderSoftwarePanel(store); } catch(e) { console.warn('Software panel error:', e); }
   updateCybernetReview();
+  updateCybernetManifestSummary();
   updateCybernetAdPopulationSummary();
 }
 
@@ -4830,6 +4954,35 @@ function updateCybernetReview() {
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
   `;
+}
+
+function updateCybernetManifestSummary() {
+  const root = document.getElementById('cybernet-manifest-summary');
+  const stats = document.getElementById('cybernet-manifest-stats');
+  if (!root || !stats) return;
+
+  const rows = store.cybernetTargetManifest || [];
+  if (!rows.length) {
+    root.style.display = 'none';
+    stats.textContent = '';
+    return;
+  }
+
+  const withHostname = rows.filter(r => r.hostname || r.dnsHostName).length;
+  const withSerial = rows.filter(r => r.serial).length;
+  const withMac = rows.filter(r => r.mac).length;
+  const missingDnsHost = rows.filter(r => !r.hostname && !r.dnsHostName).length;
+  const missingSerial = rows.filter(r => !r.serial).length;
+
+  stats.innerHTML = [
+    `<span><strong>${rows.length}</strong> manifest rows</span>`,
+    `<span><strong>${withHostname}</strong> with hostname/DNS</span>`,
+    `<span><strong>${withSerial}</strong> with serial</span>`,
+    `<span><strong>${withMac}</strong> with MAC</span>`,
+    `<span><strong>${missingDnsHost}</strong> missing hostname/DNS</span>`,
+    `<span><strong>${missingSerial}</strong> missing serial</span>`,
+  ].join(' · ');
+  root.style.display = '';
 }
 
 function updateCybernetAdPopulationSummary() {

--- a/dashboard/js/parsers.js
+++ b/dashboard/js/parsers.js
@@ -36,9 +36,62 @@ function contentLooksLikeNaabuReachability(content) {
  * Detect the log type from filename and/or CSV headers.
  * Returns one of: 'preflight', 'results', 'workstation-identity',
  *   'printer-probe', 'network-preflight', 'machine-info', 'ram-info',
- *   'monitor-info', 'neuron-inventory', 'status-json', 'smb-recon',
- *   'ad-registered-population', 'naabu-reachability', 'unknown'
+ *   'monitor-info', 'neuron-inventory', 'cybernet-target-manifest',
+ *   'ad-registered-population', 'status-json', 'smb-recon', 'naabu-reachability', 'unknown'
  */
+function csvBasename(filename) {
+  const parts = filename.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1].toLowerCase();
+}
+
+const CYBERNET_MANIFEST_FILENAMES = new Set([
+  'cybernet_targets.csv',
+  'cybernet-targets.csv',
+  'targets_resolved.csv',
+  'cybernet_targets_resolved.csv',
+]);
+
+function isCybernetManifestHeader(firstLine) {
+  const h = firstLine.toLowerCase();
+  const cybernetCols = [
+    'hostname', 'dnshostname', 'ipaddress', 'serial', 'serialnumber',
+    'site', 'location', 'neuron', 'workstation', 'mac',
+  ];
+  const hasCybernetCol = cybernetCols.some(c => h.includes(c));
+  if (!hasCybernetCol) return false;
+  if (h.includes('pingstatus') && (h.includes('port') || h.includes('mac'))) return false;
+  if (h.includes('transportused') && h.includes('identitystatus')) return false;
+  if (h.includes('targethost') && h.includes('matchexpected')) return false;
+  if (h.includes('driver') && h.includes('port') && h.includes('status')) return false;
+  if (h.includes('identifiertype') && h.includes('devicetype')) return true;
+  return hasCybernetCol;
+}
+
+function normalizeCybernetHost(value) {
+  const v = String(value || '').trim();
+  if (!v) return '';
+  return v.split('.')[0].toUpperCase();
+}
+
+function pickManifestField(row, names) {
+  const lowered = {};
+  for (const [k, v] of Object.entries(row)) {
+    const key = String(k).replace(/^\uFEFF/, '').toLowerCase();
+    lowered[key] = v;
+  }
+  for (const name of names) {
+    const val = lowered[name.toLowerCase()];
+    if (val != null && String(val).trim()) return String(val).trim();
+  }
+  return '';
+}
+
+function firstIpAddress(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  return raw.split(/[;,|\s]+/).map(s => s.trim()).find(Boolean) || '';
+}
+
 export function detectFileType(filename, content) {
   const fn = filename.toLowerCase();
 
@@ -89,6 +142,7 @@ export function detectFileType(filename, content) {
   if (fn.includes('machineinfo') || fn.includes('machine_info') || fn.includes('machine-info')) return 'machine-info';
   if (fn.includes('raminfo') || fn.includes('ram_info') || fn.includes('ram-info')) return 'ram-info';
   if (fn.includes('monitorinfo') || fn.includes('monitor_info') || fn.includes('monitor-info')) return 'monitor-info';
+  if (CYBERNET_MANIFEST_FILENAMES.has(csvBasename(filename))) return 'cybernet-target-manifest';
   if (fn.includes('neuron')) return 'neuron-inventory';
   if (fn.includes('smb')) return 'smb-recon';
   if (fn.includes('software_superset') || fn.includes('softwaresuperset') || fn.includes('software-superset')) return 'software-superset';
@@ -101,6 +155,7 @@ export function detectFileType(filename, content) {
       fn.includes('ad_missing_dns') || fn.includes('ad_duplicates') || fn.includes('evidence_only')) {
     return 'ad-registered-population';
   }
+  if (fn.includes('wmi_identity') || fn.includes('wmi-identity')) return 'workstation-identity';
 
   // Detect by headers if content is provided
   if (typeof content === 'string' && content.includes(',')) {
@@ -114,8 +169,10 @@ export function detectFileType(filename, content) {
     if (firstLine.includes('capacitygb') || firstLine.includes('memorytype')) return 'ram-info';
     if (firstLine.includes('displaynumber') || firstLine.includes('isprimary')) return 'monitor-info';
     if (firstLine.includes('targethost') && firstLine.includes('matchexpected')) return 'neuron-inventory';
+    if (isCybernetManifestHeader(firstLine)) return 'cybernet-target-manifest';
     if (firstLine.includes('share') && firstLine.includes('liststatus')) return 'smb-recon';
     if (firstLine.includes('taskname') || firstLine.includes('taskid') || firstLine.includes('outcome')) return 'remote-task';
+    if (firstLine.includes('publisher') && firstLine.includes('host') && firstLine.includes('name')) return 'software-superset';
     if (firstLine.includes('populationauthority') && firstLine.includes('reconcilebucket')) return 'ad-registered-population';
     if (firstLine.includes('populationauthority') && firstLine.includes('adstatus')) return 'ad-registered-population';
     if (firstLine.includes('reconcilebucket') && firstLine.includes('hostname')) return 'ad-registered-population';
@@ -139,6 +196,7 @@ export function parseFileContent(type, content, filename) {
     case 'ram-info': return parseRamInfo(content);
     case 'monitor-info': return parseMonitorInfo(content);
     case 'neuron-inventory': return parseNeuronInventory(content);
+    case 'cybernet-target-manifest': return parseCybernetTargetManifest(content);
     case 'smb-recon': return parseSmbRecon(content);
     case 'status-json': return parseStatusJson(content);
     case 'remote-task': return parseRemoteTask(content);
@@ -208,6 +266,37 @@ function parseNaabuReachability(content, filename) {
   }
 
   return { type: 'naabu-reachability', rows, meta: { count: rows.length, warnings } };
+}
+
+/**
+ * Parse AD registered population reconcile CSVs.
+ */
+function parseAdRegisteredPopulation(content, filename) {
+  const rows = parseCSV(content);
+  const normalized = rows.map(r => ({
+    HostName:        r.HostName        || r.hostname        || r.ComputerName || '',
+    DNSHostName:     r.DNSHostName     || r.dnshostname     || r.FQDN         || '',
+    ADStatus:        r.ADStatus        || r.adstatus        || '',
+    Enabled:         r.Enabled         || r.enabled         || '',
+    OperatingSystem: r.OperatingSystem || r.operatingsystem || r.OS           || '',
+    LastLogonDate:   r.LastLogonDate   || r.lastlogondate   || '',
+    Description:     r.Description     || r.description     || '',
+    ReconcileBucket: r.ReconcileBucket || r.reconcilebucket || r.Bucket       || '',
+    PopulationAuthority: r.PopulationAuthority || r.populationauthority || 'ad_registered',
+    MatchStatus:     r.MatchStatus     || r.matchstatus     || '',
+    EvidenceSerial:  r.EvidenceSerial  || r.evidenceserial  || r.Serial       || '',
+    EvidenceSource:  r.EvidenceSource  || r.evidencesource  || r.Source       || '',
+    Reachability:    r.Reachability    || r.reachability    || '',
+    ProbeStatus:     r.ProbeStatus     || r.probestatus     || '',
+    Reason:          r.Reason          || r.reason          || '',
+    _sourceFile:     filename || '',
+  })).filter(r => r.HostName);
+  const buckets = {};
+  for (const row of normalized) {
+    const b = row.ReconcileBucket || 'registered';
+    buckets[b] = (buckets[b] || 0) + 1;
+  }
+  return { type: 'ad-registered-population', rows: normalized, meta: { count: normalized.length, buckets } };
 }
 
 function parsePreflight(content) {
@@ -286,6 +375,68 @@ function parseNeuronInventory(content) {
   return { type: 'neuron-inventory', rows, meta: { count: rows.length } };
 }
 
+/**
+ * Parse Cybernet target manifest CSV (sas-survey-targets output or resolved manifests).
+ * Distinct from network-preflight, workstation-identity, and AD population exports.
+ */
+function parseCybernetTargetManifest(content) {
+  const rawRows = parseCSV(content);
+  const rows = rawRows.map(row => {
+    const identifierType = pickManifestField(row, ['IdentifierType', 'Identifier Type']);
+    const identifier = pickManifestField(row, ['Identifier', 'Target', 'KnownIdentifier']);
+    let hostname = pickManifestField(row, [
+      'HostName', 'Hostname', 'Host', 'ComputerName', 'Computer', 'Name',
+    ]);
+    if (!hostname && identifierType.toLowerCase() === 'hostname') hostname = identifier;
+
+    const dnsHostName = pickManifestField(row, ['DNSHostName', 'DNS Host Name', 'FQDN']);
+    const ipAddress = firstIpAddress(pickManifestField(row, [
+      'IPAddress', 'IP Address', 'IPAddresses', 'IP', 'ResolvedAddress',
+    ]));
+    const serial = pickManifestField(row, [
+      'Serial', 'SerialNumber', 'Serial Number', 'ServiceTag', 'AssetSerial',
+    ]);
+    const site = pickManifestField(row, ['Site']);
+    const location = pickManifestField(row, ['Location', 'Room']);
+    const neuron = pickManifestField(row, [
+      'Neuron', 'Neuron Hostname', 'NeuronHostName', 'Neuron Host',
+    ]);
+    const workstation = pickManifestField(row, ['Workstation', 'Workstation Hostname']);
+    const mac = pickManifestField(row, [
+      'MAC', 'MACAddress', 'MacAddress', 'Mac', 'EthernetMAC', 'WifiMAC',
+    ]);
+    const normalizedHost = normalizeCybernetHost(hostname || dnsHostName);
+
+    return {
+      type: 'cybernet-target-manifest',
+      sourceType: 'cybernet-target-manifest',
+      hostname,
+      normalizedHost,
+      dnsHostName,
+      ipAddress,
+      serial,
+      site,
+      location,
+      neuron,
+      workstation,
+      mac,
+    };
+  }).filter(r =>
+    r.hostname || r.dnsHostName || r.ipAddress || r.serial || r.mac || r.neuron || r.workstation
+  );
+
+  return {
+    type: 'cybernet-target-manifest',
+    rows,
+    meta: {
+      count: rows.length,
+      withSerial: rows.filter(r => r.serial).length,
+      withIp: rows.filter(r => r.ipAddress).length,
+      missingDnsHost: rows.filter(r => !r.hostname && !r.dnsHostName).length,
+    },
+  };
+}
+
 function parseSmbRecon(content) {
   const rows = parseCSV(content);
   return { type: 'smb-recon', rows, meta: { count: rows.length } };
@@ -338,38 +489,6 @@ function parseRemoteTask(content) {
   }
 
   return { type: 'remote-task', rows: [], meta: { count: 0 } };
-}
-
-/**
- * Parse AD registered population reconcile CSVs.
- * Expected columns include HostName, PopulationAuthority, ReconcileBucket / Bucket.
- */
-function parseAdRegisteredPopulation(content, filename) {
-  const rows = parseCSV(content);
-  const normalized = rows.map(r => ({
-    HostName:        r.HostName        || r.hostname        || r.ComputerName || '',
-    DNSHostName:     r.DNSHostName     || r.dnshostname     || r.FQDN         || '',
-    ADStatus:        r.ADStatus        || r.adstatus        || '',
-    Enabled:         r.Enabled         || r.enabled         || '',
-    OperatingSystem: r.OperatingSystem || r.operatingsystem || r.OS           || '',
-    LastLogonDate:   r.LastLogonDate   || r.lastlogondate   || '',
-    Description:     r.Description     || r.description     || '',
-    ReconcileBucket: r.ReconcileBucket || r.reconcilebucket || r.Bucket       || '',
-    PopulationAuthority: r.PopulationAuthority || r.populationauthority || 'ad_registered',
-    MatchStatus:     r.MatchStatus     || r.matchstatus     || '',
-    EvidenceSerial:  r.EvidenceSerial  || r.evidenceserial  || r.Serial       || '',
-    EvidenceSource:  r.EvidenceSource  || r.evidencesource  || r.Source       || '',
-    Reachability:    r.Reachability    || r.reachability    || '',
-    ProbeStatus:     r.ProbeStatus     || r.probestatus     || '',
-    Reason:          r.Reason          || r.reason          || '',
-    _sourceFile:     filename || '',
-  })).filter(r => r.HostName);
-  const buckets = {};
-  for (const row of normalized) {
-    const b = row.ReconcileBucket || 'registered';
-    buckets[b] = (buckets[b] || 0) + 1;
-  }
-  return { type: 'ad-registered-population', rows: normalized, meta: { count: normalized.length, buckets } };
 }
 
 /**
@@ -562,6 +681,9 @@ export function mergeDataStore(existing, incoming) {
       break;
     case 'neuron-inventory':
       store.neuronInventory = (store.neuronInventory || []).concat(rows);
+      break;
+    case 'cybernet-target-manifest':
+      store.cybernetTargetManifest = (store.cybernetTargetManifest || []).concat(rows);
       break;
     case 'smb-recon':
       store.smbRecon = (store.smbRecon || []).concat(rows);
@@ -874,7 +996,6 @@ export function buildProtocolRows(store) {
     hostMap[t].ports[port] = reach === 'open' ? 'Open' : reach;
   }
 
-  // AD registered population — reconcile buckets; do not treat AD as serial or reachability proof
   for (const row of (store.adRegisteredPopulation || [])) {
     const t = row.HostName || '';
     if (!t) continue;

--- a/dashboard/samples/cybernet_targets.sample.csv
+++ b/dashboard/samples/cybernet_targets.sample.csv
@@ -1,0 +1,4 @@
+Hostname,DNSHostName,IPAddress,Serial,Site,Location,Neuron,Workstation,MAC
+WMH300OPR001,WMH300OPR001.example.local,10.1.2.3,SN-SAMPLE-001,NSUH,Room 101,NEU-01,WS-01,00:11:22:33:44:55
+WMH300OPR002,,,SN-SAMPLE-002,NSUH,Room 102,,,
+,,10.1.2.5,SN-SAMPLE-003,NSUH,Room 103,,,

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -28,6 +28,7 @@ const cases = [
   { file: 'status.json',                           expectedType: 'status-json',         minRows: null },
   { file: 'QRTask_log.json',                       expectedType: 'remote-task',         minRows: 3 },
   { file: 'RunControl_events.json',                expectedType: 'remote-task',         minRows: 3 },
+  { file: 'cybernet_targets.sample.csv',           expectedType: 'cybernet-target-manifest', minRows: 2 },
   { file: 'ad_registered_normalized.csv',            expectedType: 'ad-registered-population', minRows: 1 },
   { file: 'ad_registered_population.sample.csv',    expectedType: 'ad-registered-population', minRows: 6 },
 ];
@@ -163,16 +164,10 @@ const contractChecks = [
   ['--targets-file /tmp/sas-cybernet/targets.txt', 'preflight/identity --targets-file'],
   ['--file /tmp/sas-cybernet/targets.txt', 'normalize --file reference'],
   ['keyports_cybernet_json', 'low-noise reachability profile'],
+  ['cybernet-target-manifest', 'manifest parser type wired'],
+  ['store.cybernetTargetManifest', 'manifest store wiring'],
   ['ad-registered-population', 'AD parser type wired'],
   ['store.adRegisteredPopulation', 'AD store wiring'],
-];
-
-const adContractChecks = [
-  ['cybernet-ad-population-summary', 'AD summary container in HTML'],
-  ['AD Registered Population', 'AD summary heading'],
-  ['registered computer accounts', 'AD population row label'],
-  ['not serial or reachability proof', 'no false AD proof claim'],
-  ['AD registered population', 'AD section label'],
 ];
 
 // ── Naabu reachability Cybernet review contracts (app.js) ───────────────────
@@ -219,8 +214,34 @@ for (const [needle, label] of naabuContractChecks) {
   }
 }
 
+const manifestContractChecks = [
+  ['cybernet-manifest-summary', 'manifest summary container in HTML'],
+  ['manifest rows', 'manifest summary row count label'],
+  ['missing hostname/DNS', 'manifest missing hostname metric'],
+  ['Target manifest', 'manifest section label'],
+];
+
+for (const [needle, label] of manifestContractChecks) {
+  const src = needle === 'cybernet-manifest-summary' ? indexHtml : appJs;
+  if (!src.includes(needle)) {
+    console.error(`FAIL [manifest-contract:${label}]: missing "${needle}"`);
+    shellFailed++;
+  } else {
+    console.log(`PASS [manifest-contract:${label}]`);
+    shellPassed++;
+  }
+}
+
+const adContractChecks = [
+  ['cybernet-ad-population-summary', 'AD summary container in HTML'],
+  ['AD Registered Population', 'AD summary heading'],
+  ['registered computer accounts', 'AD population row label'],
+  ['not serial or reachability proof', 'no false AD proof claim'],
+  ['AD registered population', 'AD section label'],
+];
+
 for (const [needle, label] of adContractChecks) {
-  const src = (needle === 'cybernet-ad-population-summary' || needle === 'AD Registered Population')
+  const src = (needle === 'cybernet-ad-population-summary' || needle === 'AD Registered Population' || needle === 'not serial or reachability proof')
     ? indexHtml
     : appJs;
   if (!src.includes(needle)) {


### PR DESCRIPTION
## Summary
- Reopens the PR #54 work on a clean branch after removing it from `main`.
- Keeps Cybernet target manifest parsing isolated from network, workstation identity, printer probe, and reachability evidence.
- Adds dashboard storage and a minimal manifest summary so loaded target manifests are visible without being treated as proof/evidence.
- Includes the follow-up accessibility/live-region fix so the manifest summary remains mounted and does not disappear from assistive technology.

## Known gaps addressed before this PR
- PR #54 was merged before manual drag/drop validation was checked.
- The feature mixed parser, dashboard UI, bundled runtime, sample data, and smoke-test changes in one merge.
- The original merge was reverted/reset out of `main`; this branch reintroduces the work for review instead of silently landing it again.
- The temporary `__no_op__` file is not present in this branch.

## Risks to review
- Header-based manifest detection can still classify broad inventory CSVs if their headers look like target manifests.
- `dashboard/js/bundle.js` is changed along with source files; reviewers should confirm the bundle matches the intended source changes.
- Manifest rows are target lists only; they should not be used as reachability, identity, or serial proof.

## Validation
- Need reviewer/local check: `node --check dashboard/js/parsers.js`
- Need reviewer/local check: `node --check dashboard/js/app.js`
- Need reviewer/local check: `node --check dashboard/js/bundle.js`
- Need reviewer/local check: `node dashboard/smoke-test.js`
- Need manual check: drag `dashboard/samples/cybernet_targets.sample.csv` into the dashboard and confirm the manifest summary counts are correct.

## Next steps
1. Review the parser detection rules for false positives.
2. Run the listed Node checks locally or in CI.
3. Complete the manual dashboard drag/drop test.
4. Only merge after those checks pass.