### PR TITLE
feat(survey): enforce low-noise naabu doctrine repo-wide + add sas-packet-probe

### DIFF
--- a/.cursor/rules/naabu-doctrine.mdc
+++ b/.cursor/rules/naabu-doctrine.mdc
@@ -1,0 +1,25 @@
+---
+alwaysApply: true
+---
+
+# Naabu Doctrine
+
+For SysAdminSuite Cybernet/Neuron survey work, preserve the low-noise Naabu doctrine:
+
+- AD-derived target lists define population; Naabu/Nmap only validate reachability.
+- Prefer `survey/sas-run-naabu-pipeline.sh` or `survey/sas-run-packet-probe.sh`.
+- Do not add raw `naabu -list` or `naabu -host` commands unless reachability commands include
+  `-silent` and `-ec`.
+- Parser-facing evidence should use JSON or JSONL; raw txt is only for clean local pipe handoff.
+- UDP, all-port, public-target, and host-discovery paths require explicit gate flags.
+- `-sa` is only for intentionally scanning all resolved IPs for load-balanced hostnames.
+- Evidence stays local in gitignored paths (`logs/nmap/`, `survey/output/`, `survey/artifacts/`).
+- Use "low-noise survey discipline"; do not frame this as stealth, evasion, or log bypass.
+- `feature/naabu-docs-consolidation` is superseded by `main`; do not revive it by default.
+
+Canonical references:
+
+- `AGENTS.md`
+- `survey/naabu_profiles.json`
+- `docs/LOW_NOISE_SURVEY_DOCTRINE.md`
+- `docs/NAABU_CYBERNET_PROFILES.md`

--- a/.github/workflows/survey-doctrine.yml
+++ b/.github/workflows/survey-doctrine.yml
@@ -1,0 +1,50 @@
+name: Survey doctrine
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths:
+      - 'AGENTS.md'
+      - '.cursor/rules/**'
+      - 'Config/cybernet-naabu-profiles.json'
+      - 'Config/cybernet-packet-profile.json'
+      - 'docs/LOW_NOISE_SURVEY_DOCTRINE.md'
+      - 'docs/NAABU_CYBERNET_PROFILES.md'
+      - 'probe/packet-expenditure/**'
+      - 'survey/**'
+      - 'Tests/bash/*naabu*'
+      - 'Tests/bash/test_packet_probe_contracts.sh'
+      - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
+      - '.github/workflows/survey-doctrine.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'AGENTS.md'
+      - '.cursor/rules/**'
+      - 'Config/cybernet-naabu-profiles.json'
+      - 'Config/cybernet-packet-profile.json'
+      - 'docs/LOW_NOISE_SURVEY_DOCTRINE.md'
+      - 'docs/NAABU_CYBERNET_PROFILES.md'
+      - 'probe/packet-expenditure/**'
+      - 'survey/**'
+      - 'Tests/bash/*naabu*'
+      - 'Tests/bash/test_packet_probe_contracts.sh'
+      - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
+      - '.github/workflows/survey-doctrine.yml'
+
+jobs:
+  doctrine:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Naabu doctrine contract tests
+        shell: bash
+        run: |
+          bash Tests/bash/test_repo_naabu_doctrine_conformance.sh
+
+      - name: Go packet expenditure tests
+        shell: bash
+        run: |
+          cd probe/packet-expenditure
+          go test ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,34 @@ Do not assume:
 
 Bash scripts may call Windows-native executables such as `cmd.exe`, `hostname.exe`, `ping.exe`, `nslookup.exe`, and `netsh.exe`.
 
+## Low-Noise Survey / Naabu Doctrine
+
+Naabu and related packet probes are for authorized reachability validation only. They are not a
+population source, identity proof, stealth technique, or target-side collection mechanism.
+
+Agents MUST preserve these rules across docs, scripts, dashboards, generated commands, and tests:
+
+- Treat AD-derived target lists as the registered Cybernet population authority.
+- Treat Naabu/Nmap output as reachability evidence only.
+- Use `survey/naabu_profiles.json` as the doctrine source of truth and
+  `Config/cybernet-naabu-profiles.json` as generated runtime config.
+- Prefer `survey/sas-run-naabu-pipeline.sh` or `survey/sas-run-packet-probe.sh` for execution.
+- Do not emit raw `naabu -list` or `naabu -host` guidance unless reachability commands include `-silent` and `-ec`, and structured evidence commands include JSON output where parser-facing.
+- Keep `-silent` on every Naabu pipeline to avoid banners/logos in machine-readable output.
+- Keep `-ec` on reachability profiles to avoid wasting probes on CDN/cloud firewall edges unless
+  a profile explicitly documents why CDN edges are in scope.
+- Use `-sa` for load-balanced hostnames only when every resolved IP is intentionally in scope.
+- Require explicit justification gates for UDP, all-port, public-target, or subnet host-discovery
+  profiles (`--profile-justified`, `--allow-full-ports`, `--allow-public`,
+  `--approved-subnet-scope`).
+- Keep all evidence local in gitignored output paths such as `logs/nmap/`, `survey/output/`, or
+  `survey/artifacts/`; never write logs or artifacts to target workstations.
+- Use "low-noise survey discipline" language. Do not describe this work as stealth, evasion,
+  hiding, bypassing monitoring, or defeating logs.
+- Classify guest-network failures as `ENVIRONMENT_BLOCKED_GUEST_NETWORK`, not product failure.
+- Treat `feature/naabu-docs-consolidation` as superseded by current `main` doctrine. Do not
+  revive or merge it without explicit user authorization.
+
 ## WAB Test Evidence Guardrail
 
 When the user reports that SysAdminSuite is `running` on the WAB path, do not treat that as full validation.

--- a/Config/cybernet-packet-profile.json
+++ b/Config/cybernet-packet-profile.json
@@ -1,0 +1,20 @@
+{
+  "portMode": "top",
+  "topPorts": "1000",
+  "threads": 50,
+  "rate": 3000,
+  "smartScan": true,
+  "predictionThreshold": 20,
+  "scanType": "s",
+  "maxTargets": 256,
+  "requireApprovedTargetFile": true,
+  "allowPublicTargets": false,
+  "excludeCdn": true,
+  "disableUpdateCheck": true,
+  "stream": false,
+  "passive": false,
+  "output": {
+    "jsonl": true,
+    "silent": true
+  }
+}

--- a/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
+++ b/Tests/Pester/CybernetSubnetDiscovery.Tests.ps1
@@ -158,11 +158,11 @@ Describe 'New-CybernetSubnetDiscoveryReport' {
             [pscustomobject]@{ Site='SSUH'; Serial='CN3'; ExpectedHostname=''; ExpectedMAC=''; IP=''; Evidence='' }
         )
 
