### PR TITLE
fix(transport): add Git Bash ping mode for network preflight

### DIFF
--- a/bash/transport/sas-network-preflight.sh
+++ b/bash/transport/sas-network-preflight.sh
@@ -79,7 +79,7 @@ IFS=',' read -r -a PORT_ARRAY <<< "$PORTS"
 
 win_ping_cmd(){
   local candidate
-  for candidate in /c/Windows/System32/ping.exe /mnt/c/Windows/System32/ping.exe "${WINDIR:-}/System32/ping.exe" ping.exe; do
+  for candidate in /c/Windows/System32/ping.exe "${WINDIR:-}/System32/ping.exe" ping.exe; do
     [[ -n "$candidate" && -x "$candidate" ]] && { printf '%s' "$candidate"; return; }
     if command -v "$candidate" >/dev/null 2>&1; then command -v "$candidate"; return; fi
   done
@@ -107,9 +107,9 @@ resolve_ip(){
     ip="$(nslookup "$t" 2>/dev/null | awk '/^Address: /{print $2}' | tail -n 1)"
     [[ -n "$ip" ]] && { printf '%s' "$ip"; return; }
   fi
-  if out="$(win_ping_output "$t" 2>/dev/null)"; then
-    printf '%s\n' "$out" | extract_ipv4
-    return
+  if [[ "$PING_MODE" != "linux" ]] && out="$(win_ping_output "$t" 2>/dev/null)"; then
+    ip="$(printf '%s\n' "$out" | extract_ipv4)"
+    [[ -n "$ip" ]] && { printf '%s' "$ip"; return; }
   fi
   printf ''
 }
@@ -120,8 +120,12 @@ linux_ping_status(){
 }
 
 windows_ping_status(){
-  local t="$1"
-  if win_ping_output "$t" >/dev/null 2>&1; then printf 'Reachable'; else printf 'NoPing'; fi
+  local t="$1" out
+  if out="$(win_ping_output "$t" 2>/dev/null)" && printf '%s\n' "$out" | grep -Eiq 'TTL='; then
+    printf 'Reachable'
+  else
+    printf 'NoPing'
+  fi
 }
 
 ping_status(){

--- a/bash/transport/sas-network-preflight.sh
+++ b/bash/transport/sas-network-preflight.sh
@@ -9,6 +9,7 @@ TARGET_FILE=""
 OUTPUT="bash/transport/output/network_preflight.csv"
 PORTS="135,139,445,3389,515,631,9100"
 TIMEOUT=3
+PING_MODE="${SAS_PING_MODE:-auto}"
 PASS_THRU=0
 
 usage(){ cat <<'USAGE'
@@ -23,8 +24,14 @@ Options:
   --ports CSV          TCP ports to check. Default: 135,139,445,3389,515,631,9100
   --output PATH        Output CSV path
   --timeout SEC        Per-check timeout. Default: 3
+  --ping-mode MODE     Ping implementation: auto, linux, or windows. Default: auto
   --pass-thru          Print CSV after writing
   -h, --help           Show help
+
+Ping modes:
+  auto     Try Linux-style ping first, then Windows ping.exe fallback.
+  linux    Use POSIX/Linux ping flags: -c 1 -W <timeout>.
+  windows  Use Windows ping.exe flags: -n 1 -w <timeout-ms>. Useful in Git Bash.
 
 Read-only. No remote mutation.
 USAGE
@@ -41,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     --ports) PORTS="${2:?missing value for --ports}"; shift 2 ;;
     --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
     --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
+    --ping-mode) PING_MODE="${2:?missing value for --ping-mode}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
@@ -50,6 +58,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
+case "$PING_MODE" in
+  auto|linux|windows) ;;
+  *) fail "--ping-mode must be auto, linux, or windows" ;;
+esac
 if [[ -n "$TARGET_FILE" ]]; then
   [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -65,16 +77,68 @@ mkdir -p "$(dirname "$OUTPUT")"
 
 IFS=',' read -r -a PORT_ARRAY <<< "$PORTS"
 
+win_ping_cmd(){
+  local candidate
+  for candidate in /c/Windows/System32/ping.exe /mnt/c/Windows/System32/ping.exe "${WINDIR:-}/System32/ping.exe" ping.exe; do
+    [[ -n "$candidate" && -x "$candidate" ]] && { printf '%s' "$candidate"; return; }
+    if command -v "$candidate" >/dev/null 2>&1; then command -v "$candidate"; return; fi
+  done
+  return 1
+}
+
+win_ping_output(){
+  local target="$1" cmd
+  cmd="$(win_ping_cmd 2>/dev/null || true)"
+  [[ -n "$cmd" ]] || return 1
+  "$cmd" -n 1 -w "$(( TIMEOUT * 1000 ))" "$target" 2>&1
+}
+
+extract_ipv4(){
+  grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | head -n1 || true
+}
+
 resolve_ip(){
-  local t="$1"
-  if has_cmd getent; then getent ahostsv4 "$t" 2>/dev/null | awk 'NR==1{print $1; exit}'; return; fi
-  if has_cmd nslookup; then nslookup "$t" 2>/dev/null | awk '/^Address: /{print $2}' | tail -n 1; return; fi
+  local t="$1" out ip
+  if has_cmd getent; then
+    ip="$(getent ahostsv4 "$t" 2>/dev/null | awk 'NR==1{print $1; exit}')"
+    [[ -n "$ip" ]] && { printf '%s' "$ip"; return; }
+  fi
+  if has_cmd nslookup; then
+    ip="$(nslookup "$t" 2>/dev/null | awk '/^Address: /{print $2}' | tail -n 1)"
+    [[ -n "$ip" ]] && { printf '%s' "$ip"; return; }
+  fi
+  if out="$(win_ping_output "$t" 2>/dev/null)"; then
+    printf '%s\n' "$out" | extract_ipv4
+    return
+  fi
   printf ''
+}
+
+linux_ping_status(){
+  local t="$1"
+  if ping -c 1 -W "$TIMEOUT" "$t" >/dev/null 2>&1; then printf 'Reachable'; else printf 'NoPing'; fi
+}
+
+windows_ping_status(){
+  local t="$1"
+  if win_ping_output "$t" >/dev/null 2>&1; then printf 'Reachable'; else printf 'NoPing'; fi
 }
 
 ping_status(){
   local t="$1"
-  if ping -c 1 -W "$TIMEOUT" "$t" >/dev/null 2>&1; then printf 'Reachable'; else printf 'NoPing'; fi
+  case "$PING_MODE" in
+    linux) linux_ping_status "$t" ;;
+    windows) windows_ping_status "$t" ;;
+    auto)
+      if [[ "$(linux_ping_status "$t")" == "Reachable" ]]; then
+        printf 'Reachable'
+      elif [[ "$(windows_ping_status "$t")" == "Reachable" ]]; then
+        printf 'Reachable'
+      else
+        printf 'NoPing'
+      fi
+      ;;
+  esac
 }
 
 tcp_status(){

--- a/bash/transport/sas-wmi-identity.sh
+++ b/bash/transport/sas-wmi-identity.sh
@@ -13,6 +13,8 @@ WMI_USER=""
 WMI_PASS=""
 WMI_DOMAIN=""
 WMI_CLIENT="${SAS_WMI_CLIENT:-auto}"
+DEBUG="${SAS_WMI_DEBUG:-${SAS_DEBUG:-0}}"
+LOG_FILE="${SAS_WMI_LOG_FILE:-}"
 PASS_THRU=0
 
 usage(){ cat <<'USAGE'
@@ -30,6 +32,8 @@ Options:
   --wmi-pass PASS      Optional WMI password. Prefer environment variable SAS_WMI_PASS.
   --wmi-domain DOMAIN  Optional domain. Prefer environment variable SAS_WMI_DOMAIN.
   --wmi-client MODE    WMI client: auto, wmic, or powershell. Default: auto.
+  --debug              Print safe diagnostic logging to stderr.
+  --log-file PATH      Write safe diagnostic logging to a local file.
   --pass-thru          Print CSV after writing
   -h, --help           Show help
 
@@ -38,6 +42,8 @@ Environment variables:
   SAS_WMI_PASS
   SAS_WMI_DOMAIN
   SAS_WMI_CLIENT
+  SAS_WMI_DEBUG
+  SAS_WMI_LOG_FILE
 
 Output columns:
   Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes
@@ -47,7 +53,7 @@ Safety:
   - No remote staging.
   - No scheduled tasks.
   - No registry edits.
-  - No credentials are written to output.
+  - No credentials are written to output or diagnostic logs.
 
 Known limitations:
   - `wmic` mode requires an approved `wmic`/Samba WMI client on the Bash host.
@@ -62,6 +68,19 @@ log(){ printf '[wmi-identity] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
 csv_escape(){ local s="${1:-}" q='"'; s="${s//$q/$q$q}"; printf '"%s"' "$s"; }
+flag_state(){ [[ -n "${1:-}" ]] && printf 'set' || printf 'unset'; }
+debug_enabled(){ [[ "$DEBUG" == "1" || "$DEBUG" == "true" || "$DEBUG" == "yes" || -n "$LOG_FILE" ]]; }
+diagnostic(){
+  local line
+  debug_enabled || return 0
+  line="$(date '+%Y-%m-%d %H:%M:%S') [wmi-identity] $*"
+  printf '%s\n' "$line" >&2
+  if [[ -n "$LOG_FILE" ]]; then
+    mkdir -p "$(dirname "$LOG_FILE")"
+    printf '%s\n' "$line" >> "$LOG_FILE"
+  fi
+}
+sanitize_field(){ local s="${1:-}"; s="${s//$'\r'/ }"; s="${s//$'\n'/ }"; s="${s//|/ }"; printf '%s' "$s"; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -73,6 +92,8 @@ while [[ $# -gt 0 ]]; do
     --wmi-pass) WMI_PASS="${2:?missing value for --wmi-pass}"; shift 2 ;;
     --wmi-domain) WMI_DOMAIN="${2:?missing value for --wmi-domain}"; shift 2 ;;
     --wmi-client) WMI_CLIENT="${2:?missing value for --wmi-client}"; shift 2 ;;
+    --debug) DEBUG=1; shift ;;
+    --log-file) LOG_FILE="${2:?missing value for --log-file}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
@@ -214,19 +235,35 @@ PY
 }
 
 run_powershell_wmi(){
-  local target="$1" ps
+  local target="$1" ps err raw rc err_text
   ps="$(powershell_cmd 2>/dev/null || true)"
-  [[ -n "$ps" ]] || { printf '{"Status":"WmiClientMissing","Notes":"powershell.exe not found"}'; return; }
-  "$ps" -NoProfile -NonInteractive -File "$PS_WMI_SCRIPT" -Target "$target" 2>/dev/null || printf '{"Status":"WmiQueryFailed","Notes":"PowerShellWMI execution failed"}'
+  if [[ -z "$ps" ]]; then
+    diagnostic "target=$target client=powershell status=WmiClientMissing reason=powershell.exe_not_found"
+    printf '{"Status":"WmiClientMissing","Notes":"powershell.exe not found"}'
+    return
+  fi
+  diagnostic "target=$target client=powershell path=$ps action=start"
+  err="$TMP_DIR/powershell_${target//[^A-Za-z0-9_.-]/_}.err"
+  raw="$($ps -NoProfile -NonInteractive -File "$PS_WMI_SCRIPT" -Target "$target" 2>"$err")"
+  rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    err_text="$(head -c 220 "$err" 2>/dev/null || true)"
+    err_text="$(sanitize_field "$err_text")"
+    diagnostic "target=$target client=powershell status=WmiQueryFailed rc=$rc stderr=${err_text:-none}"
+    printf '{"Status":"WmiQueryFailed","Notes":"PowerShellWMI execution failed"}'
+    return
+  fi
+  printf '%s' "$raw"
 }
 
 collect_with_wmic(){
   local target="$1" host_raw serial_raw mac_raw host serial macs status notes
+  diagnostic "target=$target client=wmic action=start"
   host_raw="$(run_wmic_query "$target" 'SELECT Name FROM Win32_ComputerSystem')"
   serial_raw="$(run_wmic_query "$target" 'SELECT SerialNumber FROM Win32_BIOS')"
   mac_raw="$(run_wmic_query "$target" 'SELECT MACAddress FROM Win32_NetworkAdapterConfiguration WHERE IPEnabled=True')"
   if printf '%s%s%s' "$host_raw" "$serial_raw" "$mac_raw" | grep -Eiq 'NT_STATUS|ERROR|failed|denied|timed out|timeout'; then
-    printf 'WmiQueryFailed||||WMI query failed or denied'
+    printf 'WmiQueryFailed||||WMI query failed or denied|wmic'
     return
   fi
   host="$(printf '%s
@@ -236,7 +273,7 @@ collect_with_wmic(){
   macs="$(printf '%s
 ' "$mac_raw" | extract_macs)"
   if [[ -n "$host" || -n "$serial" || -n "$macs" ]]; then status="WmiIdentityCollected"; notes="wmic"; else status="WmiNoIdentityReturned"; notes="wmic returned no host, serial, or MAC values"; fi
-  printf '%s|%s|%s|%s|%s' "$status" "$host" "$serial" "$macs" "$notes"
+  printf '%s|%s|%s|%s|%s|wmic' "$status" "$(sanitize_field "$host")" "$(sanitize_field "$serial")" "$(sanitize_field "$macs")" "$(sanitize_field "$notes")"
 }
 
 collect_with_powershell(){
@@ -247,14 +284,14 @@ collect_with_powershell(){
   serial="$(json_field "$raw" ObservedSerial)"
   macs="$(json_field "$raw" ObservedMACs)"
   notes="$(json_field "$raw" Notes)"
-  printf '%s|%s|%s|%s|%s' "${status:-WmiQueryFailed}" "$host" "$serial" "$macs" "$notes"
+  printf '%s|%s|%s|%s|%s|powershell' "$(sanitize_field "${status:-WmiQueryFailed}")" "$(sanitize_field "$host")" "$(sanitize_field "$serial")" "$(sanitize_field "$macs")" "$(sanitize_field "$notes")"
 }
 
 collect_identity(){
   local target="$1"
   case "$WMI_CLIENT" in
     wmic)
-      if has_cmd wmic; then collect_with_wmic "$target"; else printf 'WmiClientMissing||||wmic client not installed'; fi
+      if has_cmd wmic; then collect_with_wmic "$target"; else printf 'WmiClientMissing||||wmic client not installed|wmic'; fi
       ;;
     powershell)
       collect_with_powershell "$target"
@@ -265,11 +302,15 @@ collect_identity(){
   esac
 }
 
+diagnostic "start output=$OUTPUT target_count=${#TARGETS[@]} timeout=$TIMEOUT wmi_client=$WMI_CLIENT wmi_user=$(flag_state "$WMI_USER") wmi_pass=$(flag_state "$WMI_PASS") wmi_domain=$(flag_state "$WMI_DOMAIN")"
+diagnostic "tooling wmic=$(if has_cmd wmic; then printf found; else printf missing; fi) powershell=$(powershell_cmd 2>/dev/null || printf missing)"
+
 {
   printf 'Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes\n'
   for target in "${TARGETS[@]}"; do
     result="$(collect_identity "$target")"
-    IFS='|' read -r status host serial macs notes <<< "$result"
+    IFS='|' read -r status host serial macs notes client <<< "$result"
+    diagnostic "target=$target client=${client:-unknown} status=${status:-unknown} host_collected=$([[ -n "$host" ]] && printf yes || printf no) serial_collected=$([[ -n "$serial" ]] && printf yes || printf no) macs_collected=$([[ -n "$macs" ]] && printf yes || printf no) notes=$(sanitize_field "$notes")"
     csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$host"; printf ','; csv_escape "$serial"; printf ','; csv_escape "$macs"; printf ','; csv_escape "$status"; printf ','; csv_escape "$notes"; printf '\n'
   done
 } > "$OUTPUT"

--- a/bash/transport/sas-wmi-identity.sh
+++ b/bash/transport/sas-wmi-identity.sh
@@ -57,7 +57,7 @@ fail(){ printf '[wmi-identity] ERROR: %s\n' "$*" >&2; exit 1; }
 log(){ printf '[wmi-identity] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
-csv_escape(){ local s="${1:-}"; s="${s//"/""}"; printf '"%s"' "$s"; }
+csv_escape(){ local s="${1:-}" q='"'; s="${s//$q/$q$q}"; printf '"%s"' "$s"; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/bash/transport/sas-wmi-identity.sh
+++ b/bash/transport/sas-wmi-identity.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SysAdminSuite optional WMI identity adapter
-# Read-only Windows identity collection through an approved wmic-compatible client.
+# Read-only Windows identity collection through an approved WMI transport.
 # This is disabled unless called directly or wired via --allow-wmi from sas-workstation-identity.sh.
 
 set -euo pipefail
@@ -12,6 +12,7 @@ TIMEOUT=8
 WMI_USER=""
 WMI_PASS=""
 WMI_DOMAIN=""
+WMI_CLIENT="${SAS_WMI_CLIENT:-auto}"
 PASS_THRU=0
 
 usage(){ cat <<'USAGE'
@@ -28,6 +29,7 @@ Options:
   --wmi-user USER      Optional WMI username. Prefer environment variable SAS_WMI_USER.
   --wmi-pass PASS      Optional WMI password. Prefer environment variable SAS_WMI_PASS.
   --wmi-domain DOMAIN  Optional domain. Prefer environment variable SAS_WMI_DOMAIN.
+  --wmi-client MODE    WMI client: auto, wmic, or powershell. Default: auto.
   --pass-thru          Print CSV after writing
   -h, --help           Show help
 
@@ -35,6 +37,7 @@ Environment variables:
   SAS_WMI_USER
   SAS_WMI_PASS
   SAS_WMI_DOMAIN
+  SAS_WMI_CLIENT
 
 Output columns:
   Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes
@@ -47,7 +50,8 @@ Safety:
   - No credentials are written to output.
 
 Known limitations:
-  - Requires an approved `wmic`/Samba WMI client on the Bash host.
+  - `wmic` mode requires an approved `wmic`/Samba WMI client on the Bash host.
+  - `powershell` mode uses local Windows PowerShell WMI cmdlets from Git Bash.
   - Firewalls, DCOM/RPC policy, and permissions may block collection.
   - This adapter is optional. Failure should produce NeedsPrivilegedSurvey, not silent confidence.
 USAGE
@@ -68,6 +72,7 @@ while [[ $# -gt 0 ]]; do
     --wmi-user) WMI_USER="${2:?missing value for --wmi-user}"; shift 2 ;;
     --wmi-pass) WMI_PASS="${2:?missing value for --wmi-pass}"; shift 2 ;;
     --wmi-domain) WMI_DOMAIN="${2:?missing value for --wmi-domain}"; shift 2 ;;
+    --wmi-client) WMI_CLIENT="${2:?missing value for --wmi-client}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
@@ -80,6 +85,10 @@ WMI_USER="${WMI_USER:-${SAS_WMI_USER:-}}"
 WMI_PASS="${WMI_PASS:-${SAS_WMI_PASS:-}}"
 WMI_DOMAIN="${WMI_DOMAIN:-${SAS_WMI_DOMAIN:-}}"
 [[ "$TIMEOUT" =~ ^[0-9]+$ && "$TIMEOUT" -ge 1 ]] || fail "--timeout must be positive integer"
+case "$WMI_CLIENT" in
+  auto|wmic|powershell) ;;
+  *) fail "--wmi-client must be auto, wmic, or powershell" ;;
+esac
 if [[ -n "$TARGET_FILE" ]]; then
   [[ -f "$TARGET_FILE" ]] || fail "targets file not found: $TARGET_FILE"
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -90,12 +99,74 @@ fi
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
 mkdir -p "$(dirname "$OUTPUT")"
 
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+PS_WMI_SCRIPT="$TMP_DIR/sas-wmi-query.ps1"
+
+cat > "$PS_WMI_SCRIPT" <<'PS1'
+param(
+  [Parameter(Mandatory=$true)][string]$Target
+)
+$ErrorActionPreference = 'Stop'
+function New-Result {
+  param(
+    [string]$Status,
+    [string]$HostName = '',
+    [string]$Serial = '',
+    [string]$Macs = '',
+    [string]$Notes = ''
+  )
+  [pscustomobject]@{
+    Status = $Status
+    ObservedHostName = $HostName
+    ObservedSerial = $Serial
+    ObservedMACs = $Macs
+    Notes = $Notes
+  } | ConvertTo-Json -Compress
+}
+try {
+  $user = $env:SAS_WMI_USER
+  $pass = $env:SAS_WMI_PASS
+  $domain = $env:SAS_WMI_DOMAIN
+  $credential = $null
+  if ($user) {
+    $account = if ($domain) { "$domain\$user" } else { $user }
+    $secure = ConvertTo-SecureString ($pass | ForEach-Object { $_ }) -AsPlainText -Force
+    $credential = New-Object System.Management.Automation.PSCredential($account, $secure)
+  }
+  $base = @{ ComputerName = $Target; ErrorAction = 'Stop' }
+  if ($credential) { $base.Credential = $credential }
+  $computer = Get-WmiObject @base -Class Win32_ComputerSystem | Select-Object -First 1
+  $bios = Get-WmiObject @base -Class Win32_BIOS | Select-Object -First 1
+  $nics = Get-WmiObject @base -Class Win32_NetworkAdapterConfiguration | Where-Object { $_.IPEnabled -eq $true }
+  $macs = @($nics | ForEach-Object { $_.MACAddress } | Where-Object { $_ }) -join ';'
+  if ($computer.Name -or $bios.SerialNumber -or $macs) {
+    New-Result -Status 'WmiIdentityCollected' -HostName ([string]$computer.Name) -Serial ([string]$bios.SerialNumber) -Macs ([string]$macs) -Notes 'PowerShellWMI'
+  } else {
+    New-Result -Status 'WmiNoIdentityReturned' -Notes 'PowerShellWMI returned no host, serial, or MAC values'
+  }
+} catch {
+  $message = $_.Exception.Message
+  if ($message.Length -gt 220) { $message = $message.Substring(0,220) }
+  New-Result -Status 'WmiQueryFailed' -Notes ("PowerShellWMI: " + $message)
+}
+PS1
+
 norm_mac(){
   local raw="${1:-}" hx out i
   hx="$(printf '%s' "$raw" | tr -cd '[:xdigit:]' | tr '[:lower:]' '[:upper:]')"
   if [[ ${#hx} -eq 12 ]]; then
     out=""; for ((i=0;i<12;i+=2)); do [[ -n "$out" ]] && out+=":"; out+="${hx:i:2}"; done; printf '%s' "$out"
   else printf ''; fi
+}
+
+powershell_cmd(){
+  local candidate
+  for candidate in powershell.exe /c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe; do
+    if command -v "$candidate" >/dev/null 2>&1; then command -v "$candidate"; return; fi
+    [[ -x "$candidate" ]] && { printf '%s' "$candidate"; return; }
+  done
+  return 1
 }
 
 wmi_base_args(){
@@ -131,29 +202,75 @@ extract_macs(){
   grep -Eio '([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}' | while read -r m; do norm_mac "$m"; done | awk 'NF' | sort -u | paste -sd ';' -
 }
 
+json_field(){
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+try:
+    data=json.loads(sys.argv[1])
+except Exception:
+    data={}
+print(data.get(sys.argv[2], '') or '')
+PY
+}
+
+run_powershell_wmi(){
+  local target="$1" ps
+  ps="$(powershell_cmd 2>/dev/null || true)"
+  [[ -n "$ps" ]] || { printf '{"Status":"WmiClientMissing","Notes":"powershell.exe not found"}'; return; }
+  "$ps" -NoProfile -NonInteractive -File "$PS_WMI_SCRIPT" -Target "$target" 2>/dev/null || printf '{"Status":"WmiQueryFailed","Notes":"PowerShellWMI execution failed"}'
+}
+
+collect_with_wmic(){
+  local target="$1" host_raw serial_raw mac_raw host serial macs status notes
+  host_raw="$(run_wmic_query "$target" 'SELECT Name FROM Win32_ComputerSystem')"
+  serial_raw="$(run_wmic_query "$target" 'SELECT SerialNumber FROM Win32_BIOS')"
+  mac_raw="$(run_wmic_query "$target" 'SELECT MACAddress FROM Win32_NetworkAdapterConfiguration WHERE IPEnabled=True')"
+  if printf '%s%s%s' "$host_raw" "$serial_raw" "$mac_raw" | grep -Eiq 'NT_STATUS|ERROR|failed|denied|timed out|timeout'; then
+    printf 'WmiQueryFailed||||WMI query failed or denied'
+    return
+  fi
+  host="$(printf '%s
+' "$host_raw" | extract_first_value | head -n1)"
+  serial="$(printf '%s
+' "$serial_raw" | extract_first_value | head -n1)"
+  macs="$(printf '%s
+' "$mac_raw" | extract_macs)"
+  if [[ -n "$host" || -n "$serial" || -n "$macs" ]]; then status="WmiIdentityCollected"; notes="wmic"; else status="WmiNoIdentityReturned"; notes="wmic returned no host, serial, or MAC values"; fi
+  printf '%s|%s|%s|%s|%s' "$status" "$host" "$serial" "$macs" "$notes"
+}
+
+collect_with_powershell(){
+  local target="$1" raw status host serial macs notes
+  raw="$(run_powershell_wmi "$target")"
+  status="$(json_field "$raw" Status)"
+  host="$(json_field "$raw" ObservedHostName)"
+  serial="$(json_field "$raw" ObservedSerial)"
+  macs="$(json_field "$raw" ObservedMACs)"
+  notes="$(json_field "$raw" Notes)"
+  printf '%s|%s|%s|%s|%s' "${status:-WmiQueryFailed}" "$host" "$serial" "$macs" "$notes"
+}
+
+collect_identity(){
+  local target="$1"
+  case "$WMI_CLIENT" in
+    wmic)
+      if has_cmd wmic; then collect_with_wmic "$target"; else printf 'WmiClientMissing||||wmic client not installed'; fi
+      ;;
+    powershell)
+      collect_with_powershell "$target"
+      ;;
+    auto)
+      if has_cmd wmic; then collect_with_wmic "$target"; else collect_with_powershell "$target"; fi
+      ;;
+  esac
+}
+
 {
   printf 'Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes\n'
   for target in "${TARGETS[@]}"; do
-    notes=(); status="NotChecked"; host=""; serial=""; macs=""
-    if ! has_cmd wmic; then
-      status="WmiClientMissing"; notes+=("wmic client not installed")
-    else
-      host_raw="$(run_wmic_query "$target" 'SELECT Name FROM Win32_ComputerSystem')"
-      serial_raw="$(run_wmic_query "$target" 'SELECT SerialNumber FROM Win32_BIOS')"
-      mac_raw="$(run_wmic_query "$target" 'SELECT MACAddress FROM Win32_NetworkAdapterConfiguration WHERE IPEnabled=True')"
-      if printf '%s%s%s' "$host_raw" "$serial_raw" "$mac_raw" | grep -Eiq 'NT_STATUS|ERROR|failed|denied|timed out|timeout'; then
-        status="WmiQueryFailed"; notes+=("WMI query failed or denied")
-      else
-        host="$(printf '%s
-' "$host_raw" | extract_first_value | head -n1)"
-        serial="$(printf '%s
-' "$serial_raw" | extract_first_value | head -n1)"
-        macs="$(printf '%s
-' "$mac_raw" | extract_macs)"
-        if [[ -n "$host" || -n "$serial" || -n "$macs" ]]; then status="WmiIdentityCollected"; else status="WmiNoIdentityReturned"; fi
-      fi
-    fi
-    csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$host"; printf ','; csv_escape "$serial"; printf ','; csv_escape "$macs"; printf ','; csv_escape "$status"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
+    result="$(collect_identity "$target")"
+    IFS='|' read -r status host serial macs notes <<< "$result"
+    csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$host"; printf ','; csv_escape "$serial"; printf ','; csv_escape "$macs"; printf ','; csv_escape "$status"; printf ','; csv_escape "$notes"; printf '\n'
   done
 } > "$OUTPUT"
 log "Wrote WMI identity CSV: $OUTPUT"

--- a/dashboard/js/cybernet-os-preflight.js
+++ b/dashboard/js/cybernet-os-preflight.js
@@ -5,6 +5,7 @@
 
   const STORAGE_KEY = 'sasCybernetTutorialOs';
   const WINDOWS = 'windows-powershell';
+  const GIT_BASH = 'windows-gitbash';
   const BASH = 'bash-posix';
 
   const WINDOWS_PREFLIGHT = String.raw`$targets = Get-Content C:\Temp\sas-cybernet\targets.txt | Where-Object { $_.Trim() }
@@ -55,9 +56,16 @@ $rows = foreach ($target in $targets) {
 }
 $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
 
+  const GIT_BASH_PREFLIGHT = String.raw`bash bash/transport/sas-network-preflight.sh \
+  --targets-file /tmp/sas-cybernet/targets.txt \
+  --ports 135,445,3389,9100 \
+  --ping-mode windows \
+  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru`;
+
   const BASH_PREFLIGHT = String.raw`bash bash/transport/sas-network-preflight.sh \
   --targets-file /tmp/sas-cybernet/targets.txt \
   --ports 135,445,3389,9100 \
+  --ping-mode linux \
   --output /tmp/sas-cybernet/network_preflight.csv --pass-thru`;
 
   const BASH_IDENTITY = String.raw`bash bash/transport/sas-workstation-identity.sh \
@@ -65,12 +73,13 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
   --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru`;
 
   const notes = {
-    [WINDOWS]: 'Windows PowerShell mode avoids Git Bash ping/getent differences by using Resolve-DnsName, Test-Connection, and Test-NetConnection.',
-    [BASH]: 'Bash mode is for Linux, macOS, WSL, or a Bash environment where ping/getent behave like the scripts expect.'
+    [WINDOWS]: 'Windows PowerShell mode uses Resolve-DnsName, Test-Connection, and Test-NetConnection.',
+    [GIT_BASH]: 'Windows Git Bash mode keeps Bash output paths but forces Windows ping.exe syntax to avoid false NoPing results.',
+    [BASH]: 'Linux/macOS/WSL Bash mode uses POSIX ping flags. Do not use this for Git Bash on a Windows admin box.'
   };
 
   function normalizeOs(value) {
-    return value === WINDOWS || value === BASH ? value : WINDOWS;
+    return value === WINDOWS || value === GIT_BASH || value === BASH ? value : WINDOWS;
   }
 
   function selectedOs() {
@@ -105,6 +114,7 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
       <label for="cybernet-os-select">Choose the OS/shell that will run the commands:</label>
       <select id="cybernet-os-select">
         <option value="windows-powershell">Windows PowerShell / Windows admin box</option>
+        <option value="windows-gitbash">Windows Git Bash / Windows ping.exe</option>
         <option value="bash-posix">Linux/macOS/WSL Bash</option>
       </select>
       <div class="cybernet-os-note" id="cybernet-os-note"></div>
@@ -132,6 +142,12 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
     });
   }
 
+  function preflightCommandFor(os) {
+    if (os === WINDOWS) return WINDOWS_PREFLIGHT;
+    if (os === GIT_BASH) return GIT_BASH_PREFLIGHT;
+    return BASH_PREFLIGHT;
+  }
+
   function patchCurrentStep() {
     const titleEl = document.getElementById('cybernet-step-title');
     const commandEl = document.getElementById('cybernet-step-command');
@@ -144,7 +160,7 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
     if (osNoteEl) osNoteEl.textContent = notes[os] || notes[WINDOWS];
 
     if (title === 'Prove network posture first') {
-      commandEl.value = os === WINDOWS ? WINDOWS_PREFLIGHT : BASH_PREFLIGHT;
+      commandEl.value = preflightCommandFor(os);
       if (noteEl) noteEl.textContent = os === WINDOWS
         ? 'Run this in Windows PowerShell, then drag C:\\Temp\\sas-cybernet\\network_preflight.csv into the dashboard.'
         : 'Load network_preflight.csv into the Network tab after the command finishes.';


### PR DESCRIPTION
## Summary

Adds an explicit ping implementation selector to `bash/transport/sas-network-preflight.sh` so Windows Git Bash can use Windows `ping.exe` syntax instead of POSIX/Linux flags.

## What changed

- Adds `--ping-mode auto|linux|windows` to `sas-network-preflight.sh`.
- Default `auto` tries Linux-style ping first, then Windows `ping.exe` fallback.
- `windows` mode uses `ping.exe -n 1 -w <timeout-ms>` for Git Bash on Windows admin boxes.
- `linux` mode keeps the existing POSIX/Linux behavior with `ping -c 1 -W <timeout>`.
- Adds Windows-ping DNS/IP fallback through parsed `ping.exe` output when `getent`/`nslookup` do not resolve.
- Updates the Cybernet dashboard OS selector with a new **Windows Git Bash / Windows ping.exe** option.

## Why

Git Bash on Windows can resolve `ping` to Windows `ping.exe`, where Linux flags like `-c` and `-W` do not behave correctly. That caused false `NoPing` rows even when the same hostname pinged successfully from CMD.

## Safety posture

- Read-only only.
- No endpoint mutation.
- No broad scan behavior added.
- No credential use added.
- Scope remains controlled by explicit target list or `--target` arguments.

## Manual test plan

From Git Bash on a Windows admin box:

```bash
mkdir -p logs/targets logs/mini-probe
printf '%s\n' REAL-CYBERNET-HOSTNAME-1 > logs/targets/mini_real_targets.txt

bash bash/transport/sas-network-preflight.sh \
  --targets-file logs/targets/mini_real_targets.txt \
  --ports 135,445,3389,9100 \
  --ping-mode windows \
  --timeout 3 \
  --output logs/mini-probe/network_preflight.csv \
  --pass-thru
```

Expected: if CMD ping works for the same hostname, `PingStatus` should report `Reachable` instead of a Git Bash false `NoPing`.

Also verify:

```bash
bash bash/transport/sas-network-preflight.sh --help
```