### PR TITLE
docs(dashboard): record PR69 browser QA blocker and checklist

### DIFF
--- a/docs/dashboard/BROWSER_QA_STATUS.md
+++ b/docs/dashboard/BROWSER_QA_STATUS.md
@@ -10,11 +10,20 @@ Harness: **no Playwright/browser automation in CI or agent runtime**
 | Lane | PR / feature | Automated smoke | Browser QA | Status |
 |------|--------------|-----------------|------------|--------|
 | AD population | #56 (merged `e8ad69f`) | PASS | Not run | **BLOCKED — manual pass required** |
-| Cybernet manifest | #69 (merged `2bca023`) | PASS | Not run | **NOT RUN — manual pass required** |
+| Cybernet manifest | #69 (merged `2bca023`) | PASS | Not run | **BLOCKED — manual pass required** |
 | Naabu JSON | #68 (merged) | PASS | Not run | Covered by smoke contracts only |
 | Cybernet-first shell/tour | #66/#67 (merged) | PASS | Partial (`PR66_BROWSER_QA.md`) | Manual corp-network pass still needed |
 
 **Overall:** smoke contracts green on `main`; **real browser QA still required** for review separation and drag/drop UX.
+
+### Status semantics
+
+| Label | Meaning |
+|-------|---------|
+| **BLOCKED (#56)** | AD population browser proof was never completed; lane is blocked on a human manual pass. See [`PR56_BROWSER_QA.md`](PR56_BROWSER_QA.md). |
+| **BLOCKED (#69)** | Manifest + combined evidence-separation browser proof was never completed; same harness gap. See [`PR69_BROWSER_QA.md`](PR69_BROWSER_QA.md). |
+| **NOT RUN** | No operator has executed the manual checklist for that lane in a browser session yet (automation did not substitute). |
+| **Combined session** | Recommended next step: one browser session loading AD + manifest + Naabu (+ identity) samples and verifying all summaries stay separate. Neither #56 nor #69 is satisfied until that session is recorded. |
 
 ---
 
@@ -60,7 +69,7 @@ See also: [`PR56_BROWSER_QA.md`](PR56_BROWSER_QA.md)
 
 ---
 
-## PR #69 — Cybernet manifest (NOT RUN)
+## PR #69 — Cybernet manifest + evidence separation (BLOCKED)
 
 Branch was `fix/pr54-cybernet-manifest-ready` (merged).
 
@@ -70,6 +79,10 @@ Automated evidence at merge time:
 - `node --check` parsers/app PASS
 - CI dashboard-smoke + Pester PASS
 
+**Browser QA:** NOT RUN — no automated harness; manual pass required before treating manifest separation as proven.
+
+See also: [`PR69_BROWSER_QA.md`](PR69_BROWSER_QA.md)
+
 ### Manual checklist (#69)
 
 - [ ] Load `dashboard/samples/cybernet_targets.sample.csv` via drag/drop or file picker
@@ -78,6 +91,8 @@ Automated evidence at merge time:
 - [ ] Load Naabu sample — network findings do not replace AD/manifest summaries
 - [ ] Confirm manifest copy does not claim reachability or serial proof
 - [ ] Confirm broad inventory CSV (non-manifest) is **not** misclassified as manifest (false-positive check)
+- [ ] Advanced Tools collapsed by default; QR not on first screen
+- [ ] 320px viewport and keyboard nav (see PR69 doc for full list)
 
 ---
 
@@ -87,9 +102,18 @@ Run one browser session loading **all** of:
 
 1. `dashboard/samples/ad_registered_population.sample.csv`
 2. `dashboard/samples/cybernet_targets.sample.csv`
-3. Naabu JSON/JSONL sample (from dashboard samples or fixtures)
+3. Naabu JSON/JSONL sample (`dashboard/samples/cybernet_naabu.sample.json` or `.jsonl`)
+4. Optional: `dashboard/samples/workstation_identity.csv` for identity separation
 
 Verify separation of AD population, manifest targets, Naabu reachability, and identity evidence.
+
+**Session status:** NOT RUN — completes both #56 and #69 browser lanes when recorded in the PR QA docs.
+
+---
+
+## Harness note
+
+Repository grep (2026-06-25) found **no** Playwright, Puppeteer, Cypress, or Selenium test scripts or CI jobs. `PR66_BROWSER_QA.md` documents a prior one-off Playwright session for shell/tour UX; that is not a reusable CI harness and does not satisfy #56 or #69 evidence-separation lanes.
 
 ---
 

--- a/docs/dashboard/PR69_BROWSER_QA.md
+++ b/docs/dashboard/PR69_BROWSER_QA.md
@@ -1,0 +1,77 @@
+# PR69 Browser QA Status
+
+Branch: `fix/pr54-cybernet-manifest-ready` (merged to `main` via PR #69 @ `2bca023`)
+Date: 2026-06-25
+Browser harness: **not run in this lane** (no Playwright/browser automation in CI or agent runtime)
+
+## Result
+
+Overall QA result: **BLOCKED — manual browser pass required**
+
+Automated coverage at merge: dashboard smoke **manifest + AD contracts PASS** (30 shell, 18 tour), `node --check` on parsers/app PASS, CI dashboard-smoke + Pester PASS.
+
+This lane does **not** claim a browser PASS. Shell smoke proves parser wiring and contract language; it does not prove drag/drop UX, viewport layout, or visual separation of review surfaces in a real browser.
+
+## Blocker
+
+| Field | Detail |
+|-------|--------|
+| **Exact blocker** | No Playwright, Puppeteer, Cypress, or Selenium harness in repo CI or agent runtime. Grep across the worktree finds Playwright mentions only in prior QA docs (`PR66_BROWSER_QA.md`), not in executable test scripts or package dependencies. |
+| **Impact** | Evidence separation for AD population (#56), Cybernet manifest (#69), Naabu reachability, and identity panels cannot be verified automatically. Operators cannot rely on this lane for visual/UX proof. |
+| **Next human action** | Run the combined manual checklist below in Edge or Chrome on `dashboard/index.html` (local static server or `file://`), loading all three sample fixtures in one session. Record PASS/FAIL per item; attach screenshots only if a failure mode is found. |
+
+## Smoke evidence (automated — not browser proof)
+
+| Check | Result |
+|-------|--------|
+| Manifest sample detected as Cybernet target manifest | PASS (shell) |
+| AD sample detected as `ad-registered-population` | PASS (shell) |
+| Naabu parser contracts | PASS (shell) |
+| Manifest summary container in `index.html` | PASS (shell) |
+| AD summary container separate from Review Results | PASS (shell) |
+| No false manifest reachability/serial proof language in contracts | PASS (shell) |
+| Broad inventory CSV not misclassified as manifest (false-positive guard) | PASS (shell) |
+
+## Manual browser checklist (operator)
+
+Run in one session. Use synthetic fixtures only.
+
+### First screen and shell (#66 regression guard)
+
+- [ ] First screen shows exactly **3** action controls before opening panels: **Start Cybernet Survey**, **Load Evidence**, **Advanced Tools** (header)
+- [ ] **Advanced Tools** section is collapsed by default (`aria-expanded="false"`, `#advanced-section` hidden)
+- [ ] QR import controls are **not** on the first screen (QR appears only under Load Evidence → Supported formats, not in hero/header)
+- [ ] 320×800 viewport: no horizontal overflow on hero, manifest, AD, or review sections
+- [ ] Keyboard navigation: Tab through hero actions and Advanced Tools toggle; focus visible and operable
+
+### Manifest (#69)
+
+- [ ] Load `dashboard/samples/cybernet_targets.sample.csv` via drag/drop or file picker
+- [ ] **Cybernet Target Manifest** summary appears (target row count, missing hostname/DNS cues)
+- [ ] Manifest copy does **not** claim reachability or serial proof
+
+### AD population (#56 — same session)
+
+- [ ] Load `dashboard/samples/ad_registered_population.sample.csv`
+- [ ] **AD Registered Population** summary appears separately from **Review Results** reachability block
+- [ ] AD note states population authority only — not serial or reachability proof
+
+### Naabu / network (#68 — same session)
+
+- [ ] Load `dashboard/samples/cybernet_naabu.sample.json` or `dashboard/samples/cybernet_naabu.sample.jsonl`
+- [ ] Network/reachability findings appear without replacing or collapsing AD or manifest summaries
+- [ ] Reachability panel does not imply AD or manifest prove live hosts
+
+### Evidence separation (combined)
+
+- [ ] All four surfaces remain visible and semantically distinct: manifest targets, AD population, reachability/network, identity (load `dashboard/samples/workstation_identity.csv` if identity panel is in scope)
+- [ ] No summary language conflates population authority with hardware identity or live reachability
+- [ ] Load a broad inventory CSV (e.g. `dashboard/samples/NeuronNetworkInventory_20241115.csv`) — confirm it is **not** misclassified as Cybernet manifest
+
+## Notes
+
+- Manifest rows are **target list authority**, not survey evidence or reachability proof.
+- AD population is **population authority**, not hardware identity or reachability proof.
+- Naabu JSON/JSONL is **reachability/network findings**, separate from AD and manifest.
+- Prior PR #66 browser PASS (`PR66_BROWSER_QA.md`) used a one-off Playwright session; that script is not checked into CI and does not satisfy this lane.
+- Synthetic fixtures only; no live AD exports or field hostnames in repo.


### PR DESCRIPTION
## Summary

Documents browser QA status for merged dashboard evidence separation (#56 AD + #69 manifest + Naabu + identity). **No browser pass is claimed.**

### Status
- **Browser QA: BLOCKED** — no Playwright/Puppeteer/Cypress/Selenium harness in CI or agent runtime.
- Automated smoke contracts are green on `main`; they do **not** substitute for manual browser validation.

### Added
- `docs/dashboard/PR69_BROWSER_QA.md` — manual checklist and blocker documentation
- Updated `docs/dashboard/BROWSER_QA_STATUS.md` — clarifies #56 BLOCKED vs #69 NOT RUN vs combined session

### Manual checklist covers
- First screen: Start Cybernet Survey, Load Evidence, Advanced Tools only
- Load manifest, AD, and Naabu samples
- Confirm summaries remain visually and semantically separate:
  - AD = population authority
  - Manifest = target list
  - Naabu = reachability evidence
  - Workstation identity = identity evidence
- UI must not imply proof where none exists
- 320px viewport, keyboard navigation, Advanced Tools collapsed by default
- QR not promoted to first screen

### Validation
- `node dashboard/smoke-test.js` PASS
- `python scripts/validate-targets-folder-policy.py` PASS

### Notes
- No live data committed.
- Browser QA has **not** been executed; docs record the gap honestly.

### Recommended merge order
Merge **after** manifest negative-fixtures PR.
