### PR TITLE
feat(registry): add Northwell registry-first verification lane

### DIFF
--- a/.github/workflows/survey-doctrine.yml
+++ b/.github/workflows/survey-doctrine.yml
@@ -14,6 +14,7 @@ on:
       - 'survey/**'
       - 'Tests/bash/*naabu*'
       - 'Tests/bash/test_cybernet_detect_contracts.sh'
+      - 'Tests/bash/test_northwell_registry_verification_contracts.sh'
       - 'Tests/bash/test_packet_probe_contracts.sh'
       - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
       - '.github/workflows/survey-doctrine.yml'
@@ -30,6 +31,7 @@ on:
       - 'survey/**'
       - 'Tests/bash/*naabu*'
       - 'Tests/bash/test_cybernet_detect_contracts.sh'
+      - 'Tests/bash/test_northwell_registry_verification_contracts.sh'
       - 'Tests/bash/test_packet_probe_contracts.sh'
       - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
       - '.github/workflows/survey-doctrine.yml'
@@ -44,6 +46,11 @@ jobs:
         shell: bash
         run: |
           bash Tests/bash/test_repo_naabu_doctrine_conformance.sh
+
+      - name: Northwell registry verification contracts
+        shell: bash
+        run: |
+          bash Tests/bash/test_northwell_registry_verification_contracts.sh
 
       - name: Go packet expenditure tests
         shell: bash

