### PR TITLE
feat(dashboard): add double-click Cybernet tutorial launcher

### DIFF
--- a/Start-CybernetSurveyTutorial.cmd
+++ b/Start-CybernetSurveyTutorial.cmd
@@ -1,0 +1,32 @@
+@echo off
+setlocal
+
+rem SysAdminSuite Cybernet Survey Tutorial Launcher
+rem Double-click this file from the repository root after cloning.
+rem It opens the local dashboard and auto-starts the Cybernet Survey tutorial.
+rem This launcher does not run Naabu, Nmap, PowerShell survey commands, credentials, or target probes.
+
+set "REPO_ROOT=%~dp0"
+set "DASHBOARD_FILE=%REPO_ROOT%dashboard\index.html"
+
+if not exist "%DASHBOARD_FILE%" (
+  echo SysAdminSuite dashboard was not found:
+  echo   %DASHBOARD_FILE%
+  echo.
+  echo Run this launcher from the cloned SysAdminSuite repository root.
+  pause
+  exit /b 1
+)
+
+set "DASHBOARD_URI="
+for /f "usebackq delims=" %%I in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$p=(Resolve-Path -LiteralPath '%DASHBOARD_FILE%').ProviderPath; ([Uri]$p).AbsoluteUri + '?tutorial=cybernet'" 2^>nul`) do set "DASHBOARD_URI=%%I"
+
+if defined DASHBOARD_URI (
+  start "" "%DASHBOARD_URI%"
+) else (
+  rem Fallback: opens the dashboard without the auto-start query flag.
+  start "" "%DASHBOARD_FILE%"
+)
+
+endlocal
+exit /b 0

--- a/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
+++ b/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cmd="$repo_root/Start-CybernetSurveyTutorial.cmd"
+index="$repo_root/dashboard/index.html"
+helper="$repo_root/dashboard/js/launch-cybernet-tutorial.js"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$cmd" ]] || fail "Start-CybernetSurveyTutorial.cmd is missing"
+[[ -f "$index" ]] || fail "dashboard/index.html is missing"
+[[ -f "$helper" ]] || fail "dashboard/js/launch-cybernet-tutorial.js is missing"
+
+grep -q "dashboard\\index.html" "$cmd" || fail "launcher does not point at dashboard\\index.html"
+grep -q "tutorial=cybernet" "$cmd" || fail "launcher does not request the Cybernet tutorial"
+grep -q "launch-cybernet-tutorial.js" "$index" || fail "dashboard index does not include tutorial launcher helper"
+grep -q "hero-start-survey" "$helper" || fail "helper does not target the existing Start Cybernet Survey button"
+grep -q "URLSearchParams" "$helper" || fail "helper does not inspect query parameters"
+
+if grep -qiE "naabu|nmap|credential|password|psexec|invoke-command" "$cmd"; then
+  fail "double-click launcher must not run survey, credential, or remote command tooling"
+fi
+
+echo "PASS: dashboard tutorial launcher contracts"

--- a/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
+++ b/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
@@ -15,13 +15,14 @@ fail() {
 [[ -f "$index" ]] || fail "dashboard/index.html is missing"
 [[ -f "$helper" ]] || fail "dashboard/js/launch-cybernet-tutorial.js is missing"
 
-grep -q "dashboard\\index.html" "$cmd" || fail "launcher does not point at dashboard\\index.html"
+grep -Fq 'dashboard\index.html' "$cmd" || fail "launcher does not point at dashboard\index.html"
 grep -q "tutorial=cybernet" "$cmd" || fail "launcher does not request the Cybernet tutorial"
 grep -q "launch-cybernet-tutorial.js" "$index" || fail "dashboard index does not include tutorial launcher helper"
 grep -q "hero-start-survey" "$helper" || fail "helper does not target the existing Start Cybernet Survey button"
 grep -q "URLSearchParams" "$helper" || fail "helper does not inspect query parameters"
 
-if grep -qiE "naabu|nmap|credential|password|psexec|invoke-command" "$cmd"; then
+# Ignore REM lines; the launcher documents that it does not run survey tooling.
+if grep -viE '^[[:space:]]*rem[[:space:]]' "$cmd" | grep -qiE 'naabu|nmap|credential|password|psexec|invoke-command'; then
   fail "double-click launcher must not run survey, credential, or remote command tooling"
 fi
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -209,5 +209,6 @@
 })();
 </script>
 <script src="js/cybernet-os-preflight.js"></script>
+<script src="js/launch-cybernet-tutorial.js"></script>
 </body>
 </html>

--- a/dashboard/js/launch-cybernet-tutorial.js
+++ b/dashboard/js/launch-cybernet-tutorial.js
@@ -1,0 +1,39 @@
+// launch-cybernet-tutorial.js
+// Opens the existing dashboard tutorial when launched with ?tutorial=cybernet.
+(function () {
+  'use strict';
+
+  function shouldStart() {
+    const params = new URLSearchParams(window.location.search || '');
+    const hash = (window.location.hash || '').toLowerCase();
+    return (params.get('tutorial') || '').toLowerCase() === 'cybernet' ||
+      (params.get('start') || '').toLowerCase() === 'cybernet' ||
+      hash === '#cybernet-tutorial' ||
+      hash === '#start-cybernet-survey';
+  }
+
+  function startTutorial(attemptsRemaining) {
+    if (!shouldStart()) return;
+
+    const startButton = document.getElementById('hero-start-survey');
+    const tutorial = document.getElementById('cybernet-tutorial');
+
+    if (startButton && tutorial) {
+      startButton.click();
+      window.setTimeout(function () {
+        tutorial.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 50);
+      return;
+    }
+
+    if (attemptsRemaining > 0) {
+      window.setTimeout(function () { startTutorial(attemptsRemaining - 1); }, 100);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { startTutorial(25); });
+  } else {
+    startTutorial(25);
+  }
+})();


### PR DESCRIPTION
## Summary

Adds a root-level Windows double-click launcher for techs after cloning the repo.

- `Start-CybernetSurveyTutorial.cmd` opens the local dashboard from the repo root
- `dashboard/js/launch-cybernet-tutorial.js` auto-starts the existing Cybernet Survey tutorial when the dashboard is opened with `?tutorial=cybernet`
- `dashboard/index.html` wires the helper after existing dashboard scripts
- `Tests/bash/test_dashboard_tutorial_launcher_contracts.sh` covers launcher wiring and confirms the launcher does not run survey/credential/remote-command tooling

## Why `.cmd`, not `.exe`

This intentionally avoids committing a binary executable. The launcher is plain text, reviewable, and double-clickable on Windows after clone.

## Scope

- No survey execution
- No Naabu/Nmap invocation
- No credentials
- No target mutation
- No generated artifacts
- No live data

## Test plan

- [ ] `bash Tests/bash/test_dashboard_tutorial_launcher_contracts.sh`
- [ ] Manual Windows smoke: double-click `Start-CybernetSurveyTutorial.cmd` from repo root and confirm dashboard opens into the Cybernet Survey tutorial

## Notes

The dashboard already contains the Cybernet Survey interface and tutorial button. This PR only adds a safer entrypoint for field users who should not have to find the correct HTML file manually.