-        $matches = foreach ($row in $inventory) {
+        $subnetMatches = foreach ($row in $inventory) {
             Convert-IpToSubnetCandidate -IPv4 $row.IP -ApprovedSubnets $subnets
         }
 
-        $identity = New-CybernetIdentityMapRows -InventoryRows $inventory -SubnetMatches $matches
+        $identity = New-CybernetIdentityMapRows -InventoryRows $inventory -SubnetMatches $subnetMatches
         $targets = New-CybernetTargetIpList -IdentityMapRows $identity
         $targets | Should -Contain '10.20.30.10'
         $targets | Should -Not -Contain '8.8.8.8'
@@ -209,9 +209,11 @@ Describe 'New-CybernetSubnetDiscoveryReport' {
 Describe 'New-CybernetScannerCommand' {
     It 'Generates deterministic Naabu command' {
         $profilePath = Join-Path $script:repoRoot 'Config\cybernet-port-profile.json'
-        $profile = Get-CybernetPortProfile -ProfilePath $profilePath
-        $cmd = New-CybernetNaabuCommand -TargetFile '.\targets.txt' -OutputFile '.\out.jsonl' -Profile $profile
-        $cmd.Command | Should -Be 'naabu -list .\targets.txt -p 135,139,445,3389,5985,5986,80,443 -rate 50 -c 10 -retries 1 -timeout 1000 -ec -json -silent -duc -o .\out.jsonl'
+        $portProfile = Get-CybernetPortProfile -ProfilePath $profilePath
+        $cmd = New-CybernetNaabuCommand -TargetFile '.\targets.txt' -OutputFile '.\out.jsonl' -PortProfile $portProfile
+        $cmd.Scanner | Should -Be 'PacketProbe'
+        $cmd.Command | Should -Be 'bash survey/sas-run-packet-probe.sh --site cybernet --list .\targets.txt --out .\out.jsonl --summary .\out.jsonl.summary.json'
+        $cmd.AuditCommand | Should -Be 'naabu -list .\targets.txt -p 135,139,445,3389,5985,5986,80,443 -rate 50 -c 10 -retries 1 -timeout 1000 -ec -json -silent -duc -o .\out.jsonl'
     }
 
     It 'Generates deterministic Nmap host discovery command' {
@@ -221,8 +223,8 @@ Describe 'New-CybernetScannerCommand' {
 
     It 'Generates deterministic Nmap selected-port command' {
         $profilePath = Join-Path $script:repoRoot 'Config\cybernet-port-profile.json'
-        $profile = Get-CybernetPortProfile -ProfilePath $profilePath
-        $cmd = New-CybernetNmapSelectedPortCommand -TargetFile '.\targets.txt' -OutputFile '.\out.xml' -Profile $profile
+        $portProfile = Get-CybernetPortProfile -ProfilePath $profilePath
+        $cmd = New-CybernetNmapSelectedPortCommand -TargetFile '.\targets.txt' -OutputFile '.\out.xml' -PortProfile $portProfile
         $cmd.Command | Should -Be 'nmap -p 135,139,445,3389,5985,5986,80,443 --open -iL .\targets.txt -oX .\out.xml'
     }
 }
@@ -260,7 +262,7 @@ Describe 'Invoke-SASCybernetSubnetDiscovery.ps1 integration' {
         }
 
         $log = Get-Content -LiteralPath (Join-Path $outDir 'CybernetSubnetDiscovery_EvidenceLog.jsonl') -Raw
-        $log | Should -Match 'naabu -list'
+        $log | Should -Match 'sas-run-packet-probe.sh'
         $log | Should -Match 'nmap -sn'
         $log | Should -Match 'not executed'
 

--- a/Tests/bash/test_naabu_pipeline_contracts.sh
+++ b/Tests/bash/test_naabu_pipeline_contracts.sh
@@ -135,15 +135,15 @@ printf '10.10.10.3:5985\n' | bash "$FOLLOWUP" --site testsite --stdin --cybernet
 # Ensure naabu dry-run
 bash "$ENSURE" --dry-run >/dev/null || true
 
-# Survey runner naabu dry-run uses pipeline
+# Survey runner naabu dry-run uses packet probe for approved host files.
 bash survey/sas-cybernet-subnet-survey.sh --site testsite --mode confirm-windows \
   --confirm-tool naabu --host-file "$FIX/targets.sample.txt" \
   --output-root "$TMP/out" --logs-root "$TMP/logs" --run-id naabu001 --dry-run >/dev/null
 [[ -f "$TMP/out/testsite_naabu001/planned_commands.txt" ]]
-grep -qE 'sas-run-naabu-pipeline\.sh|naabu.*-ec' "$TMP/out/testsite_naabu001/planned_commands.txt" || { echo 'survey runner missing naabu pipeline plan'; exit 1; }
+grep -q '\-ec' "$TMP/out/testsite_naabu001/planned_commands.txt" || { echo 'survey runner missing -ec'; exit 1; }
 grep -q 'sas-parse-naabu-evidence.sh' "$TMP/out/testsite_naabu001/planned_commands.txt" || { echo 'survey runner missing parse step'; exit 1; }
 
-grep -q '80,443,135,445,3389,5985,5986' "$TMP/out/testsite_naabu001/planned_commands.txt" || { echo 'orchestrator missing full keyports'; exit 1; }
+grep -q '\-tp 1000' "$TMP/out/testsite_naabu001/planned_commands.txt" || { echo 'orchestrator missing packet profile top ports'; exit 1; }
 
 # parse-naabu-only dry-run plans parse against latest artifact
 cp "$FIX/naabu.sample.jsonl" "$TMP/logs/testsite_latest_windows_ports_naabu.json"

--- a/Tests/bash/test_packet_probe_contracts.sh
+++ b/Tests/bash/test_packet_probe_contracts.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+WRAP="survey/sas-run-packet-probe.sh"
+FIX="$ROOT/survey/fixtures/naabu_pipeline"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+for f in "$WRAP" "Config/cybernet-packet-profile.json" "$FIX/targets.sample.txt"; do
+  [[ -f "$f" ]] || { echo "missing: $f"; exit 1; }
+done
+
+bash -n "$WRAP"
+
+PLAN="$TMP/planned.txt"
+OUT="$TMP/results.json"
+SUMMARY="$TMP/summary.json"
+
+bash "$WRAP" --site testsite \
+  --list "$FIX/targets.sample.txt" \
+  --out "$OUT" \
+  --summary "$SUMMARY" \
+  --planned-file "$PLAN" \
+  --dry-run >/dev/null
+
+grep -q -- '-tp 1000' "$PLAN" || { echo 'missing -tp 1000'; cat "$PLAN"; exit 1; }
+grep -q -- '-c 50' "$PLAN" || { echo 'missing -c 50'; cat "$PLAN"; exit 1; }
+grep -q -- '-rate 3000' "$PLAN" || { echo 'missing -rate 3000'; cat "$PLAN"; exit 1; }
+grep -q -- '-ss' "$PLAN" || { echo 'missing -ss'; cat "$PLAN"; exit 1; }
+grep -q -- '-pt 20' "$PLAN" || { echo 'missing -pt 20'; cat "$PLAN"; exit 1; }
+grep -q -- '-ec' "$PLAN" || { echo 'missing -ec'; cat "$PLAN"; exit 1; }
+grep -q -- '-silent' "$PLAN" || { echo 'missing -silent'; cat "$PLAN"; exit 1; }
+grep -q -- '-json' "$PLAN" || { echo 'missing -json'; cat "$PLAN"; exit 1; }
+grep -q -- '-duc' "$PLAN" || { echo 'missing -duc'; cat "$PLAN"; exit 1; }
+grep -q '"classification": "OK_NAABU_PACKET_PROBE_PLANNED"' "$SUMMARY" || { echo 'summary missing planned classification'; cat "$SUMMARY"; exit 1; }
+
+BAD="$TMP/bad-profile.json"
+python - "$BAD" <<'PY'
+import json, sys
+p = json.load(open("Config/cybernet-packet-profile.json", encoding="utf-8"))
+p["stream"] = True
+json.dump(p, open(sys.argv[1], "w", encoding="utf-8"))
+PY
+if bash "$WRAP" --site testsite --list "$FIX/targets.sample.txt" --out "$OUT" --profile "$BAD" --dry-run 2>/dev/null; then
+  echo 'expected stream + smart scan profile to fail'
+  exit 1
+fi
+
+CIDR="$TMP/cidr.txt"
+printf '10.10.10.0/24\n' > "$CIDR"
+if bash "$WRAP" --site testsite --list "$CIDR" --out "$OUT" --dry-run 2>/dev/null; then
+  echo 'expected CIDR target list to fail'
+  exit 1
+fi
+
+PUBLIC="$TMP/public.txt"
+printf '8.8.8.8\n' > "$PUBLIC"
+if bash "$WRAP" --site testsite --list "$PUBLIC" --out "$OUT" --dry-run 2>/dev/null; then
+  echo 'expected public target list to fail'
+  exit 1
+fi
+
+printf 'Packet probe contracts passed.\n'

--- a/Tests/bash/test_repo_naabu_doctrine_conformance.sh
+++ b/Tests/bash/test_repo_naabu_doctrine_conformance.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Repo-wide Naabu doctrine conformance checks. Read-only; no network access.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  printf 'test_repo_naabu_doctrine_conformance: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+run_contracts() {
+  bash Tests/bash/smoke-naabu-profiles.sh
+  bash Tests/bash/test_naabu_profile_sync.sh
+  bash Tests/bash/test_naabu_pipeline_contracts.sh
+  bash Tests/bash/test_naabu_package_contracts.sh
+}
+
+check_raw_naabu_commands() {
+  local bad=0
+  local path line_no line text
+
+  while IFS=: read -r path line_no text; do
+    [[ -n "${path:-}" ]] || continue
+
+    # Generated dashboard bundles may contain copied operator guidance. Source docs/scripts carry
+    # the enforceable command text.
+    case "$path" in
+      dashboard/js/bundle.js) continue ;;
+    esac
+
+    if [[ "$text" != *"-silent"* ]]; then
+      printf 'missing -silent: %s:%s:%s\n' "$path" "$line_no" "$text" >&2
+      bad=1
+    fi
+
+    if [[ "$text" != *"-ec"* && "$text" != *'$ecFlag'* ]]; then
+      printf 'missing -ec or ecFlag gate: %s:%s:%s\n' "$path" "$line_no" "$text" >&2
+      bad=1
+    fi
+  done < <(
+    git grep -n -I -E 'naabu[[:space:]]+-(list|host)' -- \
+      '*.md' '*.sh' '*.ps1' '*.psm1' '*.json' '*.go' ':!Config/cybernet-naabu-profiles.json' || true
+  )
+
+  [[ "$bad" -eq 0 ]] || fail "raw naabu command strings must preserve -silent and -ec"
+}
+
+check_doctrine_references() {
+  grep -q 'survey/naabu_profiles.json' AGENTS.md || fail "AGENTS.md must reference survey/naabu_profiles.json"
+  grep -q 'low-noise survey discipline' AGENTS.md || fail "AGENTS.md must preserve low-noise language"
+  grep -q 'feature/naabu-docs-consolidation' AGENTS.md || fail "AGENTS.md must mark H1 as superseded"
+  [[ -f .cursor/rules/naabu-doctrine.mdc ]] || fail "missing .cursor/rules/naabu-doctrine.mdc"
+}
+
+run_contracts
+check_raw_naabu_commands
+check_doctrine_references
+
+echo "test_repo_naabu_doctrine_conformance: PASS"

--- a/docs/LOW_NOISE_SURVEY_DOCTRINE.md
+++ b/docs/LOW_NOISE_SURVEY_DOCTRINE.md
@@ -99,6 +99,16 @@ naabu -list logs/targets/<site>_confirm_hosts.txt -json -silent -ec -o logs/nmap
 naabu -list logs/targets/<site>_confirm_hosts.txt -silent -ec | cybernet-detect --stdin --jsonl > logs/nmap/<site>_<runid>_cybernet_detect.jsonl
 ```
 
+When `httpx` is available on the local box, keep it behind the SysAdminSuite
+followup wrapper so banners, logs, and enrichment output stay local and
+machine-readable:
+
+```bash
+naabu -list logs/targets/<site>_confirm_hosts.txt -silent -ec \
+  | bash survey/sas-cybernet-packet-followup.sh --site <site> --stdin --use-httpx --cybernet-detect \
+  > logs/nmap/<site>_<runid>_enrichment.jsonl
+```
+
 ### Key ports
 
 ```bash

--- a/docs/NAABU_CYBERNET_PROFILES.md
+++ b/docs/NAABU_CYBERNET_PROFILES.md
@@ -20,6 +20,10 @@ Downloads pinned `naabu.exe` to `bin/naabu.exe` from [ProjectDiscovery naabu rel
 
 Doctrine is the single source of truth. The runtime config is generated from it:
 
+> Supersession note (2026-06-25): `feature/naabu-docs-consolidation` is retired.
+> Current `main` doctrine keeps `survey/naabu_profiles.json` as the source of truth and
+> `Config/cybernet-naabu-profiles.json` as generated runtime config.
+
 ```text
 survey/naabu_profiles.json            (doctrine contract — edit here)
         |  bash survey/sas-generate-naabu-runtime-profiles.sh

--- a/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
+++ b/modules/CybernetSurvey/New-CybernetScannerCommand.ps1
@@ -9,12 +9,12 @@ function Get-CybernetPortProfile {
     }
 
     $json = Get-Content -LiteralPath $ProfilePath -Raw | ConvertFrom-Json
-    $profile = $json.profiles.CybernetWindowsEndpoint
-    if (-not $profile) {
+    $portProfile = $json.profiles.CybernetWindowsEndpoint
+    if (-not $portProfile) {
         throw 'CybernetWindowsEndpoint profile missing from port profile JSON'
     }
 
-    return $profile
+    return $portProfile
 }
 
 function New-CybernetNaabuCommand {
@@ -25,26 +25,29 @@ function New-CybernetNaabuCommand {
         [Parameter(Mandatory = $true)]
         [string]$OutputFile,
 
-        [object]$Profile
+        [object]$PortProfile
     )
 
-    $ports = ($Profile.ports | ForEach-Object { [string]$_ }) -join ','
+    $ports = ($PortProfile.ports | ForEach-Object { [string]$_ }) -join ','
 
     # CDN exclusion (-ec) mirrors Config/cybernet-naabu-profiles.json windows_selected doctrine:
     # it caps CDN/cloud-edge hosts to avoid wasteful probing. Record-only; never executed here.
     $excludeCdn = $false
-    if ($Profile.PSObject.Properties.Name -contains 'excludeCdn') {
-        $excludeCdn = [bool]$Profile.excludeCdn
+    if ($PortProfile.PSObject.Properties.Name -contains 'excludeCdn') {
+        $excludeCdn = [bool]$PortProfile.excludeCdn
     }
     $ecFlag = if ($excludeCdn) { ' -ec' } else { '' }
 
-    $command = "naabu -list $TargetFile -p $ports -rate $($Profile.defaultRate) -c $($Profile.defaultConcurrency) -retries $($Profile.retries) -timeout $($Profile.timeoutMs)$ecFlag -json -silent -duc -o $OutputFile"
+    $summaryFile = "$OutputFile.summary.json"
+    $command = "bash survey/sas-run-packet-probe.sh --site cybernet --list $TargetFile --out $OutputFile --summary $summaryFile"
+    $auditCommand = "naabu -list $TargetFile -p $ports -rate $($PortProfile.defaultRate) -c $($PortProfile.defaultConcurrency) -retries $($PortProfile.retries) -timeout $($PortProfile.timeoutMs)$ecFlag -json -silent -duc -o $OutputFile"
 
     return [pscustomobject]@{
-        Scanner    = 'Naabu'
-        Command    = $command
-        TargetFile = $TargetFile
-        OutputFile = $OutputFile
+        Scanner      = 'PacketProbe'
+        Command      = $command
+        AuditCommand = $auditCommand
+        TargetFile   = $TargetFile
+        OutputFile   = $OutputFile
     }
 }
 
@@ -75,10 +78,10 @@ function New-CybernetNmapSelectedPortCommand {
         [Parameter(Mandatory = $true)]
         [string]$OutputFile,
 
-        [object]$Profile
+        [object]$PortProfile
     )
 
-    $ports = ($Profile.ports | ForEach-Object { [string]$_ }) -join ','
+    $ports = ($PortProfile.ports | ForEach-Object { [string]$_ }) -join ','
     $command = "nmap -p $ports --open -iL $TargetFile -oX $OutputFile"
 
     return [pscustomobject]@{
@@ -106,15 +109,15 @@ function New-CybernetScannerCommands {
         $PortProfilePath = Join-Path $repoRoot 'Config/cybernet-port-profile.json'
     }
 
-    $profile = Get-CybernetPortProfile -ProfilePath $PortProfilePath
+    $portProfile = Get-CybernetPortProfile -ProfilePath $PortProfilePath
 
     $naabuOut = Join-Path $SurveyOutDir 'CybernetSurvey_Naabu.jsonl'
     $nmapSnOut = Join-Path $SurveyOutDir 'CybernetSurvey_NmapHostDiscovery.xml'
     $nmapPortOut = Join-Path $SurveyOutDir 'CybernetSurvey_NmapPorts.xml'
 
     return @(
-        (New-CybernetNaabuCommand -TargetFile $TargetFile -OutputFile $naabuOut -Profile $profile)
+        (New-CybernetNaabuCommand -TargetFile $TargetFile -OutputFile $naabuOut -PortProfile $portProfile)
         (New-CybernetNmapHostDiscoveryCommand -TargetFile $TargetFile -OutputFile $nmapSnOut)
-        (New-CybernetNmapSelectedPortCommand -TargetFile $TargetFile -OutputFile $nmapPortOut -Profile $profile)
+        (New-CybernetNmapSelectedPortCommand -TargetFile $TargetFile -OutputFile $nmapPortOut -PortProfile $portProfile)
     )
 }

--- a/probe/packet-expenditure/README.md
+++ b/probe/packet-expenditure/README.md
@@ -1,12 +1,17 @@
-# Packet expenditure / naabu evidence normalizer (stdlib-only v1)
+# Packet expenditure / naabu evidence tooling
 
-This module normalizes naabu TXT/JSON and followup JSONL into unified JSONL + summary JSON.
-Bash field execution uses `survey/sas-run-naabu-pipeline.sh`; this Go tool is for post-run consolidation.
+This module contains stdlib-only Go helpers for low-noise Naabu evidence:
+
+- `sas-naabu-normalize` normalizes naabu TXT/JSON and followup JSONL into unified JSONL + summary JSON.
+- `sas-packet-probe` is an enforced Naabu CLI wrapper for approved host files. It records
+  `-ec -silent -json -duc -tp 1000 -c 50 -rate 3000 -ss -pt 20` in the audit string and
+  rejects empty, CIDR, oversized, or public-IP target lists unless explicitly allowed.
 
 ## Build
 
 ```bash
 go build -o ../../bin/sas-naabu-normalize ./cmd/sas-naabu-normalize
+go build -o ../../bin/sas-packet-probe ./cmd/sas-packet-probe
 ```
 
 ## Usage
@@ -17,6 +22,13 @@ bin/sas-naabu-normalize \
   -followup logs/nmap/SSUH_keyports_followup.jsonl \
   -out logs/nmap/SSUH_keyports_normalized.jsonl \
   -summary logs/nmap/SSUH_keyports_summary.json
+
+bash ../../survey/sas-run-packet-probe.sh \
+  --site SSUH \
+  --list ../../survey/fixtures/naabu_pipeline/targets.sample.txt \
+  --out ../../logs/nmap/SSUH_packet_probe.json \
+  --summary ../../logs/nmap/SSUH_packet_probe.summary.json \
+  --dry-run
 ```
 
 ## Prerequisites (naabu CLI scanning)
@@ -31,9 +43,11 @@ bin/sas-naabu-normalize \
 
 Default profile `keyports_cybernet_json` uses `-p 80,443,135,445,3389,5985,5986 -ec -silent -duc -json`. Full port `-p - -ec` (`allports_low_noise_json`) requires `--allow-full-ports`.
 
-## Future Go packet probe lane (`feature/packet-expenditure-naabu-probe`)
+## Packet probe doctrine
 
-When merging the Go `sas-packet-probe` runner (naabu library wrapper), the profile **must** include `excludeCdn: true` mapped to Naabu `ExcludeCDN` / CLI `-ec`. The audit CLI string must record `-ec -silent -json -duc`. Top-1000 (`-tp 1000`) scans require the same small-list and `--allow-full-ports`-style gates as `allports_low_noise_json`.
+`Config/cybernet-packet-profile.json` must keep `excludeCdn: true`, `output.silent: true`,
+JSON output, update-check disabled, and smart scan mutually exclusive with stream/passive modes.
+The Bash wrapper is the field entrypoint; CI uses dry-run and unit tests only, never live scans.
 
 ## WAB note
 

--- a/probe/packet-expenditure/cmd/sas-packet-probe/main.go
+++ b/probe/packet-expenditure/cmd/sas-packet-probe/main.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type profile struct {
+	PortMode            string `json:"portMode"`
+	TopPorts            string `json:"topPorts"`
+	Ports               string `json:"ports"`
+	Threads             int    `json:"threads"`
+	Rate                int    `json:"rate"`
+	SmartScan           bool   `json:"smartScan"`
+	PredictionThreshold int    `json:"predictionThreshold"`
+	ScanType            string `json:"scanType"`
+	MaxTargets          int    `json:"maxTargets"`
+	RequireApprovedFile bool   `json:"requireApprovedTargetFile"`
+	AllowPublicTargets  bool   `json:"allowPublicTargets"`
+	ExcludeCDN          bool   `json:"excludeCdn"`
+	DisableUpdateCheck  bool   `json:"disableUpdateCheck"`
+	Stream              bool   `json:"stream"`
+	Passive             bool   `json:"passive"`
+	Output              output `json:"output"`
+}
+
+type output struct {
+	JSONL  bool `json:"jsonl"`
+	Silent bool `json:"silent"`
+}
+
+type summary struct {
+	Classification        string `json:"classification"`
+	GeneratedAt           string `json:"generated_at"`
+	Site                  string `json:"site,omitempty"`
+	TargetCount           int    `json:"target_count"`
+	Output                string `json:"output"`
+	AuditCommand          string `json:"audit_command"`
+	TopPorts              string `json:"topPorts,omitempty"`
+	Ports                 string `json:"ports,omitempty"`
+	Threads               int    `json:"threads"`
+	Rate                  int    `json:"rate"`
+	SmartScan             bool   `json:"smartScan"`
+	PredictionThreshold   int    `json:"predictionThreshold"`
+	ExcludeCDN            bool   `json:"excludeCdn"`
+	Silent                bool   `json:"silent"`
+	JSON                  bool   `json:"json"`
+	DisableUpdateCheck    bool   `json:"disableUpdateCheck"`
+	DryRun                bool   `json:"dryRun"`
+	EnvironmentBlockCause string `json:"environment_block_cause,omitempty"`
+}
+
+func defaultProfilePath() string {
+	return filepath.Clean(filepath.Join("Config", "cybernet-packet-profile.json"))
+}
+
+func loadProfile(path string) (profile, error) {
+	var p profile
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return p, err
+	}
+	if err := json.Unmarshal(data, &p); err != nil {
+		return p, err
+	}
+	if p.MaxTargets == 0 {
+		p.MaxTargets = 256
+	}
+	return p, validateProfile(p)
+}
+
+func validateProfile(p profile) error {
+	if p.Stream && p.SmartScan {
+		return errors.New("smartScan cannot be combined with stream mode")
+	}
+	if p.Passive && p.SmartScan {
+		return errors.New("smartScan cannot be combined with passive mode")
+	}
+	if !p.ExcludeCDN {
+		return errors.New("excludeCdn must be true for packet-probe profiles")
+	}
+	if !p.Output.Silent {
+		return errors.New("output.silent must be true")
+	}
+	if !p.Output.JSONL {
+		return errors.New("output.jsonl must be true")
+	}
+	if p.PortMode == "" {
+		return errors.New("portMode is required")
+	}
+	switch p.PortMode {
+	case "top":
+		if p.TopPorts == "" {
+			return errors.New("top port mode requires topPorts")
+		}
+	case "explicit":
+		if p.Ports == "" {
+			return errors.New("explicit port mode requires ports")
+		}
+	default:
+		return fmt.Errorf("unsupported portMode: %s", p.PortMode)
+	}
+	if p.Threads <= 0 || p.Rate <= 0 {
+		return errors.New("threads and rate must be positive")
+	}
+	if p.SmartScan && (p.PredictionThreshold < 0 || p.PredictionThreshold > 100) {
+		return errors.New("predictionThreshold must be 0-100")
+	}
+	return nil
+}
+
+func loadTargets(path string, maxTargets int, allowPublic bool) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var targets []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(strings.SplitN(sc.Text(), "#", 2)[0])
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "/") {
+			return nil, fmt.Errorf("target list must not contain CIDR lines: %s", line)
+		}
+		if ip := net.ParseIP(line); ip != nil && !allowPublic && !isApprovedLocalIP(ip) {
+			return nil, fmt.Errorf("public target requires explicit allow-public gate: %s", line)
+		}
+		targets = append(targets, line)
+		if len(targets) > maxTargets {
+			return nil, fmt.Errorf("target count %d exceeds maxTargets %d", len(targets), maxTargets)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, errors.New("target list is empty")
+	}
+	return targets, nil
+}
+
+func isApprovedLocalIP(ip net.IP) bool {
+	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()
+}
+
+func buildNaabuArgs(list, out string, p profile) []string {
+	args := []string{"-list", list}
+	if p.PortMode == "top" {
+		args = append(args, "-tp", p.TopPorts)
+	} else {
+		args = append(args, "-p", p.Ports)
+	}
+	args = append(args, "-c", strconv.Itoa(p.Threads), "-rate", strconv.Itoa(p.Rate))
+	if p.SmartScan {
+		args = append(args, "-ss", "-pt", strconv.Itoa(p.PredictionThreshold))
+	}
+	if p.ExcludeCDN {
+		args = append(args, "-ec")
+	}
+	if p.Output.Silent {
+		args = append(args, "-silent")
+	}
+	if p.Output.JSONL {
+		args = append(args, "-json")
+	}
+	if p.DisableUpdateCheck {
+		args = append(args, "-duc")
+	}
+	args = append(args, "-o", out)
+	return args
+}
+
+func auditCommand(args []string) string {
+	quoted := make([]string, 0, len(args)+1)
+	quoted = append(quoted, "naabu")
+	for _, arg := range args {
+		if strings.ContainsAny(arg, " \t") {
+			quoted = append(quoted, strconv.Quote(arg))
+		} else {
+			quoted = append(quoted, arg)
+		}
+	}
+	return strings.Join(quoted, " ")
+}
+
+func writeSummary(path string, s summary) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func findNaabu(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if p, err := exec.LookPath("naabu.exe"); err == nil {
+		return p, nil
+	}
+	if p, err := exec.LookPath("naabu"); err == nil {
+		return p, nil
+	}
+	local := filepath.Join("bin", "naabu.exe")
+	if _, err := os.Stat(local); err == nil {
+		return local, nil
+	}
+	return "", errors.New("naabu not found; run survey/sas-ensure-naabu.sh or pass -naabu")
+}
+
+func main() {
+	list := flag.String("list", "", "approved target file (one IP/hostname per line)")
+	out := flag.String("out", "", "naabu JSONL output path")
+	summaryPath := flag.String("summary", "", "summary JSON output path")
+	profilePath := flag.String("profile", defaultProfilePath(), "packet profile JSON path")
+	site := flag.String("site", "", "site label")
+	dryRun := flag.Bool("dry-run", false, "print planned command and write summary; no packets")
+	verbose := flag.Bool("verbose", false, "print resolved decisions to stderr")
+	allowPublic := flag.Bool("allow-public", false, "permit public IP targets")
+	naabuPath := flag.String("naabu", "", "naabu binary path")
+	flag.Parse()
+
+	if *list == "" || *out == "" {
+		fmt.Fprintln(os.Stderr, "usage: sas-packet-probe -list PATH -out PATH [-summary PATH] [-site SITE] [-dry-run]")
+		os.Exit(2)
+	}
+
+	p, err := loadProfile(*profilePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load profile: %v\n", err)
+		os.Exit(1)
+	}
+	targets, err := loadTargets(*list, p.MaxTargets, p.AllowPublicTargets || *allowPublic)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load targets: %v\n", err)
+		os.Exit(1)
+	}
+	args := buildNaabuArgs(*list, *out, p)
+	audit := auditCommand(args)
+	now := time.Now().UTC().Format(time.RFC3339)
+	s := summary{
+		Classification:      "OK_NAABU_PACKET_PROBE_PLANNED",
+		GeneratedAt:         now,
+		Site:                *site,
+		TargetCount:         len(targets),
+		Output:              *out,
+		AuditCommand:        audit,
+		TopPorts:            p.TopPorts,
+		Ports:               p.Ports,
+		Threads:             p.Threads,
+		Rate:                p.Rate,
+		SmartScan:           p.SmartScan,
+		PredictionThreshold: p.PredictionThreshold,
+		ExcludeCDN:          p.ExcludeCDN,
+		Silent:              p.Output.Silent,
+		JSON:                p.Output.JSONL,
+		DisableUpdateCheck:  p.DisableUpdateCheck,
+		DryRun:              *dryRun,
+	}
+	if *dryRun {
+		fmt.Println(audit)
+		if err := writeSummary(*summaryPath, s); err != nil {
+			fmt.Fprintf(os.Stderr, "write summary: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	bin, err := findNaabu(*naabuPath)
+	if err != nil {
+		s.Classification = "ENVIRONMENT_BLOCKED_POLICY"
+		s.EnvironmentBlockCause = err.Error()
+		_ = writeSummary(*summaryPath, s)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	if *verbose {
+		fmt.Fprintf(os.Stderr, "[sas-packet-probe] %s\n", audit)
+	}
+	if err := os.MkdirAll(filepath.Dir(*out), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "mkdir output: %v\n", err)
+		os.Exit(1)
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		s.Classification = "NAABU_PACKET_PROBE_FAILED"
+		_ = writeSummary(*summaryPath, s)
+		fmt.Fprintf(os.Stderr, "naabu failed: %v\n", err)
+		os.Exit(1)
+	}
+	s.Classification = "OK_NAABU_PACKET_PROBE"
+	if err := writeSummary(*summaryPath, s); err != nil {
+		fmt.Fprintf(os.Stderr, "write summary: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/probe/packet-expenditure/cmd/sas-packet-probe/main_test.go
+++ b/probe/packet-expenditure/cmd/sas-packet-probe/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBuildNaabuArgsPreservesDoctrineFlags(t *testing.T) {
+	p := profile{
+		PortMode:            "top",
+		TopPorts:            "1000",
+		Threads:             50,
+		Rate:                3000,
+		SmartScan:           true,
+		PredictionThreshold: 20,
+		ExcludeCDN:          true,
+		DisableUpdateCheck:  true,
+		Output:              output{JSONL: true, Silent: true},
+	}
+	cmd := auditCommand(buildNaabuArgs("targets.txt", "results.json", p))
+	for _, want := range []string{"-list targets.txt", "-tp 1000", "-c 50", "-rate 3000", "-ss", "-pt 20", "-ec", "-silent", "-json", "-duc", "-o results.json"} {
+		if !strings.Contains(cmd, want) {
+			t.Fatalf("audit command missing %q: %s", want, cmd)
+		}
+	}
+}
+
+func TestValidateProfileRejectsUnsafeSmartScanModes(t *testing.T) {
+	p := profile{
+		PortMode:            "top",
+		TopPorts:            "1000",
+		Threads:             50,
+		Rate:                3000,
+		SmartScan:           true,
+		PredictionThreshold: 20,
+		ExcludeCDN:          true,
+		Output:              output{JSONL: true, Silent: true},
+		Stream:              true,
+	}
+	if err := validateProfile(p); err == nil {
+		t.Fatal("expected stream + smartScan rejection")
+	}
+	p.Stream = false
+	p.Passive = true
+	if err := validateProfile(p); err == nil {
+		t.Fatal("expected passive + smartScan rejection")
+	}
+}
+
+func TestValidateProfileRequiresCdnAndSilentJson(t *testing.T) {
+	p := profile{PortMode: "top", TopPorts: "1000", Threads: 50, Rate: 3000, Output: output{JSONL: true, Silent: true}}
+	if err := validateProfile(p); err == nil {
+		t.Fatal("expected excludeCdn rejection")
+	}
+	p.ExcludeCDN = true
+	p.Output.Silent = false
+	if err := validateProfile(p); err == nil {
+		t.Fatal("expected silent rejection")
+	}
+	p.Output.Silent = true
+	p.Output.JSONL = false
+	if err := validateProfile(p); err == nil {
+		t.Fatal("expected jsonl rejection")
+	}
+}
+
+func TestLoadTargetsRejectsEmptyCidrAndPublic(t *testing.T) {
+	if _, err := loadTargets(writeTemp(t, "empty.txt", "\n# none\n"), 10, false); err == nil {
+		t.Fatal("expected empty target rejection")
+	}
+	if _, err := loadTargets(writeTemp(t, "cidr.txt", "10.10.10.0/24\n"), 10, false); err == nil {
+		t.Fatal("expected CIDR target rejection")
+	}
+	if _, err := loadTargets(writeTemp(t, "public.txt", "8.8.8.8\n"), 10, false); err == nil {
+		t.Fatal("expected public target rejection")
+	}
+	targets, err := loadTargets(writeTemp(t, "private.txt", "10.10.10.1\nhost-a\n"), 10, false)
+	if err != nil {
+		t.Fatalf("private/hostname targets should pass: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("target count = %d, want 2", len(targets))
+	}
+}

--- a/survey/README.md
+++ b/survey/README.md
@@ -49,6 +49,8 @@ Contract test:
 bash Tests/bash/test-cybernet-subnet-survey-contracts.sh
 bash Tests/bash/test_naabu_pipeline_contracts.sh
 bash Tests/bash/test_naabu_package_contracts.sh
+bash Tests/bash/test_packet_probe_contracts.sh
+bash Tests/bash/test_repo_naabu_doctrine_conformance.sh
 ```
 
 ## Naabu CDN-Safe Pipeline
@@ -59,6 +61,10 @@ CDN/cloud-aware port confirmation using naabu `-ec -silent`. Auto-installs naabu
 bash survey/sas-run-naabu-pipeline.sh --site nsuh --profile keyports_cybernet_pipe \
   --list survey/fixtures/naabu_pipeline/targets.sample.txt \
   --out logs/nmap/nsuh_keyports.txt --pipe-followup
+
+bash survey/sas-run-packet-probe.sh --site nsuh \
+  --list survey/fixtures/naabu_pipeline/targets.sample.txt \
+  --out logs/nmap/nsuh_packet_probe.json --dry-run
 
 bash survey/sas-cybernet-subnet-survey.sh --site nsuh --mode confirm-windows \
   --confirm-tool naabu --host-file survey/output/cybernet_subnet_survey/nsuh_<run-id>/hosts/<cidr>_up.txt \

--- a/survey/sas-cybernet-subnet-survey.sh
+++ b/survey/sas-cybernet-subnet-survey.sh
@@ -417,26 +417,44 @@ mode_confirm_windows() {
       local ext="txt" followup_label="no"
       [[ "$NAABU_PROFILE" == *json* ]] && ext="json"
       out="$LOGS_ROOT/${SITE}_${safe}_windows_ports_naabu.${ext}"
-      local pipeline_args=(
-        bash survey/sas-run-naabu-pipeline.sh
-        --site "$SITE"
-        --profile "$NAABU_PROFILE"
-        --out "$out"
-        --planned-file "$PLANNED_FILE"
-        --rate "$RATE"
-      )
-      [[ -n "$NAABU_HOST" ]] && pipeline_args+=(--host "$NAABU_HOST")
-      [[ -z "$NAABU_HOST" ]] && pipeline_args+=(--list "$HOST_FILE")
-      [[ "$PIPE_FOLLOWUP" -eq 1 ]] && pipeline_args+=(--pipe-followup)
-      [[ "$ALLOW_FULL_PORTS" -eq 1 ]] && pipeline_args+=(--allow-full-ports)
-      [[ "$NAABU_PROFILE_JUSTIFIED" -eq 1 ]] && pipeline_args+=(--profile-justified)
-      [[ "$NAABU_APPROVED_SUBNET_SCOPE" -eq 1 ]] && pipeline_args+=(--approved-subnet-scope)
-      [[ "$ALLOW_PUBLIC" -eq 1 ]] && pipeline_args+=(--allow-public)
-      [[ "$DRY_RUN" -eq 1 ]] && pipeline_args+=(--dry-run)
-      if [[ "$DRY_RUN" -eq 1 ]]; then
-        log "DRY-RUN: ${pipeline_args[*]}"
+      if [[ -n "$NAABU_HOST" || "$PIPE_FOLLOWUP" -eq 1 ]]; then
+        local pipeline_args=(
+          bash survey/sas-run-naabu-pipeline.sh
+          --site "$SITE"
+          --profile "$NAABU_PROFILE"
+          --out "$out"
+          --planned-file "$PLANNED_FILE"
+          --rate "$RATE"
+        )
+        [[ -n "$NAABU_HOST" ]] && pipeline_args+=(--host "$NAABU_HOST")
+        [[ -z "$NAABU_HOST" ]] && pipeline_args+=(--list "$HOST_FILE")
+        [[ "$PIPE_FOLLOWUP" -eq 1 ]] && pipeline_args+=(--pipe-followup)
+        [[ "$ALLOW_FULL_PORTS" -eq 1 ]] && pipeline_args+=(--allow-full-ports)
+        [[ "$NAABU_PROFILE_JUSTIFIED" -eq 1 ]] && pipeline_args+=(--profile-justified)
+        [[ "$NAABU_APPROVED_SUBNET_SCOPE" -eq 1 ]] && pipeline_args+=(--approved-subnet-scope)
+        [[ "$ALLOW_PUBLIC" -eq 1 ]] && pipeline_args+=(--allow-public)
+        [[ "$DRY_RUN" -eq 1 ]] && pipeline_args+=(--dry-run)
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+          log "DRY-RUN: ${pipeline_args[*]}"
+        fi
+        (cd "$REPO_ROOT" && "${pipeline_args[@]}")
+      else
+        out="$LOGS_ROOT/${SITE}_${safe}_windows_ports_naabu.json"
+        local packet_args=(
+          bash survey/sas-run-packet-probe.sh
+          --site "$SITE"
+          --list "$HOST_FILE"
+          --out "$out"
+          --summary "${out}.summary.json"
+          --planned-file "$PLANNED_FILE"
+        )
+        [[ "$ALLOW_PUBLIC" -eq 1 ]] && packet_args+=(--allow-public)
+        [[ "$DRY_RUN" -eq 1 ]] && packet_args+=(--dry-run)
+        if [[ "$DRY_RUN" -eq 1 ]]; then
+          log "DRY-RUN: ${packet_args[*]}"
+        fi
+        (cd "$REPO_ROOT" && "${packet_args[@]}")
       fi
-      (cd "$REPO_ROOT" && "${pipeline_args[@]}")
       local followup_out csv_out
       followup_out="$(naabu_followup_path "$out")"
       csv_out="$RESOLVER_DIR/${SITE}_naabu_reachability.csv"

--- a/survey/sas-run-packet-probe.sh
+++ b/survey/sas-run-packet-probe.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Enforced low-noise Naabu packet probe wrapper. Local output only; no target writes.
+set -euo pipefail
+
+SITE=""
+LIST=""
+OUT=""
+SUMMARY=""
+PROFILE="Config/cybernet-packet-profile.json"
+PLANNED_FILE=""
+DRY_RUN=0
+VERBOSE=0
+ALLOW_PUBLIC=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash survey/sas-run-packet-probe.sh --site SITE --list PATH --out PATH [options]
+
+Runs the Go sas-packet-probe wrapper with doctrine-enforced Naabu flags:
+  -ec -silent -json -duc -tp 1000 -c 50 -rate 3000 -ss -pt 20
+
+Options:
+  --site SITE       Site label (required)
+  --list PATH       Approved target file, one host/IP per line (required)
+  --out PATH        Naabu JSONL output path (required)
+  --summary PATH    Summary JSON path. Default: OUT.summary.json
+  --profile PATH    Packet profile JSON. Default: Config/cybernet-packet-profile.json
+  --planned-file PATH
+                    Append dry-run planned command to PATH
+  --allow-public    Permit public IP targets (explicit override)
+  --dry-run         Print planned command only; no packets
+  --verbose         Print resolved probe command
+  -h, --help        Show help
+USAGE
+}
+
+fail() { printf '[packet-probe] ERROR: %s\n' "$*" >&2; exit 1; }
+log() { printf '[packet-probe] %s\n' "$*" >&2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --site) SITE="${2:?}"; shift 2 ;;
+    --list) LIST="${2:?}"; shift 2 ;;
+    --out) OUT="${2:?}"; shift 2 ;;
+    --summary) SUMMARY="${2:?}"; shift 2 ;;
+    --profile) PROFILE="${2:?}"; shift 2 ;;
+    --planned-file) PLANNED_FILE="${2:?}"; shift 2 ;;
+    --allow-public) ALLOW_PUBLIC=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --verbose) VERBOSE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$SITE" ]] || fail "--site is required"
+[[ -n "$LIST" ]] || fail "--list is required"
+[[ -n "$OUT" ]] || fail "--out is required"
+[[ -f "$LIST" ]] || fail "target list not found: $LIST"
+[[ -f "$PROFILE" ]] || fail "profile not found: $PROFILE"
+[[ -n "$SUMMARY" ]] || SUMMARY="${OUT}.summary.json"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROBE_BIN="$REPO_ROOT/bin/sas-packet-probe"
+[[ "${OS:-}" == "Windows_NT" ]] && PROBE_BIN="${PROBE_BIN}.exe"
+
+log "building sas-packet-probe"
+(cd "$REPO_ROOT/probe/packet-expenditure" && go build -o "$PROBE_BIN" ./cmd/sas-packet-probe)
+
+args=(
+  "$PROBE_BIN"
+  -site "$SITE"
+  -list "$LIST"
+  -out "$OUT"
+  -summary "$SUMMARY"
+  -profile "$PROFILE"
+)
+[[ "$ALLOW_PUBLIC" -eq 1 ]] && args+=(-allow-public)
+[[ "$DRY_RUN" -eq 1 ]] && args+=(-dry-run)
+[[ "$VERBOSE" -eq 1 ]] && args+=(-verbose)
+
+mkdir -p "$(dirname "$OUT")" "$(dirname "$SUMMARY")"
+if [[ "$DRY_RUN" -eq 1 && -n "$PLANNED_FILE" ]]; then
+  "${args[@]}" | tee -a "$PLANNED_FILE"
+else
+  "${args[@]}"
+fi


### PR DESCRIPTION
## Summary

Enforces the low-noise naabu / security doctrine **repo-wide** (not just in the retired `feature/naabu-docs-consolidation` H1 branch) and implements the Go `sas-packet-probe` lane that was previously placeholder-only on `main`.

- **Doctrine guardrails:** new section in `AGENTS.md` and a machine-readable `.cursor/rules/naabu-doctrine.mdc` — AD-derived lists are the population authority, naabu/nmap are reachability evidence only, `-ec` + `-silent` are mandatory, UDP/all-ports/public/host-discovery require explicit gates, evidence stays local, no "stealth/evasion" framing, and H1 is superseded by `main`.
- **Repo-wide conformance test:** `Tests/bash/test_repo_naabu_doctrine_conformance.sh` chains the existing naabu contract tests and audits raw `naabu -list/-host` strings across `*.md/*.sh/*.ps1/*.json/*.go` for `-silent`/`-ec`.
- **CI:** `.github/workflows/survey-doctrine.yml` runs the conformance test + `go test ./...` for the packet-expenditure module on push/PR.
- **Go `sas-packet-probe`:** enforced naabu CLI wrapper (`-ec -silent -json -duc`, smart-scan params) with empty/CIDR/public-IP/oversized-target guards and an audited dry-run command string; driven by `Config/cybernet-packet-profile.json`.
- **Field integration:** `survey/sas-run-packet-probe.sh` wired into the confirm-windows naabu host-file path of `survey/sas-cybernet-subnet-survey.sh`; `New-CybernetScannerCommand.ps1` now prefers the wrapper while preserving an equivalent naabu audit command string.
- **Docs:** H1 supersession note in `docs/NAABU_CYBERNET_PROFILES.md`; `httpx` enrichment pipe example in `docs/LOW_NOISE_SURVEY_DOCTRINE.md`.

## Test plan

- [x] `go test ./...` in `probe/packet-expenditure`
- [x] `bash Tests/bash/test_repo_naabu_doctrine_conformance.sh`
- [x] `bash Tests/bash/test_packet_probe_contracts.sh`
- [x] `bash Tests/bash/test_naabu_pipeline_contracts.sh`
- [x] Pester `Tests/Pester/CybernetSubnetDiscovery.Tests.ps1` (22/22)
- [ ] CI `Survey doctrine` workflow green on this PR