--- a/Config/software_registry_evidence.example.json
+++ b/Config/software_registry_evidence.example.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.0",
+  "description": "Public-safe sample catalog for registry-first software installation verification. Do not place real customer package names or live evidence in this file.",
+  "software": [
+    {
+      "software_id": "sample-viewer",
+      "display_name": "Sample Viewer",
+      "registry": {
+        "uninstall_display_name_patterns": [
+          "Sample Viewer"
+        ],
+        "uninstall_publisher_patterns": [
+          "Sample Vendor"
+        ],
+        "custom_keys": [
+          {
+            "root": "HKLM",
+            "path": "SOFTWARE\\SampleVendor\\SampleViewer",
+            "value": "Version",
+            "expected_pattern": "*"
+          }
+        ]
+      },
+      "fallback": {
+        "files": [
+          {
+            "path": "C:\\Program Files\\SampleVendor\\SampleViewer\\Viewer.exe",
+            "version_min": "1.0.0"
+          }
+        ],
+        "services": [
+          {
+            "name": "SampleViewerService",
+            "required": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/Tests/bash/test_northwell_registry_verification_contracts.sh
+++ b/Tests/bash/test_northwell_registry_verification_contracts.sh
@@ -39,6 +39,18 @@ grep -q "parse_registry_install_evidence.py" "$WRAPPER" || fail "Bash wrapper mu
 grep -q "installed_registry_confirmed" "$PARSER" || fail "parser must emit installed_registry_confirmed"
 grep -q "installed_fallback_confirmed" "$PARSER" || fail "parser must emit installed_fallback_confirmed"
 grep -q "environment_blocked" "$PARSER" || fail "parser must emit environment_blocked"
+grep -q "target_from_raw_header" "$PARSER" || fail "parser must read # target= from raw evidence headers"
+grep -q "is_local_target" "$PARSER" || fail "parser must gate local fallback checks to localhost targets"
+
+runtime_files=("$CMD_HELPER" "$WRAPPER" "$PARSER")
+for f in "${runtime_files[@]}"; do
+  if grep -viE '^[[:space:]]*rem[[:space:]]' "$f" | grep -Eiq 'reg\.exe[[:space:]]+(ADD|DELETE|IMPORT|RESTORE)'; then
+    fail "forbidden reg.exe mutation verb in $f"
+  fi
+  if grep -Eiq 'Set-ItemProperty|New-ItemProperty|Remove-ItemProperty' "$f"; then
+    fail "forbidden registry mutation cmdlet in $f"
+  fi
+done
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
@@ -71,6 +83,30 @@ python3 "$PARSER" \
 [[ -f "$OUT_JSON" ]] || fail "parser did not write JSON"
 grep -q "installed_registry_confirmed" "$OUT_CSV" || fail "fixture should classify as installed_registry_confirmed"
 grep -q "registry_uninstall_key" "$OUT_CSV" || fail "fixture should label registry_uninstall_key evidence"
+grep -q "SAMPLEHOST001" "$OUT_CSV" || fail "fixture should preserve # target= from raw header"
+
+REMOTE_RAW="$TMPDIR/remote_no_install.txt"
+OUT_REMOTE_CSV="$TMPDIR/remote_install_evidence.csv"
+OUT_REMOTE_JSON="$TMPDIR/remote_install_evidence.json"
+cat > "$REMOTE_RAW" <<'EOF'
+# SysAdminSuite registry evidence raw output
+# target=REMOTEHOST001
+# software_id=sample-viewer
+# command_family=reg_query_read_only
+
+### UNINSTALL_64
+EOF
+
+python3 "$PARSER" \
+  --catalog "$CATALOG" \
+  --software-id sample-viewer \
+  --target localhost \
+  --raw "$REMOTE_RAW" \
+  --output "$OUT_REMOTE_CSV" \
+  --json "$OUT_REMOTE_JSON" >/dev/null
+
+grep -q "REMOTEHOST001" "$OUT_REMOTE_CSV" || fail "remote raw header should set target attribution"
+grep -q "not_installed" "$OUT_REMOTE_CSV" || fail "remote host without registry proof should be not_installed, not local fallback"
 
 if git -C "$ROOT" check-ignore -q survey/output/example_registry_output.csv; then
   :

--- a/Tests/bash/test_northwell_registry_verification_contracts.sh
+++ b/Tests/bash/test_northwell_registry_verification_contracts.sh
@@ -33,18 +33,12 @@ grep -q "reg.exe QUERY" "$CMD_HELPER" || fail "CMD helper must use reg.exe QUERY
 grep -q "command_family=reg_query_read_only" "$CMD_HELPER" || fail "CMD helper must label read-only command family"
 
 grep -q "cmd.exe" "$WRAPPER" || fail "Bash wrapper must call cmd.exe"
-grep -q "--fixture-raw" "$WRAPPER" || fail "Bash wrapper must support fixture raw parsing for CI"
+grep -q -- "--fixture-raw" "$WRAPPER" || fail "Bash wrapper must support fixture raw parsing for CI"
 grep -q "parse_registry_install_evidence.py" "$WRAPPER" || fail "Bash wrapper must call Python parser"
 
 grep -q "installed_registry_confirmed" "$PARSER" || fail "parser must emit installed_registry_confirmed"
 grep -q "installed_fallback_confirmed" "$PARSER" || fail "parser must emit installed_fallback_confirmed"
 grep -q "environment_blocked" "$PARSER" || fail "parser must emit environment_blocked"
-
-runtime_files=("$CMD_HELPER" "$WRAPPER" "$PARSER")
-for f in "${runtime_files[@]}"; do
-  grep -Eiq 'reg\.exe[[:space:]]+(ADD|DELETE|IMPORT|RESTORE)' "$f" && fail "forbidden reg.exe mutation verb in $f"
-  grep -Eiq 'Set-ItemProperty|New-ItemProperty|Remove-ItemProperty' "$f" && fail "forbidden registry mutation cmdlet in $f"
-done
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/Tests/bash/test_northwell_registry_verification_contracts.sh
+++ b/Tests/bash/test_northwell_registry_verification_contracts.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOC="$ROOT/docs/NORTHWELL_REGISTRY_VERIFICATION_DOCTRINE.md"
+CATALOG="$ROOT/Config/software_registry_evidence.example.json"
+CMD_HELPER="$ROOT/survey/sas-reg-query.cmd"
+WRAPPER="$ROOT/survey/sas-verify-software-install.sh"
+PARSER="$ROOT/survey/parse_registry_install_evidence.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$DOC" ]] || fail "missing doctrine doc"
+[[ -f "$CATALOG" ]] || fail "missing software evidence catalog"
+[[ -f "$CMD_HELPER" ]] || fail "missing CMD registry collector"
+[[ -f "$WRAPPER" ]] || fail "missing Bash wrapper"
+[[ -f "$PARSER" ]] || fail "missing Python parser"
+
+[[ ! -e "$ROOT/scripts/powershell/Test-SoftwareInstallEvidence.ps1" ]] || fail "new PowerShell verifier must not be added for this Northwell lane"
+
+grep -q "CMD/reg.exe" "$DOC" || fail "doctrine must identify CMD/reg.exe as the primary Northwell runtime"
+grep -q "must not attempt to suppress" "$DOC" || fail "doctrine must reject log suppression"
+grep -q "environment_blocked" "$DOC" || fail "doctrine must define environment_blocked"
+grep -q "survey/output/" "$DOC" || fail "doctrine must keep live outputs under ignored survey/output"
+
+grep -q '"software_id": "sample-viewer"' "$CATALOG" || fail "catalog must include public-safe sample-viewer"
+grep -q '"uninstall_display_name_patterns"' "$CATALOG" || fail "catalog must define uninstall display name patterns"
+
+grep -q "reg.exe QUERY" "$CMD_HELPER" || fail "CMD helper must use reg.exe QUERY"
+grep -q "command_family=reg_query_read_only" "$CMD_HELPER" || fail "CMD helper must label read-only command family"
+
+grep -q "cmd.exe" "$WRAPPER" || fail "Bash wrapper must call cmd.exe"
+grep -q "--fixture-raw" "$WRAPPER" || fail "Bash wrapper must support fixture raw parsing for CI"
+grep -q "parse_registry_install_evidence.py" "$WRAPPER" || fail "Bash wrapper must call Python parser"
+
+grep -q "installed_registry_confirmed" "$PARSER" || fail "parser must emit installed_registry_confirmed"
+grep -q "installed_fallback_confirmed" "$PARSER" || fail "parser must emit installed_fallback_confirmed"
+grep -q "environment_blocked" "$PARSER" || fail "parser must emit environment_blocked"
+
+runtime_files=("$CMD_HELPER" "$WRAPPER" "$PARSER")
+for f in "${runtime_files[@]}"; do
+  grep -Eiq 'reg\.exe[[:space:]]+(ADD|DELETE|IMPORT|RESTORE)' "$f" && fail "forbidden reg.exe mutation verb in $f"
+  grep -Eiq 'Set-ItemProperty|New-ItemProperty|Remove-ItemProperty' "$f" && fail "forbidden registry mutation cmdlet in $f"
+done
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+RAW="$TMPDIR/sample_registry_raw.txt"
+OUT_CSV="$TMPDIR/software_install_evidence.csv"
+OUT_JSON="$TMPDIR/software_install_evidence.json"
+
+cat > "$RAW" <<'EOF'
+# SysAdminSuite registry evidence raw output
+# target=SAMPLEHOST001
+# software_id=sample-viewer
+# command_family=reg_query_read_only
+
+### UNINSTALL_64
+HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\SampleViewer
+    DisplayName    REG_SZ    Sample Viewer
+    DisplayVersion    REG_SZ    1.2.3
+    Publisher    REG_SZ    Sample Vendor
+EOF
+
+python3 "$PARSER" \
+  --catalog "$CATALOG" \
+  --software-id sample-viewer \
+  --target SAMPLEHOST001 \
+  --raw "$RAW" \
+  --output "$OUT_CSV" \
+  --json "$OUT_JSON" >/dev/null
+
+[[ -f "$OUT_CSV" ]] || fail "parser did not write CSV"
+[[ -f "$OUT_JSON" ]] || fail "parser did not write JSON"
+grep -q "installed_registry_confirmed" "$OUT_CSV" || fail "fixture should classify as installed_registry_confirmed"
+grep -q "registry_uninstall_key" "$OUT_CSV" || fail "fixture should label registry_uninstall_key evidence"
+
+if git -C "$ROOT" check-ignore -q survey/output/example_registry_output.csv; then
+  :
+else
+  fail "survey/output must remain gitignored for live verification outputs"
+fi
+
+echo "PASS: Northwell registry verification contracts"

--- a/docs/NORTHWELL_REGISTRY_VERIFICATION_DOCTRINE.md
+++ b/docs/NORTHWELL_REGISTRY_VERIFICATION_DOCTRINE.md
@@ -1,0 +1,119 @@
+# Northwell Registry-First Software Verification Doctrine
+
+## Purpose
+
+This doctrine defines a Northwell-compatible software installation verification lane for SysAdminSuite.
+
+The lane augments existing working legacy tooling. It does not replace the existing PowerShell registry install-diff pipeline, Cybernet survey workflow, auto-logon assessment, or dashboard launcher.
+
+## Core Principle
+
+Software installation verification should prefer registry evidence first.
+
+Installer exit code is execution evidence. It is not proof that software is installed.
+
+A workstation is considered verified only when post-install evidence confirms the installed state.
+
+## Northwell Runtime Pivot
+
+For this lane, the primary runtime is:
+
+1. `cmd.exe` and `reg.exe` for registry reads
+2. Bash for repo-style orchestration
+3. Python for parsing and normalization
+
+PowerShell remains available in existing legacy/advanced lanes, but this lane does not add new PowerShell-first functionality.
+
+## Evidence Hierarchy
+
+| Priority | Evidence source | Authority |
+|---:|---|---|
+| 1 | Registry uninstall keys under `HKLM` 64-bit and WOW6432Node views | Primary install proof |
+| 2 | Product-specific registry keys from the software evidence catalog | Strong product-specific proof |
+| 3 | File path and version checks | Fallback proof |
+| 4 | Service existence/status checks | Fallback proof |
+| 5 | Installer exit code | Execution result only |
+| 6 | Operator note or dashboard note | Human context only |
+
+Fallback evidence is allowed, but it must be labeled as fallback.
+
+## OS and Security Logging Posture
+
+Registry queries, file checks, service checks, command execution, and process creation can naturally produce operating-system, endpoint-protection, and security telemetry.
+
+SysAdminSuite must not attempt to suppress, clear, bypass, hide, or evade that logging.
+
+Mitigation means limiting unnecessary activity and making the operator intent clear:
+
+- Use approved target manifests only.
+- Query only the keys and fallback paths needed for the selected software ID.
+- Prefer local or small approved batches before broader use.
+- Do not run live checks from CI.
+- Do not use credentials in this lane.
+- Do not mutate target workstations.
+- Do not write registry values.
+- Do not run installers from this verification lane.
+- Keep raw live evidence under gitignored output paths.
+- Label environment blocks honestly instead of calling them product failures.
+
+This lane is designed for transparent, low-noise verification discipline. It is not a log-suppression or evasion mechanism.
+
+## Status Values
+
+| Status | Meaning |
+|---|---|
+| `installed_registry_confirmed` | Registry evidence confirms the software is installed. |
+| `installed_registry_partial` | Some registry evidence exists, but it is incomplete or ambiguous. |
+| `installed_fallback_confirmed` | Registry proof is missing, but fallback file/service evidence indicates installation. |
+| `not_installed` | No registry or fallback evidence confirms installation. |
+| `ambiguous` | Conflicting or duplicate evidence requires review. |
+| `verification_failed` | The verification logic failed for a tool/runtime reason. |
+| `environment_blocked` | The environment blocked evidence collection, such as network, permission, policy, or remote registry access. |
+
+## Evidence Strength Values
+
+| Evidence strength | Meaning |
+|---|---|
+| `registry_uninstall_key` | Match from Windows uninstall registry view. |
+| `registry_custom_key` | Match from product-specific registry key. |
+| `fallback_file` | Match from configured file path or version. |
+| `fallback_service` | Match from configured service query. |
+| `none` | No confirming evidence found. |
+
+## Live Evidence Policy
+
+Do not commit live outputs.
+
+The following are local/gitignored evidence only:
+
+- raw `reg.exe` output
+- normalized CSV/JSON summaries from live machines
+- target manifests containing real hostnames
+- generated dashboards
+- workstation names, IPs, MACs, serials, AD exports, or location-specific artifacts
+
+Recommended live output roots:
+
+- `survey/output/`
+- `logs/registry/`
+- `logs/targets/`
+
+## Relationship to Existing Registry Install Diff
+
+The existing registry install-diff pipeline remains useful for before/after snapshots and deeper localhost analysis.
+
+This Northwell lane is different:
+
+- It is CMD/reg.exe-first.
+- It is verification-focused, not install-diff-focused.
+- It does not execute installers.
+- It does not require PowerShell.
+- It labels fallback evidence clearly.
+
+Both lanes can coexist.
+
+## Safe Operating Rule
+
+Use the least necessary check to answer the install-state question.
+
+When the environment blocks evidence collection, report `environment_blocked` and stop. Do not broaden the check or reframe the result as a software failure.

--- a/survey/parse_registry_install_evidence.py
+++ b/survey/parse_registry_install_evidence.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Parse CMD/reg.exe software installation evidence.
+
+This parser is intentionally read-only. It consumes raw evidence files and a
+public-safe software evidence catalog, then emits normalized CSV/JSON results.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import fnmatch
+import json
+import re
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class EvidenceResult:
+    target: str
+    software_id: str
+    status: str
+    evidence_strength: str
+    evidence_source: str
+    display_name: str = ""
+    display_version: str = ""
+    publisher: str = ""
+    detail: str = ""
+    revisit_recommendation: str = ""
+
+
+def load_catalog(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def find_software(catalog: dict[str, Any], software_id: str) -> dict[str, Any]:
+    for item in catalog.get("software", []):
+        if item.get("software_id") == software_id:
+            return item
+    raise SystemExit(f"software_id not found in catalog: {software_id}")
+
+
+def parse_reg_blocks(text: str) -> list[dict[str, str]]:
+    blocks: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for raw in text.splitlines():
+        line = raw.rstrip("\r\n")
+        if re.match(r"^(HKEY_|HKLM|\\\\[^\\]+\\HKLM)", line.strip(), re.IGNORECASE):
+            if current:
+                blocks.append(current)
+            current = {"__key": line.strip()}
+            continue
+        if current is None:
+            continue
+        match = re.match(r"^\s{2,}([^\s].*?)\s+REG_\w+\s+(.*)$", line)
+        if match:
+            current[match.group(1).strip()] = match.group(2).strip()
+    if current:
+        blocks.append(current)
+    return blocks
+
+
+def any_pattern(value: str, patterns: list[str]) -> bool:
+    normalized = value or ""
+    for pattern in patterns:
+        if fnmatch.fnmatch(normalized.lower(), pattern.lower()):
+            return True
+        if pattern.lower() in normalized.lower():
+            return True
+    return False
+
+
+def registry_match(blocks: list[dict[str, str]], software: dict[str, Any]) -> tuple[str, dict[str, str] | None, str]:
+    registry = software.get("registry", {})
+    name_patterns = registry.get("uninstall_display_name_patterns", [])
+    publisher_patterns = registry.get("uninstall_publisher_patterns", [])
+
+    partial: dict[str, str] | None = None
+    for block in blocks:
+        name = block.get("DisplayName", "")
+        publisher = block.get("Publisher", "")
+        name_ok = bool(name_patterns) and any_pattern(name, name_patterns)
+        publisher_ok = not publisher_patterns or any_pattern(publisher, publisher_patterns)
+        if name_ok and publisher_ok:
+            return "confirmed", block, "registry_uninstall_key"
+        if name_ok or (publisher_patterns and any_pattern(publisher, publisher_patterns)):
+            partial = block
+    if partial:
+        return "partial", partial, "registry_uninstall_key"
+    return "none", None, "none"
+
+
+def fallback_file_check(software: dict[str, Any]) -> tuple[bool, str]:
+    for item in software.get("fallback", {}).get("files", []):
+        path = item.get("path", "")
+        if path and Path(path).exists():
+            return True, path
+    return False, ""
+
+
+def classify(target: str, software_id: str, software: dict[str, Any], raw_path: Path) -> EvidenceResult:
+    try:
+        text = raw_path.read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:
+        return EvidenceResult(
+            target=target,
+            software_id=software_id,
+            status="verification_failed",
+            evidence_strength="none",
+            evidence_source=str(raw_path),
+            detail=str(exc),
+            revisit_recommendation="Verify raw evidence path and permissions.",
+        )
+
+    lower = text.lower()
+    if "access is denied" in lower or "network path was not found" in lower or "unable to find" in lower:
+        return EvidenceResult(
+            target=target,
+            software_id=software_id,
+            status="environment_blocked",
+            evidence_strength="none",
+            evidence_source=str(raw_path),
+            detail="Registry evidence collection was blocked by environment, access, network, or policy.",
+            revisit_recommendation="Retry only from an authorized segment with approved access. Do not reclassify as product failure.",
+        )
+
+    blocks = parse_reg_blocks(text)
+    match_state, block, strength = registry_match(blocks, software)
+    if match_state == "confirmed" and block:
+        return EvidenceResult(
+            target=target,
+            software_id=software_id,
+            status="installed_registry_confirmed",
+            evidence_strength=strength,
+            evidence_source=block.get("__key", str(raw_path)),
+            display_name=block.get("DisplayName", ""),
+            display_version=block.get("DisplayVersion", ""),
+            publisher=block.get("Publisher", ""),
+            detail="Registry uninstall evidence matched catalog patterns.",
+            revisit_recommendation="None.",
+        )
+    if match_state == "partial" and block:
+        return EvidenceResult(
+            target=target,
+            software_id=software_id,
+            status="installed_registry_partial",
+            evidence_strength=strength,
+            evidence_source=block.get("__key", str(raw_path)),
+            display_name=block.get("DisplayName", ""),
+            display_version=block.get("DisplayVersion", ""),
+            publisher=block.get("Publisher", ""),
+            detail="Registry evidence partially matched catalog patterns.",
+            revisit_recommendation="Review catalog patterns or product naming.",
+        )
+
+    fallback_ok, fallback_path = fallback_file_check(software)
+    if fallback_ok:
+        return EvidenceResult(
+            target=target,
+            software_id=software_id,
+            status="installed_fallback_confirmed",
+            evidence_strength="fallback_file",
+            evidence_source=fallback_path,
+            detail="Registry proof missing; configured fallback file exists on the current machine.",
+            revisit_recommendation="Treat as fallback evidence; confirm registry catalog if possible.",
+        )
+
+    return EvidenceResult(
+        target=target,
+        software_id=software_id,
+        status="not_installed",
+        evidence_strength="none",
+        evidence_source=str(raw_path),
+        detail="No registry or fallback evidence matched catalog.",
+        revisit_recommendation="Install through approved deployment process, then re-run verification.",
+    )
+
+
+def write_csv(rows: list[EvidenceResult], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(asdict(rows[0]).keys()))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(asdict(row))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--catalog", required=True)
+    parser.add_argument("--software-id", required=True)
+    parser.add_argument("--raw", required=True, nargs="+", help="Raw reg.exe evidence files")
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--json", required=True)
+    parser.add_argument("--target", default="localhost")
+    args = parser.parse_args()
+
+    catalog = load_catalog(Path(args.catalog))
+    software = find_software(catalog, args.software_id)
+    rows = [classify(args.target, args.software_id, software, Path(raw)) for raw in args.raw]
+
+    out_csv = Path(args.output)
+    out_json = Path(args.json)
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    write_csv(rows, out_csv)
+    out_json.write_text(json.dumps([asdict(row) for row in rows], indent=2), encoding="utf-8")
+    print(str(out_csv))
+    print(str(out_json))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/survey/parse_registry_install_evidence.py
+++ b/survey/parse_registry_install_evidence.py
@@ -92,7 +92,22 @@ def registry_match(blocks: list[dict[str, str]], software: dict[str, Any]) -> tu
     return "none", None, "none"
 
 
-def fallback_file_check(software: dict[str, Any]) -> tuple[bool, str]:
+def is_local_target(target: str) -> bool:
+    normalized = (target or "").strip().lower()
+    return normalized in {"", "localhost", ".", "127.0.0.1"}
+
+
+def target_from_raw_header(text: str) -> str | None:
+    for line in text.splitlines()[:30]:
+        match = re.match(r"^#\s*target=(.+)$", line.strip(), re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+def fallback_file_check(software: dict[str, Any], *, allow_local_fallback: bool) -> tuple[bool, str]:
+    if not allow_local_fallback:
+        return False, ""
     for item in software.get("fallback", {}).get("files", []):
         path = item.get("path", "")
         if path and Path(path).exists():
@@ -100,12 +115,12 @@ def fallback_file_check(software: dict[str, Any]) -> tuple[bool, str]:
     return False, ""
 
 
-def classify(target: str, software_id: str, software: dict[str, Any], raw_path: Path) -> EvidenceResult:
+def classify(default_target: str, software_id: str, software: dict[str, Any], raw_path: Path) -> EvidenceResult:
     try:
         text = raw_path.read_text(encoding="utf-8", errors="replace")
     except Exception as exc:
         return EvidenceResult(
-            target=target,
+            target=default_target,
             software_id=software_id,
             status="verification_failed",
             evidence_strength="none",
@@ -113,6 +128,9 @@ def classify(target: str, software_id: str, software: dict[str, Any], raw_path: 
             detail=str(exc),
             revisit_recommendation="Verify raw evidence path and permissions.",
         )
+
+    target = target_from_raw_header(text) or default_target
+    allow_local_fallback = is_local_target(target)
 
     lower = text.lower()
     if "access is denied" in lower or "network path was not found" in lower or "unable to find" in lower:
@@ -155,7 +173,7 @@ def classify(target: str, software_id: str, software: dict[str, Any], raw_path: 
             revisit_recommendation="Review catalog patterns or product naming.",
         )
 
-    fallback_ok, fallback_path = fallback_file_check(software)
+    fallback_ok, fallback_path = fallback_file_check(software, allow_local_fallback=allow_local_fallback)
     if fallback_ok:
         return EvidenceResult(
             target=target,
@@ -163,7 +181,7 @@ def classify(target: str, software_id: str, software: dict[str, Any], raw_path: 
             status="installed_fallback_confirmed",
             evidence_strength="fallback_file",
             evidence_source=fallback_path,
-            detail="Registry proof missing; configured fallback file exists on the current machine.",
+            detail="Registry proof missing; configured fallback file exists on the local operator machine.",
             revisit_recommendation="Treat as fallback evidence; confirm registry catalog if possible.",
         )
 
@@ -194,12 +212,15 @@ def main() -> int:
     parser.add_argument("--raw", required=True, nargs="+", help="Raw reg.exe evidence files")
     parser.add_argument("--output", required=True)
     parser.add_argument("--json", required=True)
-    parser.add_argument("--target", default="localhost")
+    parser.add_argument("--target", default="localhost", help="Default target when raw header omits # target=")
     args = parser.parse_args()
 
     catalog = load_catalog(Path(args.catalog))
     software = find_software(catalog, args.software_id)
-    rows = [classify(args.target, args.software_id, software, Path(raw)) for raw in args.raw]
+    rows = [
+        classify(args.target, args.software_id, software, Path(raw))
+        for raw in args.raw
+    ]
 
     out_csv = Path(args.output)
     out_json = Path(args.json)

--- a/survey/sas-reg-query.cmd
+++ b/survey/sas-reg-query.cmd
@@ -1,0 +1,102 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+rem SysAdminSuite Northwell registry evidence collector
+rem Read-only helper. Uses reg.exe QUERY only.
+rem This script does not install software, write registry values, use credentials, or change target state.
+
+set "TARGET=localhost"
+set "OUTPUT_DIR=survey\output\registry-evidence"
+set "SOFTWARE_ID=unspecified-software"
+set "CUSTOM_KEY="
+
+:parse
+if "%~1"=="" goto parsed
+if /I "%~1"=="--target" (
+  set "TARGET=%~2"
+  shift
+  shift
+  goto parse
+)
+if /I "%~1"=="--output-dir" (
+  set "OUTPUT_DIR=%~2"
+  shift
+  shift
+  goto parse
+)
+if /I "%~1"=="--software-id" (
+  set "SOFTWARE_ID=%~2"
+  shift
+  shift
+  goto parse
+)
+if /I "%~1"=="--custom-key" (
+  set "CUSTOM_KEY=%~2"
+  shift
+  shift
+  goto parse
+)
+if /I "%~1"=="-h" goto usage
+if /I "%~1"=="--help" goto usage
+echo [sas-reg-query] ERROR: unknown argument %~1 1>&2
+exit /b 2
+
+:usage
+echo SysAdminSuite registry evidence collector
+echo.
+echo Usage:
+echo   survey\sas-reg-query.cmd --target HOST --software-id sample-viewer --output-dir survey\output\registry-evidence
+echo.
+echo Safety:
+echo   Read-only. Uses reg.exe QUERY only. Does not install software or modify registry.
+exit /b 0
+
+:parsed
+if "%TARGET%"=="" set "TARGET=localhost"
+if "%SOFTWARE_ID%"=="" set "SOFTWARE_ID=unspecified-software"
+if not exist "%OUTPUT_DIR%" mkdir "%OUTPUT_DIR%" >nul 2>nul
+
+set "SAFE_TARGET=%TARGET%"
+set "SAFE_TARGET=%SAFE_TARGET:\=_%"
+set "SAFE_TARGET=%SAFE_TARGET:/=_%"
+set "SAFE_TARGET=%SAFE_TARGET::=_%"
+set "SAFE_TARGET=%SAFE_TARGET: =_%"
+
+set "SAFE_SOFTWARE=%SOFTWARE_ID%"
+set "SAFE_SOFTWARE=%SAFE_SOFTWARE:\=_%"
+set "SAFE_SOFTWARE=%SAFE_SOFTWARE:/=_%"
+set "SAFE_SOFTWARE=%SAFE_SOFTWARE::=_%"
+set "SAFE_SOFTWARE=%SAFE_SOFTWARE: =_%"
+
+set "OUT=%OUTPUT_DIR%\%SAFE_TARGET%_%SAFE_SOFTWARE%_registry_raw.txt"
+
+if /I "%TARGET%"=="localhost" (
+  set "ROOT=HKLM"
+) else if /I "%TARGET%"=="." (
+  set "ROOT=HKLM"
+) else (
+  set "ROOT=\\%TARGET%\HKLM"
+)
+
+> "%OUT%" echo # SysAdminSuite registry evidence raw output
+>> "%OUT%" echo # target=%TARGET%
+>> "%OUT%" echo # software_id=%SOFTWARE_ID%
+>> "%OUT%" echo # command_family=reg_query_read_only
+>> "%OUT%" echo # note=OS and endpoint telemetry may record this read-only query activity.
+>> "%OUT%" echo.
+
+>> "%OUT%" echo ### UNINSTALL_64
+reg.exe QUERY "%ROOT%\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" /s >> "%OUT%" 2>>&1
+>> "%OUT%" echo.
+>> "%OUT%" echo ### UNINSTALL_32
+reg.exe QUERY "%ROOT%\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall" /s >> "%OUT%" 2>>&1
+
+if not "%CUSTOM_KEY%"=="" (
+  >> "%OUT%" echo.
+  >> "%OUT%" echo ### CUSTOM_KEY
+  reg.exe QUERY "%ROOT%\%CUSTOM_KEY%" /s >> "%OUT%" 2>>&1
+)
+
+echo %OUT%
+endlocal
+exit /b 0

--- a/survey/sas-verify-software-install.sh
+++ b/survey/sas-verify-software-install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANIFEST=""
+SOFTWARE_ID=""
+CATALOG="Config/software_registry_evidence.example.json"
+OUTPUT="survey/output/software_install_evidence.csv"
+JSON_OUT="survey/output/software_install_evidence.json"
+RAW_DIR="survey/output/registry-evidence"
+TARGET="localhost"
+FIXTURE_RAW=""
+
+usage() {
+  cat <<'USAGE'
+SysAdminSuite Northwell registry-first software verification
+
+Usage:
+  bash survey/sas-verify-software-install.sh --software-id sample-viewer [options]
+
+Options:
+  --software-id ID       Software ID from catalog (required)
+  --catalog PATH         Evidence catalog JSON
+  --target HOST          Single target, default localhost
+  --manifest PATH        Approved target manifest with HostName/Target column
+  --raw-dir PATH         Raw reg.exe output directory
+  --fixture-raw PATH     Parse an existing raw fixture instead of running cmd.exe
+  --output PATH          CSV output path
+  --json PATH            JSON output path
+  -h, --help             Show help
+
+Safety:
+  Read-only verification. Uses CMD/reg.exe QUERY via survey/sas-reg-query.cmd unless --fixture-raw is supplied.
+  Does not run installers, use credentials, modify registry, or change target state.
+USAGE
+}
+
+fail() { echo "[sas-verify-software-install] ERROR: $*" >&2; exit 1; }
+log() { echo "[sas-verify-software-install] $*" >&2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --software-id) SOFTWARE_ID="${2:?missing --software-id value}"; shift 2 ;;
+    --catalog) CATALOG="${2:?missing --catalog value}"; shift 2 ;;
+    --target) TARGET="${2:?missing --target value}"; shift 2 ;;
+    --manifest) MANIFEST="${2:?missing --manifest value}"; shift 2 ;;
+    --raw-dir) RAW_DIR="${2:?missing --raw-dir value}"; shift 2 ;;
+    --fixture-raw) FIXTURE_RAW="${2:?missing --fixture-raw value}"; shift 2 ;;
+    --output) OUTPUT="${2:?missing --output value}"; shift 2 ;;
+    --json) JSON_OUT="${2:?missing --json value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$SOFTWARE_ID" ]] || fail "--software-id is required"
+[[ -f "$CATALOG" ]] || fail "Catalog not found: $CATALOG"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+
+mkdir -p "$RAW_DIR" "$(dirname "$OUTPUT")" "$(dirname "$JSON_OUT")"
+
+raw_files=()
+targets=()
+
+if [[ -n "$MANIFEST" ]]; then
+  [[ -f "$MANIFEST" ]] || fail "Manifest not found: $MANIFEST"
+  mapfile -t targets < <(python3 - "$MANIFEST" <<'PY'
+import csv, sys
+path = sys.argv[1]
+with open(path, newline='', encoding='utf-8-sig') as handle:
+    for row in csv.DictReader(handle):
+        for key in ('HostName','Hostname','Target','ComputerName','Name'):
+            value = (row.get(key) or '').strip()
+            if value:
+                print(value)
+                break
+PY
+)
+else
+  targets=("$TARGET")
+fi
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+  fail "No targets resolved. Use --target or a manifest with HostName/Target column."
+fi
+
+if [[ -n "$FIXTURE_RAW" ]]; then
+  [[ -f "$FIXTURE_RAW" ]] || fail "Fixture raw file not found: $FIXTURE_RAW"
+  raw_files+=("$FIXTURE_RAW")
+else
+  if ! command -v cmd.exe >/dev/null 2>&1; then
+    fail "cmd.exe is required unless --fixture-raw is supplied"
+  fi
+  for target in "${targets[@]}"; do
+    log "Collecting read-only registry evidence for $target"
+    raw_path=$(cmd.exe /c survey\\sas-reg-query.cmd --target "$target" --software-id "$SOFTWARE_ID" --output-dir "${RAW_DIR//\//\\}" | tr -d '\r' | tail -n 1)
+    [[ -n "$raw_path" ]] || fail "Registry collector did not return an output path for $target"
+    raw_files+=("$raw_path")
+  done
+fi
+
+python3 survey/parse_registry_install_evidence.py \
+  --catalog "$CATALOG" \
+  --software-id "$SOFTWARE_ID" \
+  --target "${targets[0]}" \
+  --raw "${raw_files[@]}" \
+  --output "$OUTPUT" \
+  --json "$JSON_OUT"


### PR DESCRIPTION
## Summary

Adds a new Northwell-compatible registry-first software installation verification lane without changing the existing legacy PowerShell, Cybernet, autologon, or dashboard flows.

### Added

- `docs/NORTHWELL_REGISTRY_VERIFICATION_DOCTRINE.md`
  - registry-first doctrine
  - CMD/reg.exe as the Northwell-primary runtime
  - OS/security logging transparency
  - explicit statement that SysAdminSuite must not suppress, clear, bypass, hide, or evade natural OS/security logging
- `Config/software_registry_evidence.example.json`
  - public-safe sample software evidence catalog
- `survey/sas-reg-query.cmd`
  - read-only CMD/reg.exe collector using `reg.exe QUERY`
- `survey/sas-verify-software-install.sh`
  - Bash wrapper for CMD collection and Python normalization
- `survey/parse_registry_install_evidence.py`
  - parser for raw registry evidence into CSV/JSON verdicts
- `Tests/bash/test_northwell_registry_verification_contracts.sh`
  - contracts for doctrine, runtime shape, fixture parsing, and ignored output policy

## Runtime doctrine

- CMD/reg.exe first
- Bash orchestration second
- Python parsing third
- Existing PowerShell remains legacy/advanced only
- No installer execution
- No registry writes
- No credentials
- No target mutation
- No live execution in CI

## OS/security logging mitigation

This PR does not attempt log suppression. Mitigation is by scope and transparency:

- approved target manifests only
- read-only registry queries only
- narrow software catalog patterns
- live evidence under ignored paths
- `environment_blocked` status when access/policy/network prevents evidence collection

## Test plan

- [ ] `bash Tests/bash/test_northwell_registry_verification_contracts.sh`
- [ ] Confirm no generated outputs are staged
- [ ] Confirm no existing legacy working lanes were modified

## Notes

The first update attempt for the contract file included stronger forbidden-string scanning, but connector safety checks blocked that exact write. The committed contract still verifies the Northwell runtime pivot, fixture parser behavior, and ignored output policy. Reviewers can strengthen forbidden-pattern checks locally if desired.