### PR TITLE
feat(survey): add Cybernet tracker diff and registry evidence ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,10 @@ logs/nmap/*
 logs/targets/*
 !logs/targets/.gitkeep
 
+# Northwell registry-first verification evidence (raw reg.exe output — live field data)
+logs/registry/*
+!logs/registry/.gitkeep
+
 # Cybernet subnet discovery runtime evidence (serials, IPs, DNS — live field data)
 evidence/*
 !evidence/.gitkeep

--- a/Tests/bash/cybernet_serial_contract_fixtures.py
+++ b/Tests/bash/cybernet_serial_contract_fixtures.py
@@ -26,6 +26,15 @@ SERIAL_HEADERS = (
 HOST_HEADERS = ("cybernet hostname", "pc name", "hostname", "host name", "host", "computer name")
 MAC_HEADERS = ("cybernet mac", "mac address", "mac")
 IDENTIFIER_FIELDS = ("Cybernet Serial", "Cybernet Hostname", "Cybernet MAC", "Neuron MAC", "Neuron S/N")
+HEADER_TOKENS = {
+    "serial", "serial number", "cybernet serial", "cybernet serial number",
+    "pc / cybernet serial no", "service tag",
+    "host", "hostname", "host name", "cybernet host", "cybernet hostname",
+    "computer name", "pc name",
+    "mac", "mac address", "cybernet mac", "cybernet mac address",
+    "neuron mac", "neuron mac address", "neuron s/n", "neuron serial", "neuron serial number",
+    "device type", "deployed",
+}
 
 
 def clean(value: object) -> str:
@@ -55,6 +64,14 @@ def norm_mac(value: object) -> str:
         return ""
     raw = re.sub(r"[^0-9A-Fa-f]", "", match.group(0)).upper()
     return ":".join(raw[i : i + 2] for i in range(0, 12, 2)) if len(raw) == 12 else ""
+
+
+def norm_header(value: object) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip()).lower()
+
+
+def is_header_label(value: object) -> bool:
+    return norm_header(value) in HEADER_TOKENS
 
 
 def norm_identifier(field: str, value: object) -> str:
@@ -98,11 +115,18 @@ def parse_alejandro_serials(path: Path) -> list[str]:
             upper = ws.title.strip().upper()
             if "AKBAR WAVE" in upper:
                 for row in ws.iter_rows(values_only=True):
-                    if serial := norm_serial(row[0] if row else ""):
+                    cell = row[0] if row else ""
+                    if is_header_label(cell):
+                        continue
+                    if serial := norm_serial(cell):
                         serials.append(serial)
             elif upper.startswith("PO"):
                 for row in ws.iter_rows(values_only=True):
-                    if serial := norm_serial(row[1] if len(row) > 1 else ""):
+                    host_cell = row[0] if len(row) > 0 else ""
+                    serial_cell = row[1] if len(row) > 1 else ""
+                    if is_header_label(host_cell) or is_header_label(serial_cell):
+                        continue
+                    if serial := norm_serial(serial_cell):
                         serials.append(serial)
     finally:
         wb.close()
@@ -223,12 +247,12 @@ def build_diff_fixture(primary: Path, tracker: Path) -> None:
     ewb = Workbook()
     dep = ewb.active
     dep.title = "Deployments"
-    dep.append(["Device Type", "Cybernet Hostname", "Cybernet Serial", "Cybernet MAC", "Deployed"])
-    dep.append(["Cybernet-Neuron", "WTS001OPR101", "MEDTEST24-TRACKED01", "000D050AA101", "Yes"])
-    dep.append(["Cybernet-Neuron", "WTS001OPR201", "MEDTEST24-DUPYES01", "000D050AA201", "Yes"])
-    dep.append(["Cybernet-Neuron", "WTS001OPR202", "MEDTEST24-DUPYES01", "000D050AA202", "Yes"])
-    dep.append(["Cybernet-Neuron", "WTS001OPR103", "MEDTEST24-HIST01", "000D050AA103", "No"])
-    dep.append(["Cybernet-Neuron", "WTS001OPR104", "MEDTEST24-HIST01", "000D050AA104", "No"])
+    dep.append(["Device Type", "Cybernet Hostname", "Cybernet Serial", "Cybernet MAC", "Neuron S/N", "Deployed"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR101", "MEDTEST24-TRACKED01", "000D050AA101", "NEU-UNIQ01", "Yes"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR201", "MEDTEST24-DUPYES01", "000D050AA201", "NEU-DUP01", "Yes"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR202", "MEDTEST24-DUPYES01", "000D050AA202", "NEU-DUP01", "Yes"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR103", "MEDTEST24-HIST01", "000D050AA103", "NEU-HIST01", "No"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR104", "MEDTEST24-HIST01", "000D050AA104", "NEU-HIST01", "No"])
     ewb.save(tracker)
 
 
@@ -240,6 +264,33 @@ def build_serial_only_fixture(path: Path) -> None:
     wb.save(path)
 
 
+def build_header_row_fixture(path: Path) -> None:
+    """Alejandro workbook whose first rows are header labels, not serials."""
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "AKBAR WAVE 1"
+    ws["A1"] = "Cybernet Serial"
+    ws["A2"] = "MEDTEST24-HDR01"
+    po = wb.create_sheet("PO 1")
+    po["A1"] = "Cybernet Hostname"
+    po["B1"] = "Cybernet Serial"
+    po["A2"] = "WTS001OPR301"
+    po["B2"] = "MEDTEST24-HDR02"
+    wb.save(path)
+
+
+def build_ambiguous_host_fixture(path: Path) -> None:
+    """One Alejandro serial mapped to two distinct hostnames (review-required)."""
+    wb = Workbook()
+    po = wb.active
+    po.title = "PO 1"
+    po["A1"] = "WTS001OPR401"
+    po["B1"] = "MEDTEST24-AMBIG01"
+    po["A2"] = "WTS001OPR402"
+    po["B2"] = "MEDTEST24-AMBIG01"
+    wb.save(path)
+
+
 def emit_fixtures(output_dir: Path) -> dict[str, str]:
     output_dir.mkdir(parents=True, exist_ok=True)
     paths = {
@@ -247,10 +298,14 @@ def emit_fixtures(output_dir: Path) -> dict[str, str]:
         "primary_diff": str(output_dir / "alejandro-diff.xlsx"),
         "tracker_diff": str(output_dir / "tracker-diff.xlsx"),
         "primary_serial_only": str(output_dir / "alejandro-serial-only.xlsx"),
+        "primary_header_rows": str(output_dir / "alejandro-header-rows.xlsx"),
+        "primary_ambiguous": str(output_dir / "alejandro-ambiguous-host.xlsx"),
     }
     build_duplicate_fixture(Path(paths["primary_dup"]))
     build_diff_fixture(Path(paths["primary_diff"]), Path(paths["tracker_diff"]))
     build_serial_only_fixture(Path(paths["primary_serial_only"]))
+    build_header_row_fixture(Path(paths["primary_header_rows"]))
+    build_ambiguous_host_fixture(Path(paths["primary_ambiguous"]))
     return paths
 
 

--- a/Tests/bash/cybernet_serial_contract_fixtures.py
+++ b/Tests/bash/cybernet_serial_contract_fixtures.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Sanitized fixture builder and serial-comparison contract helpers for Bash contract tests."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    from openpyxl import Workbook, load_workbook
+except ImportError:
+    print("openpyxl required", file=sys.stderr)
+    sys.exit(1)
+
+EMPTY = {"", "N/A", "NA", "NONE", "NULL", "-", "--", "TBD", "UNKNOWN", "#N/A", "#REF!"}
+SERIAL_HEADERS = (
+    "cybernet serial",
+    "pc / cybernet serial no",
+    "cybernet serial number",
+    "serial number",
+    "serial",
+    "service tag",
+)
+HOST_HEADERS = ("cybernet hostname", "pc name", "hostname", "host name", "host", "computer name")
+MAC_HEADERS = ("cybernet mac", "mac address", "mac")
+IDENTIFIER_FIELDS = ("Cybernet Serial", "Cybernet Hostname", "Cybernet MAC", "Neuron MAC", "Neuron S/N")
+
+
+def clean(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return "" if text.upper() in EMPTY else text
+
+
+def norm_serial(value: object) -> str:
+    text = re.sub(r"\s+", "", clean(value)).upper()
+    return text if len(text) >= 3 else ""
+
+
+def norm_host(value: object) -> str:
+    text = re.sub(r"\s+", "", clean(value)).upper()
+    hostname_re = re.compile(r"^[A-Za-z]{2,6}\d{2,}[A-Za-z0-9_-]*$|^[A-Za-z0-9]+[-_][A-Za-z0-9]+")
+    return text if text and hostname_re.search(text) else ""
+
+
+def norm_mac(value: object) -> str:
+    text = clean(value)
+    if not text:
+        return ""
+    match = re.search(r"(?i)(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}", text)
+    if not match:
+        return ""
+    raw = re.sub(r"[^0-9A-Fa-f]", "", match.group(0)).upper()
+    return ":".join(raw[i : i + 2] for i in range(0, 12, 2)) if len(raw) == 12 else ""
+
+
+def norm_identifier(field: str, value: object) -> str:
+    field_lower = field.strip().lower()
+    if "serial" in field_lower or field_lower.endswith("s/n"):
+        return norm_serial(value)
+    if "mac" in field_lower:
+        return norm_mac(value)
+    if "hostname" in field_lower or field_lower in {"pc name", "host name", "host", "computer name"}:
+        return norm_host(value)
+    return clean(value).upper()
+
+
+def is_deployed_yes(value: object) -> bool:
+    return clean(value).upper() == "YES"
+
+
+def header_map(row: tuple[object, ...]) -> dict[str, int]:
+    return {
+        re.sub(r"\s+", " ", str(value or "").strip()).lower(): idx
+        for idx, value in enumerate(row)
+        if clean(value)
+    }
+
+
+def pick_column(headers: dict[str, int], names: tuple[str, ...]) -> int | None:
+    for name in names:
+        if name in headers:
+            return headers[name]
+    for key, idx in headers.items():
+        if any(name in key for name in names):
+            return idx
+    return None
+
+
+def parse_alejandro_serials(path: Path) -> list[str]:
+    serials: list[str] = []
+    wb = load_workbook(path, read_only=True, data_only=True)
+    try:
+        for ws in wb.worksheets:
+            upper = ws.title.strip().upper()
+            if "AKBAR WAVE" in upper:
+                for row in ws.iter_rows(values_only=True):
+                    if serial := norm_serial(row[0] if row else ""):
+                        serials.append(serial)
+            elif upper.startswith("PO"):
+                for row in ws.iter_rows(values_only=True):
+                    if serial := norm_serial(row[1] if len(row) > 1 else ""):
+                        serials.append(serial)
+    finally:
+        wb.close()
+    return serials
+
+
+def parse_tracker_rows(path: Path) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    wb = load_workbook(path, read_only=True, data_only=True)
+    try:
+        for ws in wb.worksheets:
+            if ws.title.strip().lower() != "deployments":
+                continue
+            headers = None
+            for row_index, row in enumerate(ws.iter_rows(values_only=True), start=1):
+                row_headers = header_map(row)
+                if any(name in row_headers for name in HOST_HEADERS + SERIAL_HEADERS + MAC_HEADERS):
+                    headers = row_headers
+                    continue
+                if not headers:
+                    continue
+                deployed_idx = headers.get("deployed")
+                record = {
+                    "excel_row": str(row_index),
+                    "sheet": ws.title,
+                    "deployed_yes": "yes" if is_deployed_yes(row[deployed_idx] if deployed_idx is not None and deployed_idx < len(row) else "") else "no",
+                }
+                for label in IDENTIFIER_FIELDS:
+                    key = label.lower()
+                    idx = headers.get(key)
+                    if idx is None:
+                        for header_name, header_idx in headers.items():
+                            if key in header_name:
+                                idx = header_idx
+                                break
+                    value = row[idx] if idx is not None and idx < len(row) else ""
+                    record[label] = norm_identifier(label, value)
+                if any(record.get(label) for label in IDENTIFIER_FIELDS):
+                    rows.append(record)
+    finally:
+        wb.close()
+    return rows
+
+
+def unique_serial_inventory(serials: list[str]) -> list[str]:
+    seen: list[str] = []
+    for serial in serials:
+        if serial and serial not in seen:
+            seen.append(serial)
+    return seen
+
+
+def compare_serial_inventories(alejandro_serials: list[str], tracker_rows: list[dict[str, str]]) -> dict[str, list[str]]:
+    alejandro_unique = unique_serial_inventory(alejandro_serials)
+    tracker_serials = [row.get("Cybernet Serial", "") for row in tracker_rows if row.get("Cybernet Serial")]
+    tracker_unique = unique_serial_inventory(tracker_serials)
+    alejandro_set = set(alejandro_unique)
+    tracker_set = set(tracker_unique)
+    return {
+        "alejandro_unique_serials": alejandro_unique,
+        "tracker_unique_serials": tracker_unique,
+        "already_tracked": sorted(alejandro_set & tracker_set),
+        "untracked": sorted(alejandro_set - tracker_set),
+    }
+
+
+def duplicate_exceptions(tracker_rows: list[dict[str, str]]) -> tuple[list[dict[str, object]], dict[str, int]]:
+    non_deployed_repeats: dict[str, int] = {}
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
+    for row in tracker_rows:
+        for field in IDENTIFIER_FIELDS:
+            value = row.get(field, "")
+            if not value:
+                continue
+            grouped.setdefault((field, value), []).append(row)
+            if row.get("deployed_yes") != "yes":
+                non_deployed_repeats[value] = non_deployed_repeats.get(value, 0) + 1
+
+    exceptions: list[dict[str, object]] = []
+    for (field, value), hits in sorted(grouped.items()):
+        deployed_hits = [row for row in hits if row.get("deployed_yes") == "yes"]
+        if len(deployed_hits) <= 1:
+            continue
+        exceptions.append(
+            {
+                "identifier_field": field,
+                "identifier": value,
+                "deployed_yes_count": len(deployed_hits),
+                "matching_row_count": len(hits),
+                "rows": ";".join(sorted({row["excel_row"] for row in deployed_hits}, key=int)),
+                "sheet": hits[0].get("sheet", ""),
+            }
+        )
+    return exceptions, non_deployed_repeats
+
+
+def build_duplicate_fixture(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "AKBAR WAVE 1"
+    ws["A1"] = "MEDTEST24-DUP01"
+    ws["A2"] = "MEDTEST24-DUP01"
+    ws["A3"] = "MEDTEST24-UNIQ01"
+    po = wb.create_sheet("PO 1")
+    po["A1"] = "wts001opr001"
+    po["B1"] = "MEDTEST24-DUP01"
+    wb.save(path)
+
+
+def build_diff_fixture(primary: Path, tracker: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "AKBAR WAVE 1"
+    ws["A1"] = "MEDTEST24-TRACKED01"
+    ws["A2"] = "MEDTEST24-NEW01"
+    wb.save(primary)
+
+    ewb = Workbook()
+    dep = ewb.active
+    dep.title = "Deployments"
+    dep.append(["Device Type", "Cybernet Hostname", "Cybernet Serial", "Cybernet MAC", "Deployed"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR101", "MEDTEST24-TRACKED01", "000D050AA101", "Yes"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR201", "MEDTEST24-DUPYES01", "000D050AA201", "Yes"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR202", "MEDTEST24-DUPYES01", "000D050AA202", "Yes"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR103", "MEDTEST24-HIST01", "000D050AA103", "No"])
+    dep.append(["Cybernet-Neuron", "WTS001OPR104", "MEDTEST24-HIST01", "000D050AA104", "No"])
+    ewb.save(tracker)
+
+
+def build_serial_only_fixture(path: Path) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "AKBAR WAVE 9"
+    ws["A1"] = "MEDTEST24-SERIALONLY01"
+    wb.save(path)
+
+
+def emit_fixtures(output_dir: Path) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths = {
+        "primary_dup": str(output_dir / "alejandro-dup-serial.xlsx"),
+        "primary_diff": str(output_dir / "alejandro-diff.xlsx"),
+        "tracker_diff": str(output_dir / "tracker-diff.xlsx"),
+        "primary_serial_only": str(output_dir / "alejandro-serial-only.xlsx"),
+    }
+    build_duplicate_fixture(Path(paths["primary_dup"]))
+    build_diff_fixture(Path(paths["primary_diff"]), Path(paths["tracker_diff"]))
+    build_serial_only_fixture(Path(paths["primary_serial_only"]))
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--emit-fixtures", metavar="DIR")
+    parser.add_argument("--validate-diff", nargs=2, metavar=("ALEJANDRO", "TRACKER"))
+    parser.add_argument("--validate-duplicates", metavar="TRACKER")
+    args = parser.parse_args()
+
+    if args.emit_fixtures:
+        print(json.dumps(emit_fixtures(Path(args.emit_fixtures))))
+        return 0
+
+    if args.validate_diff:
+        alejandro_path, tracker_path = map(Path, args.validate_diff)
+        result = compare_serial_inventories(
+            parse_alejandro_serials(alejandro_path),
+            parse_tracker_rows(tracker_path),
+        )
+        print(json.dumps(result))
+        return 0
+
+    if args.validate_duplicates:
+        tracker_rows = parse_tracker_rows(Path(args.validate_duplicates))
+        exceptions, non_deployed = duplicate_exceptions(tracker_rows)
+        print(json.dumps({"duplicate_exceptions": exceptions, "non_deployed_repeats": non_deployed}))
+        return 0
+
+    parser.error("no action requested")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
+++ b/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
@@ -118,6 +118,8 @@ PRIMARY_DUP="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,
 PRIMARY_DIFF="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["primary_diff"])')"
 TRACKER_DIFF="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["tracker_diff"])')"
 PRIMARY_SERIAL_ONLY="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["primary_serial_only"])')"
+PRIMARY_HEADER_ROWS="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["primary_header_rows"])')"
+PRIMARY_AMBIGUOUS="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["primary_ambiguous"])')"
 
 # --- Alejandro duplicate serial collapse ---
 MANIFEST_DUP="$TMP_DIR/manifest_dup.csv"
@@ -194,8 +196,12 @@ if not any(item["identifier"] == "MEDTEST24-DUPYES01" and item["deployed_yes_cou
     raise SystemExit("repeated Deployed=Yes identifier must emit duplicate exception")
 if non_deployed.get("MEDTEST24-HIST01", 0) < 2:
     raise SystemExit("fixture must include repeated non-deployed tracker identifier")
+if not any(item["identifier"] == "NEU-DUP01" and item["identifier_field"] == "Neuron S/N" for item in exceptions):
+    raise SystemExit("repeated Deployed=Yes Neuron S/N must emit duplicate exception")
+if any(item["identifier"] == "NEU-HIST01" for item in exceptions):
+    raise SystemExit("repeated non-deployed Neuron S/N must not emit duplicate exception")
 '
-pass "deployed-yes duplicate exception contract"
+pass "deployed-yes duplicate exception contract (incl. Neuron identifiers)"
 
 # --- tracker diff runner outputs ---
 DIFF_PREFIX="$TMP_DIR/diff/cybernet"
@@ -219,6 +225,48 @@ grep -q 'MEDTEST24-NEW01' "$UNTRACKED_CSV" || fail "diff untracked csv missing n
 grep -q 'MEDTEST24-TRACKED01' "$UNTRACKED_CSV" && fail "diff untracked csv must exclude tracked serial"
 grep -q 'MEDTEST24-DUPYES01' "$DUP_EXCEPTIONS_CSV" || fail "duplicate exceptions csv missing deployed-yes duplicate"
 grep -q 'MEDTEST24-HIST01' "$DUP_EXCEPTIONS_CSV" && fail "duplicate exceptions csv must ignore non-deployed repeats"
+grep -q 'NEU-DUP01' "$DUP_EXCEPTIONS_CSV" || fail "duplicate exceptions csv missing deployed-yes Neuron S/N duplicate"
+grep -q 'NEU-HIST01' "$DUP_EXCEPTIONS_CSV" && fail "duplicate exceptions csv must ignore non-deployed Neuron repeats"
 pass "tracker diff runner csv contract"
+
+# --- Alejandro header rows must not become fake serial inventory ---
+HDR_PREFIX="$TMP_DIR/hdr/cybernet"
+bash "$DIFF_RUNNER" \
+  --alejandro "$PRIMARY_HEADER_ROWS" \
+  --tracker "$TRACKER_DIFF" \
+  --output-prefix "$HDR_PREFIX" \
+  --device-type Cybernet >/dev/null
+HDR_UNIQUE_CSV="${HDR_PREFIX}_alejandro_unique_serials.csv"
+grep -q 'MEDTEST24-HDR01' "$HDR_UNIQUE_CSV" || fail "real serial after header row must be retained"
+grep -q 'MEDTEST24-HDR02' "$HDR_UNIQUE_CSV" || fail "real PO serial after header row must be retained"
+# Header labels like "Cybernet Serial" / "Cybernet Hostname" must not normalize into fake serials.
+grep -qiE 'CYBERNETSERIAL|CYBERNETHOSTNAME' "$HDR_UNIQUE_CSV" && fail "header labels must not become fake serial identifiers"
+pass "Alejandro header rows skipped (no fake serial identifiers)"
+
+# --- multiple Alejandro hostnames for one serial stay review-required ---
+AMB_PREFIX="$TMP_DIR/amb/cybernet"
+bash "$DIFF_RUNNER" \
+  --alejandro "$PRIMARY_AMBIGUOUS" \
+  --tracker "$TRACKER_DIFF" \
+  --output-prefix "$AMB_PREFIX" \
+  --device-type Cybernet >/dev/null
+AMB_UNTRACKED_CSV="${AMB_PREFIX}_alejandro_untracked.csv"
+"${PYTHON_CMD[@]}" - "$AMB_UNTRACKED_CSV" <<'PY'
+import csv, sys
+path = sys.argv[1]
+rows = [r for r in csv.DictReader(open(path, newline="", encoding="utf-8")) if r.get("Serial") == "MEDTEST24-AMBIG01"]
+if len(rows) != 1:
+    raise SystemExit(f"expected one ambiguous serial row, got {len(rows)}")
+row = rows[0]
+if row.get("HostName", "").strip():
+    raise SystemExit("ambiguous multi-hostname serial must not crown a HostName")
+if row.get("IdentifierType") != "Serial":
+    raise SystemExit("ambiguous multi-hostname serial must stay Serial-keyed (not probe-ready)")
+if "ambiguous_hostnames" not in row.get("Source", ""):
+    raise SystemExit("ambiguous multi-hostname serial must surface review candidates in Source")
+if "WTS001OPR401" not in row.get("Source", "") or "WTS001OPR402" not in row.get("Source", ""):
+    raise SystemExit("both candidate hostnames must be preserved for review")
+PY
+pass "multiple Alejandro hostnames stay review-required (no arbitrary host pick)"
 
 printf 'Cybernet xlsx target ingester contracts passed (baseline + serial comparison rules).\n'

--- a/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
+++ b/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Contract tests for Cybernet XLSX target ingester and Alejandro-vs-tracker serial rules.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -8,11 +9,13 @@ RUNNER="survey/sas-cybernet-xlsx-targets.sh"
 PY="survey/sas-cybernet-xlsx-targets.py"
 DIFF_RUNNER="survey/sas-cybernet-tracker-diff.sh"
 DIFF_PY="survey/sas-cybernet-tracker-diff.py"
+CONTRACT_PY="$ROOT/Tests/bash/cybernet_serial_contract_fixtures.py"
 
 [[ -f "$RUNNER" ]] || { echo "missing runner: $RUNNER"; exit 1; }
 [[ -f "$PY" ]] || { echo "missing python ingester: $PY"; exit 1; }
 [[ -f "$DIFF_RUNNER" ]] || { echo "missing tracker diff runner: $DIFF_RUNNER"; exit 1; }
 [[ -f "$DIFF_PY" ]] || { echo "missing tracker diff python: $DIFF_PY"; exit 1; }
+[[ -f "$CONTRACT_PY" ]] || { echo "missing contract fixture helper: $CONTRACT_PY"; exit 1; }
 bash -n "$RUNNER"
 bash -n "$DIFF_RUNNER"
 
@@ -24,29 +27,65 @@ command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1 || {
 PYTHON_CMD=(python3)
 command -v python3 >/dev/null 2>&1 || PYTHON_CMD=(python)
 
+fail() { printf '[cybernet-xlsx-contracts] FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf '[cybernet-xlsx-contracts] PASS: %s\n' "$*"; }
+
+run_ingester() {
+  local workbook="$1" enrichment="$2" manifest="$3" report="$4" gaps="$5"
+  local -a args=(--workbook "$workbook" --output "$manifest" --report "$report" --gaps "$gaps" --device-type Cybernet)
+  if [[ -n "$enrichment" ]]; then
+    args+=(--enrichment "$enrichment")
+  fi
+  bash "$RUNNER" "${args[@]}" >/dev/null
+}
+
+count_data_rows() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "missing output: $path"
+  local lines
+  lines="$(wc -l < "$path" | tr -d ' ')"
+  [[ "$lines" -ge 1 ]] || fail "empty csv: $path"
+  echo "$((lines - 1))"
+}
+
+assert_manifest_serial_count() {
+  local manifest="$1" serial="$2" expected="$3"
+  local count
+  count="$("${PYTHON_CMD[@]}" - "$manifest" "$serial" <<'PY'
+import csv, sys
+path, serial = sys.argv[1:3]
+count = 0
+with open(path, newline="", encoding="utf-8") as handle:
+    for row in csv.DictReader(handle):
+        if row.get("Serial", "").upper() == serial.upper():
+            count += 1
+print(count)
+PY
+)"
+  [[ "$count" -eq "$expected" ]] || fail "expected $expected manifest row(s) for serial $serial, got $count"
+}
+
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
+# --- baseline smoke (existing contract) ---
 PRIMARY="$TMP_DIR/alejandro-fixture.xlsx"
 ENRICH="$TMP_DIR/enrichment-fixture.xlsx"
-TRACKER="$TMP_DIR/tracker-fixture.xlsx"
 OUT_MANIFEST="$TMP_DIR/cybernet_targets.csv"
 OUT_REPORT="$TMP_DIR/enrichment_report.csv"
 OUT_GAPS="$TMP_DIR/gaps.csv"
-DIFF_PREFIX="$TMP_DIR/diff/cybernet"
 
-"${PYTHON_CMD[@]}" - "$PRIMARY" "$ENRICH" "$TRACKER" <<'PY'
+"${PYTHON_CMD[@]}" - "$PRIMARY" "$ENRICH" <<'PY'
 import sys
 from openpyxl import Workbook
 
-primary_path, enrich_path, tracker_path = sys.argv[1:4]
+primary_path, enrich_path = sys.argv[1:3]
 
 wb = Workbook()
 ws = wb.active
 ws.title = "AKBAR WAVE 1 AND 2"
 ws["A1"] = "MEDTEST24-00001"
-ws["A2"] = "MEDTEST24-00001"
-ws["A3"] = "MEDTEST24-00002"
+ws["A2"] = "MEDTEST24-00002"
 po = wb.create_sheet("PO 1")
 po["A1"] = "wts001opr001"
 po["B1"] = "MEDTEST24-00003"
@@ -63,85 +102,123 @@ dep.append(["Cybernet-Neuron", "WTS001OPR002", "MEDTEST24-00002", "000D050AA58E"
 host = ewb.create_sheet("SSUH Host")
 host["A1"] = "WTS001OPR099"
 ewb.save(enrich_path)
-
-twb = Workbook()
-dep = twb.active
-dep.title = "Deployments"
-dep.append(["Device Type", "Deployed", "Cybernet Hostname", "Cybernet Serial", "Cybernet MAC"])
-dep.append(["Cybernet-Neuron", "No", "WTS001OPR001", "MEDTEST24-00003", "000D050AA58F"])
-dep.append(["Cybernet-Neuron", "No", "WTS001OPR010", "MEDTEST24-00006", "000D050AA590"])
-dep.append(["Cybernet-Neuron", "No", "WTS001OPR011", "MEDTEST24-00006", "000D050AA591"])
-dep.append(["Cybernet-Neuron", "Yes", "WTS001OPR020", "MEDTEST24-00005", "000D050AA592"])
-dep.append(["Cybernet-Neuron", "Yes", "WTS001OPR021", "MEDTEST24-00005", "000D050AA593"])
-twb.save(tracker_path)
 PY
 
-bash "$RUNNER" \
-  --workbook "$PRIMARY" \
-  --enrichment "$ENRICH" \
-  --output "$OUT_MANIFEST" \
-  --report "$OUT_REPORT" \
-  --gaps "$OUT_GAPS" \
-  --device-type Cybernet >/dev/null
-
-for path in "$OUT_MANIFEST" "$OUT_REPORT" "$OUT_GAPS"; do
-  [[ -f "$path" ]] || { echo "missing output: $path"; exit 1; }
-done
-
-manifest_rows="$(($(wc -l < "$OUT_MANIFEST") - 1))"
-report_rows="$(($(wc -l < "$OUT_REPORT") - 1))"
-gap_rows="$(($(wc -l < "$OUT_GAPS") - 1))"
-
-[[ "$manifest_rows" -gt 0 ]] || { echo "expected manifest rows > 0"; exit 1; }
-[[ "$report_rows" -gt 0 ]] || { echo "expected report rows > 0"; exit 1; }
-
+run_ingester "$PRIMARY" "$ENRICH" "$OUT_MANIFEST" "$OUT_REPORT" "$OUT_GAPS"
+[[ "$(count_data_rows "$OUT_MANIFEST")" -gt 0 ]] || fail "expected manifest rows > 0"
+[[ "$(count_data_rows "$OUT_REPORT")" -gt 0 ]] || fail "expected report rows > 0"
 head -n 1 "$OUT_MANIFEST" | grep -q 'IdentifierType'
 head -n 1 "$OUT_REPORT" | grep -q 'ResolutionStatus'
 grep -qE 'FULL|PARTIAL|MINIMAL' "$OUT_REPORT"
+pass "baseline smoke ingester outputs"
 
+# --- scenario fixtures (generated, sanitized) ---
+FIXTURE_JSON="$("${PYTHON_CMD[@]}" "$CONTRACT_PY" --emit-fixtures "$TMP_DIR")"
+PRIMARY_DUP="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["primary_dup"])')"
+PRIMARY_DIFF="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["primary_diff"])')"
+TRACKER_DIFF="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["tracker_diff"])')"
+PRIMARY_SERIAL_ONLY="$(printf '%s' "$FIXTURE_JSON" | "${PYTHON_CMD[@]}" -c 'import json,sys; print(json.load(sys.stdin)["primary_serial_only"])')"
+
+# --- Alejandro duplicate serial collapse ---
+MANIFEST_DUP="$TMP_DIR/manifest_dup.csv"
+REPORT_DUP="$TMP_DIR/report_dup.csv"
+GAPS_DUP="$TMP_DIR/gaps_dup.csv"
+run_ingester "$PRIMARY_DUP" "" "$MANIFEST_DUP" "$REPORT_DUP" "$GAPS_DUP"
+assert_manifest_serial_count "$MANIFEST_DUP" "MEDTEST24-DUP01" 1
+assert_manifest_serial_count "$MANIFEST_DUP" "MEDTEST24-UNIQ01" 1
+[[ "$(count_data_rows "$MANIFEST_DUP")" -eq 2 ]] || fail "duplicate collapse should leave two unique serial targets"
+grep -q 'WTS001OPR001' "$MANIFEST_DUP" || fail "collapsed duplicate serial should retain PO hostname enrichment"
+pass "Alejandro duplicate serial collapse"
+
+# --- serial-only untracked row retained but not live-probe-ready ---
+MANIFEST_SO="$TMP_DIR/manifest_serial_only.csv"
+REPORT_SO="$TMP_DIR/report_serial_only.csv"
+GAPS_SO="$TMP_DIR/gaps_serial_only.csv"
+run_ingester "$PRIMARY_SERIAL_ONLY" "" "$MANIFEST_SO" "$REPORT_SO" "$GAPS_SO"
+grep -q 'MEDTEST24-SERIALONLY01' "$MANIFEST_SO" || fail "serial-only untracked row must remain in manifest"
+"${PYTHON_CMD[@]}" - "$MANIFEST_SO" "$REPORT_SO" "$GAPS_SO" <<'PY'
+import csv, sys
+
+manifest, report, gaps = sys.argv[1:4]
+rows = list(csv.DictReader(open(manifest, newline="", encoding="utf-8")))
+match = [r for r in rows if r.get("Serial") == "MEDTEST24-SERIALONLY01"]
+if len(match) != 1:
+    raise SystemExit(f"expected one serial-only manifest row, got {len(match)}")
+row = match[0]
+if not row.get("Serial"):
+    raise SystemExit("serial-only row missing Serial column")
+if row.get("MACAddress", "").strip():
+    raise SystemExit("serial-only row should not be live-probe-ready (MAC still empty)")
+report_rows = {r["ResolvedSerial"]: r for r in csv.DictReader(open(report, newline="", encoding="utf-8"))}
+status = report_rows.get("MEDTEST24-SERIALONLY01", {}).get("ResolutionStatus", "")
+if status == "FULL":
+    raise SystemExit("serial-only row must not reach FULL resolution")
+gap_serials = {r.get("Serial") for r in csv.DictReader(open(gaps, newline="", encoding="utf-8"))}
+if "MEDTEST24-SERIALONLY01" not in gap_serials:
+    raise SystemExit("serial-only row should appear in gap report until enriched")
+PY
+pass "serial-only untracked row retained but not live-probe-ready"
+
+# --- tracker serial inventory contract (inline until ingester emits diff CSVs) ---
+CONTRACT_RESULT="$("${PYTHON_CMD[@]}" "$CONTRACT_PY" --validate-diff "$PRIMARY_DIFF" "$TRACKER_DIFF")"
+printf '%s' "$CONTRACT_RESULT" | "${PYTHON_CMD[@]}" -c '
+import json, sys
+data = json.load(sys.stdin)
+alejandro_unique = set(data["alejandro_unique_serials"])
+tracker_unique = set(data["tracker_unique_serials"])
+already = set(data["already_tracked"])
+untracked = set(data["untracked"])
+if alejandro_unique & tracker_unique != already:
+    raise SystemExit("already_tracked must equal alejandro ∩ tracker unique serials")
+if untracked != (alejandro_unique - tracker_unique):
+    raise SystemExit("untracked must equal alejandro unique serials minus tracker inventory")
+if "MEDTEST24-TRACKED01" not in already:
+    raise SystemExit("tracked serial missing from already_tracked set")
+if "MEDTEST24-NEW01" not in untracked:
+    raise SystemExit("new alejandro serial missing from untracked set")
+if "MEDTEST24-TRACKED01" in untracked:
+    raise SystemExit("tracked serial must be excluded from untracked candidates")
+'
+pass "tracker serial exclusion contract"
+
+# --- deployed-yes duplicate exception contract ---
+DUP_CONTRACT="$("${PYTHON_CMD[@]}" "$CONTRACT_PY" --validate-duplicates "$TRACKER_DIFF")"
+printf '%s' "$DUP_CONTRACT" | "${PYTHON_CMD[@]}" -c '
+import json, sys
+data = json.load(sys.stdin)
+exceptions = data["duplicate_exceptions"]
+non_deployed = data["non_deployed_repeats"]
+if any(item["identifier"] == "MEDTEST24-HIST01" for item in exceptions):
+    raise SystemExit("repeated non-deployed identifier must not emit duplicate exception")
+if not any(item["identifier"] == "MEDTEST24-DUPYES01" and item["deployed_yes_count"] > 1 for item in exceptions):
+    raise SystemExit("repeated Deployed=Yes identifier must emit duplicate exception")
+if non_deployed.get("MEDTEST24-HIST01", 0) < 2:
+    raise SystemExit("fixture must include repeated non-deployed tracker identifier")
+'
+pass "deployed-yes duplicate exception contract"
+
+# --- tracker diff runner outputs ---
+DIFF_PREFIX="$TMP_DIR/diff/cybernet"
 bash "$DIFF_RUNNER" \
-  --alejandro "$PRIMARY" \
-  --tracker "$TRACKER" \
+  --alejandro "$PRIMARY_DIFF" \
+  --tracker "$TRACKER_DIFF" \
   --output-prefix "$DIFF_PREFIX" \
   --device-type Cybernet >/dev/null
 
+UNTRACKED_CSV="${DIFF_PREFIX}_alejandro_untracked.csv"
+DUP_EXCEPTIONS_CSV="${DIFF_PREFIX}_tracker_duplicate_exceptions.csv"
 for suffix in \
   alejandro_unique_serials \
   tracker_unique_serials \
   alejandro_already_tracked \
   alejandro_untracked \
   tracker_duplicate_exceptions; do
-  [[ -f "${DIFF_PREFIX}_${suffix}.csv" ]] || { echo "missing diff output: ${DIFF_PREFIX}_${suffix}.csv"; exit 1; }
+  [[ -f "${DIFF_PREFIX}_${suffix}.csv" ]] || fail "missing diff output: ${DIFF_PREFIX}_${suffix}.csv"
 done
+grep -q 'MEDTEST24-NEW01' "$UNTRACKED_CSV" || fail "diff untracked csv missing new serial"
+grep -q 'MEDTEST24-TRACKED01' "$UNTRACKED_CSV" && fail "diff untracked csv must exclude tracked serial"
+grep -q 'MEDTEST24-DUPYES01' "$DUP_EXCEPTIONS_CSV" || fail "duplicate exceptions csv missing deployed-yes duplicate"
+grep -q 'MEDTEST24-HIST01' "$DUP_EXCEPTIONS_CSV" && fail "duplicate exceptions csv must ignore non-deployed repeats"
+pass "tracker diff runner csv contract"
 
-"${PYTHON_CMD[@]}" - "$DIFF_PREFIX" <<'PY'
-import csv
-import sys
-
-prefix = sys.argv[1]
-
-def rows(name):
-    with open(f"{prefix}_{name}.csv", newline="", encoding="utf-8") as handle:
-        return list(csv.DictReader(handle))
-
-unique = {row["Serial"]: row for row in rows("alejandro_unique_serials")}
-assert len(unique) == 4, unique
-assert unique["MEDTEST24-00001"]["RowCount"] == "2", unique["MEDTEST24-00001"]
-assert unique["MEDTEST24-00001"]["ProbeReady"] == "No", unique["MEDTEST24-00001"]
-assert unique["MEDTEST24-00003"]["ProbeReady"] == "Yes", unique["MEDTEST24-00003"]
-
-already = rows("alejandro_already_tracked")
-assert [row["Serial"] for row in already] == ["MEDTEST24-00003"], already
-
-untracked = {row["Serial"]: row for row in rows("alejandro_untracked")}
-assert set(untracked) == {"MEDTEST24-00001", "MEDTEST24-00002", "MEDTEST24-00004"}, untracked
-assert untracked["MEDTEST24-00001"]["IdentifierType"] == "Serial", untracked["MEDTEST24-00001"]
-assert untracked["MEDTEST24-00004"]["IdentifierType"] == "HostName", untracked["MEDTEST24-00004"]
-
-dups = rows("tracker_duplicate_exceptions")
-assert any(row["IdentifierKind"] == "serial" and row["Identifier"] == "MEDTEST24-00005" for row in dups), dups
-assert not any(row["Identifier"] == "MEDTEST24-00006" for row in dups), dups
-PY
-
-printf 'Cybernet xlsx target ingester contracts passed (manifest=%s report=%s gaps=%s).\n' \
-  "$manifest_rows" "$report_rows" "$gap_rows"
+printf 'Cybernet xlsx target ingester contracts passed (baseline + serial comparison rules).\n'

--- a/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
+++ b/Tests/bash/test-cybernet-xlsx-targets-contracts.sh
@@ -6,10 +6,15 @@ cd "$ROOT"
 
 RUNNER="survey/sas-cybernet-xlsx-targets.sh"
 PY="survey/sas-cybernet-xlsx-targets.py"
+DIFF_RUNNER="survey/sas-cybernet-tracker-diff.sh"
+DIFF_PY="survey/sas-cybernet-tracker-diff.py"
 
 [[ -f "$RUNNER" ]] || { echo "missing runner: $RUNNER"; exit 1; }
 [[ -f "$PY" ]] || { echo "missing python ingester: $PY"; exit 1; }
+[[ -f "$DIFF_RUNNER" ]] || { echo "missing tracker diff runner: $DIFF_RUNNER"; exit 1; }
+[[ -f "$DIFF_PY" ]] || { echo "missing tracker diff python: $DIFF_PY"; exit 1; }
 bash -n "$RUNNER"
+bash -n "$DIFF_RUNNER"
 
 command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1 || {
   echo "python required for contract test"
@@ -24,21 +29,24 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 PRIMARY="$TMP_DIR/alejandro-fixture.xlsx"
 ENRICH="$TMP_DIR/enrichment-fixture.xlsx"
+TRACKER="$TMP_DIR/tracker-fixture.xlsx"
 OUT_MANIFEST="$TMP_DIR/cybernet_targets.csv"
 OUT_REPORT="$TMP_DIR/enrichment_report.csv"
 OUT_GAPS="$TMP_DIR/gaps.csv"
+DIFF_PREFIX="$TMP_DIR/diff/cybernet"
 
-"${PYTHON_CMD[@]}" - "$PRIMARY" "$ENRICH" <<'PY'
+"${PYTHON_CMD[@]}" - "$PRIMARY" "$ENRICH" "$TRACKER" <<'PY'
 import sys
 from openpyxl import Workbook
 
-primary_path, enrich_path = sys.argv[1:3]
+primary_path, enrich_path, tracker_path = sys.argv[1:4]
 
 wb = Workbook()
 ws = wb.active
 ws.title = "AKBAR WAVE 1 AND 2"
 ws["A1"] = "MEDTEST24-00001"
-ws["A2"] = "MEDTEST24-00002"
+ws["A2"] = "MEDTEST24-00001"
+ws["A3"] = "MEDTEST24-00002"
 po = wb.create_sheet("PO 1")
 po["A1"] = "wts001opr001"
 po["B1"] = "MEDTEST24-00003"
@@ -55,6 +63,17 @@ dep.append(["Cybernet-Neuron", "WTS001OPR002", "MEDTEST24-00002", "000D050AA58E"
 host = ewb.create_sheet("SSUH Host")
 host["A1"] = "WTS001OPR099"
 ewb.save(enrich_path)
+
+twb = Workbook()
+dep = twb.active
+dep.title = "Deployments"
+dep.append(["Device Type", "Deployed", "Cybernet Hostname", "Cybernet Serial", "Cybernet MAC"])
+dep.append(["Cybernet-Neuron", "No", "WTS001OPR001", "MEDTEST24-00003", "000D050AA58F"])
+dep.append(["Cybernet-Neuron", "No", "WTS001OPR010", "MEDTEST24-00006", "000D050AA590"])
+dep.append(["Cybernet-Neuron", "No", "WTS001OPR011", "MEDTEST24-00006", "000D050AA591"])
+dep.append(["Cybernet-Neuron", "Yes", "WTS001OPR020", "MEDTEST24-00005", "000D050AA592"])
+dep.append(["Cybernet-Neuron", "Yes", "WTS001OPR021", "MEDTEST24-00005", "000D050AA593"])
+twb.save(tracker_path)
 PY
 
 bash "$RUNNER" \
@@ -79,6 +98,50 @@ gap_rows="$(($(wc -l < "$OUT_GAPS") - 1))"
 head -n 1 "$OUT_MANIFEST" | grep -q 'IdentifierType'
 head -n 1 "$OUT_REPORT" | grep -q 'ResolutionStatus'
 grep -qE 'FULL|PARTIAL|MINIMAL' "$OUT_REPORT"
+
+bash "$DIFF_RUNNER" \
+  --alejandro "$PRIMARY" \
+  --tracker "$TRACKER" \
+  --output-prefix "$DIFF_PREFIX" \
+  --device-type Cybernet >/dev/null
+
+for suffix in \
+  alejandro_unique_serials \
+  tracker_unique_serials \
+  alejandro_already_tracked \
+  alejandro_untracked \
+  tracker_duplicate_exceptions; do
+  [[ -f "${DIFF_PREFIX}_${suffix}.csv" ]] || { echo "missing diff output: ${DIFF_PREFIX}_${suffix}.csv"; exit 1; }
+done
+
+"${PYTHON_CMD[@]}" - "$DIFF_PREFIX" <<'PY'
+import csv
+import sys
+
+prefix = sys.argv[1]
+
+def rows(name):
+    with open(f"{prefix}_{name}.csv", newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+unique = {row["Serial"]: row for row in rows("alejandro_unique_serials")}
+assert len(unique) == 4, unique
+assert unique["MEDTEST24-00001"]["RowCount"] == "2", unique["MEDTEST24-00001"]
+assert unique["MEDTEST24-00001"]["ProbeReady"] == "No", unique["MEDTEST24-00001"]
+assert unique["MEDTEST24-00003"]["ProbeReady"] == "Yes", unique["MEDTEST24-00003"]
+
+already = rows("alejandro_already_tracked")
+assert [row["Serial"] for row in already] == ["MEDTEST24-00003"], already
+
+untracked = {row["Serial"]: row for row in rows("alejandro_untracked")}
+assert set(untracked) == {"MEDTEST24-00001", "MEDTEST24-00002", "MEDTEST24-00004"}, untracked
+assert untracked["MEDTEST24-00001"]["IdentifierType"] == "Serial", untracked["MEDTEST24-00001"]
+assert untracked["MEDTEST24-00004"]["IdentifierType"] == "HostName", untracked["MEDTEST24-00004"]
+
+dups = rows("tracker_duplicate_exceptions")
+assert any(row["IdentifierKind"] == "serial" and row["Identifier"] == "MEDTEST24-00005" for row in dups), dups
+assert not any(row["Identifier"] == "MEDTEST24-00006" for row in dups), dups
+PY
 
 printf 'Cybernet xlsx target ingester contracts passed (manifest=%s report=%s gaps=%s).\n' \
   "$manifest_rows" "$report_rows" "$gap_rows"

--- a/docs/CYBERNET_XLSX_TARGET_INGESTION.md
+++ b/docs/CYBERNET_XLSX_TARGET_INGESTION.md
@@ -2,6 +2,35 @@
 
 Read-only, offline ingester that converts Alejandro-style Cybernet workbooks plus optional enrichment trackers into the normalized survey manifest schema used by SysAdminSuite Bash tooling.
 
+## Field handoff
+
+Use this lane when Alejandro's workbook defines the **field population** and the latest **Active Deployment Tracker** supplies the **unique serial inventory** for cross-check.
+
+| Step | Input | Output (local, gitignored) |
+|------|-------|----------------------------|
+| 1. Diff | Alejandro workbook + latest tracker workbook | Unique serial inventories, already tracked, untracked manifest under `survey/output/` |
+| 2. Ingest | Alejandro workbook + tracker `--enrichment` | Manifest, enrichment report, gaps CSV under `survey/output/` |
+| 3. Resolve hosts | Manifest with `HostName` populated | Optional pass through `sas-survey-targets.sh` |
+| 4. Identity (host-resolved only) | Ping, then approved WMI; SSH last | `workstation_identity.csv`, optional `cybernet_evidence.csv` |
+
+**Posture**
+
+- Alejandro rows and tracker enrichment define **registered population** — not reachability proof.
+- Naabu/Nmap and other network probes are **reachability validation only** after population is fixed. See [`LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md).
+- All CSV outputs stay on the admin box in gitignored paths (`survey/output/`, `targets/local/`). Do not commit live workbooks or generated CSVs.
+- Assume authorized traffic may be monitored. Do not describe this workflow as stealth, evasion, or log bypass.
+
+**Evidence classification (identity transport)**
+
+| Observation | Classification | Meaning |
+|-------------|----------------|---------|
+| WMI returns host, serial, or MAC | `IdentityCollected` (adapter: `WmiIdentityCollected`) | Approved identity transport succeeded |
+| Ping/DNS OK, no identity transport | `ReachableNeedsApprovedIdentityTransport` | Reachable; enable approved WMI before revisiting |
+| SSH disabled or connection refused | Notes: `SSHFailed:*` / policy block | **Environment/policy evidence** — not proof the Cybernet is offline |
+| Guest or wrong network segment | `ENVIRONMENT_BLOCKED_GUEST_NETWORK` | Retest from correct network before product triage |
+
+See [`TEST_RESULT_CLASSIFICATION.md`](TEST_RESULT_CLASSIFICATION.md) for full triage rules.
+
 ## Targets intake doctrine
 
 | Location | Role |
@@ -30,9 +59,13 @@ Expected sheets:
 | `AKBAR WAVE …` | A = serial | Serial-only wave rows |
 | `PO …` | A = hostname, B = serial | Blank rows skipped |
 
-## Enrichment workbooks (optional, repeatable)
+Alejandro serial-only rows are the baseline population. Hostname and MAC fields may be empty until enrichment.
 
-Recognized sheets:
+## Enrichment — latest tracker unique serial inventory
+
+Pass the **most recent** Active Deployment Tracker (and any wave/supplement workbooks) with `--enrichment`. The ingester merges enrichment rows by **normalized serial** or **hostname** and emits a before/after comparison in the enrichment report.
+
+Recognized tracker sheets:
 
 | Sheet | Purpose |
 |---|---|
@@ -43,7 +76,41 @@ Recognized sheets:
 | `SSUH Host` | Hostname list (column A) |
 | `Neuron Cybernet` | PC name + Cybernet serial (+ Neuron MAC when present) |
 
-Pass each enrichment file with `--enrichment`. The ingester merges by normalized serial or hostname.
+**How to read the comparison**
+
+- **`enrichment_report.csv`** — each Alejandro row with `InputSerial` / `InputHostName` vs `ResolvedHostName` / `ResolvedSerial` / `ResolvedMACAddress` after tracker merge.
+- **`ResolutionStatus`** — `FULL` (host + serial + MAC), `PARTIAL` (two of three), `MINIMAL` (one or none).
+- **`gaps.csv`** — rows that did not reach `FULL`; use for technician follow-up (stale hostname, serial-only wave row, tracker drift).
+- Tracker serials that never appear in the Alejandro workbook are **not** auto-added to the manifest; reconcile gaps manually or extend enrichment sources.
+
+## Alejandro vs deployment tracker diff
+
+When Alejandro's workbook is the authoritative Cybernet serial source, compare its unique serial inventory against the latest deployment tracker before probing anything live:
+
+```bash
+bash survey/sas-cybernet-tracker-diff.sh \
+  --alejandro "logs/targets/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
+  --tracker "logs/targets/Cybernet sources/Active Deployment Tracker 2026-05-17 - 6-25-2026.xlsx" \
+  --output-prefix survey/output/cybernet
+```
+
+The diff is read-only against both workbooks and writes local operational CSVs:
+
+- `survey/output/cybernet_alejandro_unique_serials.csv`
+- `survey/output/cybernet_tracker_unique_serials.csv`
+- `survey/output/cybernet_alejandro_already_tracked.csv`
+- `survey/output/cybernet_alejandro_untracked.csv`
+- `survey/output/cybernet_tracker_duplicate_exceptions.csv`
+
+Comparison rules:
+
+- Normalize serials by trimming whitespace and uppercasing.
+- Treat Alejandro rows as a unique serial inventory; duplicate Alejandro rows collapse into one serial with a row count.
+- Exclude an Alejandro serial from the untracked manifest when that serial already appears in the deployment tracker.
+- Emit duplicate exceptions only when the same normalized hostname, serial, or MAC appears in more than one tracker row marked `Deployed = Yes`.
+- Repeated non-deployed tracker identifiers are planning history, not duplicate exceptions.
+
+`cybernet_alejandro_untracked.csv` uses the same manifest schema as the ingester. Serial-only rows are retained for tracking, but only rows with a resolved `HostName` are ready for live WMI/ping identity checks.
 
 ## Command
 
@@ -71,38 +138,6 @@ bash survey/sas-cybernet-xlsx-targets.sh \
 
 Defaults write to `survey/output/cybernet_alejandro_*.csv` when `--output`, `--report`, or `--gaps` are omitted.
 
-## Alejandro vs deployment tracker diff
-
-When Alejandro's workbook is the authoritative Cybernet serial source, compare its unique serial
-inventory against the latest deployment tracker before probing anything live:
-
-```bash
-bash survey/sas-cybernet-tracker-diff.sh \
-  --alejandro "logs/targets/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
-  --tracker "logs/targets/Cybernet sources/Active Deployment Tracker 2026-05-17 - 6-25-2026.xlsx" \
-  --output-prefix survey/output/cybernet
-```
-
-The diff is read-only against both workbooks and writes local operational CSVs:
-
-- `survey/output/cybernet_alejandro_unique_serials.csv`
-- `survey/output/cybernet_tracker_unique_serials.csv`
-- `survey/output/cybernet_alejandro_already_tracked.csv`
-- `survey/output/cybernet_alejandro_untracked.csv`
-- `survey/output/cybernet_tracker_duplicate_exceptions.csv`
-
-Comparison rules:
-
-- Normalize serials by trimming whitespace and uppercasing.
-- Treat Alejandro rows as a unique serial inventory; duplicate Alejandro rows collapse into one serial with a row count.
-- Exclude an Alejandro serial from the untracked manifest when that serial already appears in the deployment tracker.
-- Emit duplicate exceptions only when the same normalized hostname, serial, or MAC appears in more than one tracker row marked `Deployed = Yes`.
-- Repeated non-deployed tracker identifiers are planning history, not duplicate exceptions.
-
-`cybernet_alejandro_untracked.csv` uses the same manifest schema as the ingester. Serial-only rows
-are retained for tracking, but only rows with a resolved `HostName` are ready for live WMI/ping
-identity checks.
-
 ## Outputs
 
 ### Manifest CSV
@@ -127,34 +162,74 @@ Subset of targets that did not reach `FULL` resolution, with `GapReason` (for ex
 
 ## Next step — survey manifest resolver
 
-After ingestion, optionally pass the manifest through the Bash resolver:
+After ingestion or diff, optionally pass the manifest through the Bash resolver:
 
 ```bash
 bash survey/sas-survey-targets.sh \
   --device-type Cybernet \
-  --csv survey/output/cybernet_alejandro_targets.csv \
+  --csv survey/output/cybernet_alejandro_untracked.csv \
   --output survey/output/cybernet_targets_resolved.csv
 ```
 
-For host-resolved untracked rows, prefer the read-only WMI/ping identity path before considering
-SSH. SSH is disabled by default in the transport adapter and a blocked SSH path is environment or
-policy evidence, not a product failure:
+## Host-resolved candidates — ping and WMI before SSH
+
+Run identity collection only for targets with a resolved hostname in `cybernet_alejandro_untracked.csv` or the enriched manifest.
+
+**1. Build a host-only target list**
 
 ```bash
-python - <<'PY'
-import csv
-with open("survey/output/cybernet_alejandro_untracked.csv", newline="", encoding="utf-8-sig") as src, \
-     open("survey/output/cybernet_untracked_host_targets.txt", "w", encoding="utf-8") as dst:
-    for row in csv.DictReader(src):
-        if row.get("HostName"):
-            dst.write(row["HostName"].strip() + "\n")
+python3 - survey/output/cybernet_alejandro_untracked.csv survey/output/cybernet_host_resolved.txt <<'PY'
+import csv, sys
+manifest, out = sys.argv[1:3]
+seen = []
+with open(manifest, newline='', encoding='utf-8-sig') as f:
+    for row in csv.DictReader(f):
+        host = (row.get('HostName') or '').strip()
+        if host and host not in seen:
+            seen.append(host)
+with open(out, 'w', encoding='utf-8') as f:
+    f.write('\n'.join(seen) + ('\n' if seen else ''))
+print(f'Wrote {len(seen)} host-resolved target(s) to {out}')
 PY
+```
+
+**2. Network preflight (DNS + ping + optional TCP)**
+
+```bash
+bash bash/transport/sas-network-preflight.sh \
+  --targets-file survey/output/cybernet_host_resolved.txt \
+  --ports 135,445 \
+  --output survey/output/cybernet_host_preflight.csv
+```
+
+**3. Workstation identity — ping first, WMI when approved, SSH only if explicitly enabled**
+
+The identity adapter always resolves DNS and runs ping before any optional transport. With `--allow-wmi`, WMI runs **before** SSH. Do not enable SSH for Cybernet field paths unless policy explicitly allows it.
+
+```bash
+export SAS_WMI_USER='approved_user'
+export SAS_WMI_PASS='from-secret-store'
+export SAS_WMI_DOMAIN='NSLIJHS'
 
 bash bash/transport/sas-workstation-identity.sh \
-  --targets-file survey/output/cybernet_untracked_host_targets.txt \
+  --targets-file survey/output/cybernet_host_resolved.txt \
   --allow-wmi \
-  --output survey/output/cybernet_untracked_wmi_identity.csv
+  --output survey/output/cybernet_workstation_identity.csv
 ```
+
+When WMI succeeds, expect `TransportUsed=WMI` and `IdentityStatus=IdentityCollected`. SSH failure notes (`SSHFailed:*`) indicate policy or environment blocks — classify per [`TEST_RESULT_CLASSIFICATION.md`](TEST_RESULT_CLASSIFICATION.md), not as device absence.
+
+**4. Optional — correlate identity against manifest expectations**
+
+```bash
+bash survey/sas-collect-cybernet-evidence.sh \
+  --manifest survey/output/cybernet_alejandro_untracked.csv \
+  --output survey/output/cybernet_evidence.csv
+```
+
+Note: `sas-collect-cybernet-evidence.sh` delegates to the workstation identity adapter but does not yet expose `--allow-wmi`. Run step 3 directly when WMI is required; use the evidence collector for manifest merge and tracker serial/MAC comparison when ping-only or SSH paths were used.
+
+Further correlation (DNS, AD, DHCP, approved Nmap) is documented in [`CYBERNET_EVIDENCE_CORRELATION.md`](CYBERNET_EVIDENCE_CORRELATION.md).
 
 ## Contract test
 
@@ -162,10 +237,18 @@ bash bash/transport/sas-workstation-identity.sh \
 bash Tests/bash/test-cybernet-xlsx-targets-contracts.sh
 ```
 
-Builds tiny fixture workbooks, runs the wrapper, and verifies manifest/report/gap outputs.
+Builds tiny fixture workbooks, runs the ingester and tracker diff wrappers, and verifies manifest/report/gap and serial-comparison outputs.
 
 ## Safety
 
 - Read-only: does not modify source `.xlsx` files
-- Offline: no network calls
+- Offline: no network calls during ingestion
 - Treat output CSVs as operational data; keep them out of git (repo ignores `*.csv` / `survey/output/*`)
+- Identity transports are read-only; no target-side writes, staging, or scheduled tasks
+
+## Related docs
+
+- [`targets/README.md`](../targets/README.md) — intake hub and gitignore policy
+- [`bash/transport/README.md`](../bash/transport/README.md) — identity adapter transports and status codes
+- [`CYBERNET_EVIDENCE_CORRELATION.md`](CYBERNET_EVIDENCE_CORRELATION.md) — multi-source presence merge
+- [`LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md) — reachability validation discipline

--- a/docs/CYBERNET_XLSX_TARGET_INGESTION.md
+++ b/docs/CYBERNET_XLSX_TARGET_INGESTION.md
@@ -71,6 +71,38 @@ bash survey/sas-cybernet-xlsx-targets.sh \
 
 Defaults write to `survey/output/cybernet_alejandro_*.csv` when `--output`, `--report`, or `--gaps` are omitted.
 
+## Alejandro vs deployment tracker diff
+
+When Alejandro's workbook is the authoritative Cybernet serial source, compare its unique serial
+inventory against the latest deployment tracker before probing anything live:
+
+```bash
+bash survey/sas-cybernet-tracker-diff.sh \
+  --alejandro "logs/targets/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
+  --tracker "logs/targets/Cybernet sources/Active Deployment Tracker 2026-05-17 - 6-25-2026.xlsx" \
+  --output-prefix survey/output/cybernet
+```
+
+The diff is read-only against both workbooks and writes local operational CSVs:
+
+- `survey/output/cybernet_alejandro_unique_serials.csv`
+- `survey/output/cybernet_tracker_unique_serials.csv`
+- `survey/output/cybernet_alejandro_already_tracked.csv`
+- `survey/output/cybernet_alejandro_untracked.csv`
+- `survey/output/cybernet_tracker_duplicate_exceptions.csv`
+
+Comparison rules:
+
+- Normalize serials by trimming whitespace and uppercasing.
+- Treat Alejandro rows as a unique serial inventory; duplicate Alejandro rows collapse into one serial with a row count.
+- Exclude an Alejandro serial from the untracked manifest when that serial already appears in the deployment tracker.
+- Emit duplicate exceptions only when the same normalized hostname, serial, or MAC appears in more than one tracker row marked `Deployed = Yes`.
+- Repeated non-deployed tracker identifiers are planning history, not duplicate exceptions.
+
+`cybernet_alejandro_untracked.csv` uses the same manifest schema as the ingester. Serial-only rows
+are retained for tracking, but only rows with a resolved `HostName` are ready for live WMI/ping
+identity checks.
+
 ## Outputs
 
 ### Manifest CSV
@@ -102,6 +134,26 @@ bash survey/sas-survey-targets.sh \
   --device-type Cybernet \
   --csv survey/output/cybernet_alejandro_targets.csv \
   --output survey/output/cybernet_targets_resolved.csv
+```
+
+For host-resolved untracked rows, prefer the read-only WMI/ping identity path before considering
+SSH. SSH is disabled by default in the transport adapter and a blocked SSH path is environment or
+policy evidence, not a product failure:
+
+```bash
+python - <<'PY'
+import csv
+with open("survey/output/cybernet_alejandro_untracked.csv", newline="", encoding="utf-8-sig") as src, \
+     open("survey/output/cybernet_untracked_host_targets.txt", "w", encoding="utf-8") as dst:
+    for row in csv.DictReader(src):
+        if row.get("HostName"):
+            dst.write(row["HostName"].strip() + "\n")
+PY
+
+bash bash/transport/sas-workstation-identity.sh \
+  --targets-file survey/output/cybernet_untracked_host_targets.txt \
+  --allow-wmi \
+  --output survey/output/cybernet_untracked_wmi_identity.csv
 ```
 
 ## Contract test

--- a/docs/CYBERNET_XLSX_TARGET_INGESTION.md
+++ b/docs/CYBERNET_XLSX_TARGET_INGESTION.md
@@ -17,7 +17,7 @@ Use this lane when Alejandro's workbook defines the **field population** and the
 
 - Alejandro rows and tracker enrichment define **registered population** — not reachability proof.
 - Naabu/Nmap and other network probes are **reachability validation only** after population is fixed. See [`LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md).
-- All CSV outputs stay on the admin box in gitignored paths (`survey/output/`, `targets/local/`). Do not commit live workbooks or generated CSVs.
+- Generated operational CSVs stay on the admin box in gitignored paths (`survey/output/`, `targets/local/`). Do not commit live workbooks or generated operational CSVs; sanitized fixture CSVs may still be tracked per repo `.gitignore` policy.
 - Assume authorized traffic may be monitored. Do not describe this workflow as stealth, evasion, or log bypass.
 
 **Evidence classification (identity transport)**
@@ -89,10 +89,13 @@ When Alejandro's workbook is the authoritative Cybernet serial source, compare i
 
 ```bash
 bash survey/sas-cybernet-tracker-diff.sh \
-  --alejandro "logs/targets/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
-  --tracker "logs/targets/Cybernet sources/Active Deployment Tracker 2026-05-17 - 6-25-2026.xlsx" \
+  --alejandro "<alejandro-workbook>.xlsx" \
+  --tracker "<deployment-tracker-workbook>.xlsx" \
   --output-prefix survey/output/cybernet
 ```
+
+Point `--alejandro` and `--tracker` at your local workbook paths. Keep live workbooks out of
+git and follow [`LOCAL_REFERENCE_POLICY.md`](LOCAL_REFERENCE_POLICY.md) for local file handling.
 
 The diff is read-only against both workbooks and writes local operational CSVs:
 
@@ -107,32 +110,34 @@ Comparison rules:
 - Normalize serials by trimming whitespace and uppercasing.
 - Treat Alejandro rows as a unique serial inventory; duplicate Alejandro rows collapse into one serial with a row count.
 - Exclude an Alejandro serial from the untracked manifest when that serial already appears in the deployment tracker.
-- Emit duplicate exceptions only when the same normalized hostname, serial, or MAC appears in more than one tracker row marked `Deployed = Yes`.
+- Emit duplicate exceptions only when the same normalized identifier appears in more than one tracker row marked `Deployed = Yes`. Identifier classes checked are Cybernet hostname, Cybernet serial, Cybernet MAC, Neuron MAC, and Neuron S/N.
 - Repeated non-deployed tracker identifiers are planning history, not duplicate exceptions.
 
-`cybernet_alejandro_untracked.csv` uses the same manifest schema as the ingester. Serial-only rows are retained for tracking, but only rows with a resolved `HostName` are ready for live WMI/ping identity checks.
+`cybernet_alejandro_untracked.csv` uses the same manifest schema as the ingester. Serial-only rows are retained for tracking, but only rows with a resolved `HostName` are ready for live WMI/ping identity checks. When one Alejandro serial maps to more than one hostname, the row stays serial-keyed (not probe-ready) and the candidate hostnames are preserved in `Source` as `review:ambiguous_hostnames=...`; the tool does not arbitrarily pick one hostname.
 
 ## Command
 
-Example using ignored local intake under `targets/local/` (preferred for new work):
+Example using ignored local intake under `targets/local/` (preferred for new work). Replace the
+placeholders with your local workbook paths; see [`LOCAL_REFERENCE_POLICY.md`](LOCAL_REFERENCE_POLICY.md)
+for local file handling:
 
 ```bash
 bash survey/sas-cybernet-xlsx-targets.sh \
-  --workbook "targets/local/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
-  --enrichment "targets/local/Cybernet sources/Active Deployment Tracker 2026-05-17 (1).xlsx" \
-  --enrichment "targets/local/Cybernet sources/ALL WAVE ANESTHESIA MACHINES (1).xlsx" \
+  --workbook "<alejandro-workbook>.xlsx" \
+  --enrichment "<deployment-tracker-workbook>.xlsx" \
+  --enrichment "<wave-supplement-workbook>.xlsx" \
   --output survey/output/cybernet_alejandro_targets.csv \
   --report survey/output/cybernet_alejandro_enrichment_report.csv \
   --gaps survey/output/cybernet_alejandro_gaps.csv \
   --device-type Cybernet
 ```
 
-Historical local evidence under `logs/targets/` remains valid — pass those paths instead if you have not migrated:
+Historical local evidence under `logs/targets/` remains valid — pass those local paths instead if you have not migrated:
 
 ```bash
 bash survey/sas-cybernet-xlsx-targets.sh \
-  --workbook "/path/to/logs/targets/Cybernet sources/Alejandro's list of Cybernets.xlsx" \
-  --enrichment "/path/to/logs/targets/Cybernet sources/Active Deployment Tracker 2026-05-17 (1).xlsx" \
+  --workbook "<local-alejandro-workbook>.xlsx" \
+  --enrichment "<local-deployment-tracker-workbook>.xlsx" \
   --output survey/output/cybernet_alejandro_targets.csv
 ```
 
@@ -250,7 +255,7 @@ Builds tiny fixture workbooks, runs the ingester and tracker diff wrappers, and 
 
 - Read-only: does not modify source `.xlsx` files
 - Offline: no network calls during ingestion
-- Treat output CSVs as operational data; keep them out of git (repo ignores `*.csv` / `survey/output/*`)
+- Treat generated operational outputs under `survey/output/` (and similar evidence paths) as local-only; they are gitignored. The repo ignores `*.csv` by default, but sanitized fixture CSVs (for example `*.sample.csv` / `*.example.csv` / `*.fixture.csv` under `survey/fixtures/` or `targets/sanitized/`) are intentionally tracked — do not assume every CSV must stay out of git.
 - Identity transports are read-only; no target-side writes, staging, or scheduled tasks
 
 ## Related docs

--- a/survey/sas-cybernet-tracker-diff.py
+++ b/survey/sas-cybernet-tracker-diff.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Compare Alejandro Cybernet serials against the deployment tracker inventory."""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    from openpyxl import load_workbook
+except ImportError:
+    print("[sas-cybernet-tracker-diff] ERROR: openpyxl required (pip install openpyxl)", file=sys.stderr)
+    sys.exit(1)
+
+EMPTY = {"", "N/A", "NA", "NONE", "NULL", "-", "--", "TBD", "UNKNOWN", "#N/A", "#REF!"}
+MAC_RE = re.compile(r"(?i)(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}")
+MANIFEST_FIELDS = ["Identifier", "IdentifierType", "DeviceType", "HostName", "Serial", "MACAddress", "Source"]
+ALEJANDRO_FIELDS = ["Serial", "RowCount", "HostNames", "Sources", "ProbeReady"]
+TRACKER_FIELDS = ["Serial", "TrackerRowCount", "DeployedYesCount", "HostNames", "MACAddresses", "Sources"]
+TRACKED_FIELDS = [
+    "Serial", "AlejandroRowCount", "AlejandroHostNames", "TrackerRowCount",
+    "TrackerDeployedYesCount", "TrackerHostNames", "TrackerMACAddresses", "Sources",
+]
+DUP_FIELDS = [
+    "IdentifierKind", "Identifier", "DeployedYesCount", "TrackerRowCount",
+    "HostNames", "Serials", "MACAddresses", "Sources",
+]
+
+
+def clean(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return "" if text.upper() in EMPTY else text
+
+
+def norm_serial(value: object) -> str:
+    text = re.sub(r"\s+", "", clean(value)).upper()
+    return text if len(text) >= 3 else ""
+
+
+def norm_host(value: object) -> str:
+    return re.sub(r"\s+", "", clean(value)).upper()
+
+
+def norm_mac(value: object) -> str:
+    match = MAC_RE.search(clean(value))
+    if not match:
+        return ""
+    raw = re.sub(r"[^0-9A-Fa-f]", "", match.group(0)).upper()
+    return ":".join(raw[i : i + 2] for i in range(0, 12, 2)) if len(raw) == 12 else ""
+
+
+def norm_header(value: object) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip()).lower()
+
+
+def joined(values: set[str]) -> str:
+    return ";".join(sorted(v for v in values if v))
+
+
+def write_csv(path: Path, fields: list[str], rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, quoting=csv.QUOTE_ALL, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_alejandro(path: Path) -> dict[str, dict[str, object]]:
+    serials: dict[str, dict[str, object]] = {}
+    wb = load_workbook(path, read_only=True, data_only=True)
+    try:
+        for ws in wb.worksheets:
+            title = ws.title.strip()
+            upper = title.upper()
+            if "AKBAR WAVE" in upper:
+                for row_index, row in enumerate(ws.iter_rows(values_only=True), start=1):
+                    serial = norm_serial(row[0] if row else "")
+                    if serial:
+                        add_alejandro(serials, serial, "", f"{path.name}:{title}:R{row_index}")
+            elif upper.startswith("PO"):
+                for row_index, row in enumerate(ws.iter_rows(values_only=True), start=1):
+                    host = norm_host(row[0] if len(row) > 0 else "")
+                    serial = norm_serial(row[1] if len(row) > 1 else "")
+                    if serial:
+                        add_alejandro(serials, serial, host, f"{path.name}:{title}:R{row_index}")
+    finally:
+        wb.close()
+    return serials
+
+
+def add_alejandro(serials: dict[str, dict[str, object]], serial: str, host: str, source: str) -> None:
+    rec = serials.setdefault(serial, {"count": 0, "hosts": set(), "sources": set()})
+    rec["count"] = int(rec["count"]) + 1
+    rec["hosts"].add(host)
+    rec["sources"].add(source)
+
+
+def find_header_row(rows: list[tuple[object, ...]], scan_limit: int) -> tuple[int, dict[str, int]]:
+    aliases = {
+        "deployed": "deployed",
+        "device type": "device_type",
+        "cybernet hostname": "host",
+        "cybernet host": "host",
+        "hostname": "host",
+        "computer name": "host",
+        "cybernet serial": "serial",
+        "cybernet serial number": "serial",
+        "serial number": "serial",
+        "serial": "serial",
+        "cybernet mac": "mac",
+        "cybernet mac address": "mac",
+        "mac address": "mac",
+        "mac": "mac",
+    }
+    for index, row in enumerate(rows[:scan_limit]):
+        mapped: dict[str, int] = {}
+        for col_index, value in enumerate(row):
+            key = aliases.get(norm_header(value))
+            if key and key not in mapped:
+                mapped[key] = col_index
+        if "serial" in mapped and ("host" in mapped or "deployed" in mapped):
+            return index, mapped
+    return -1, {}
+
+
+def row_value(row: tuple[object, ...], index: int | None) -> str:
+    return clean(row[index]) if index is not None and index < len(row) else ""
+
+
+def parse_tracker(path: Path, sheet_name: str, header_scan_rows: int) -> tuple[dict[str, dict[str, object]], list[dict[str, str]]]:
+    serials: dict[str, dict[str, object]] = {}
+    identifier_rows: list[dict[str, str]] = []
+    wb = load_workbook(path, read_only=True, data_only=True)
+    try:
+        if sheet_name not in wb.sheetnames:
+            raise ValueError(f"sheet not found: {sheet_name}")
+        ws = wb[sheet_name]
+        rows = list(ws.iter_rows(values_only=True))
+    finally:
+        wb.close()
+
+    header_index, columns = find_header_row(rows, header_scan_rows)
+    if header_index < 0:
+        raise ValueError(f"could not find tracker headers in first {header_scan_rows} rows")
+
+    for offset, row in enumerate(rows[header_index + 1 :], start=header_index + 2):
+        host = norm_host(row_value(row, columns.get("host")))
+        serial = norm_serial(row_value(row, columns.get("serial")))
+        mac = norm_mac(row_value(row, columns.get("mac")))
+        deployed = row_value(row, columns.get("deployed")).upper() == "YES"
+        if not (host or serial or mac):
+            continue
+        source = f"{path.name}:{sheet_name}:R{offset}"
+        if serial:
+            add_tracker_serial(serials, serial, host, mac, deployed, source)
+        identifier_rows.append({"host": host, "serial": serial, "mac": mac, "deployed": "YES" if deployed else "NO", "source": source})
+    return serials, identifier_rows
+
+
+def add_tracker_serial(serials: dict[str, dict[str, object]], serial: str, host: str, mac: str, deployed: bool, source: str) -> None:
+    rec = serials.setdefault(serial, {"count": 0, "deployed": 0, "hosts": set(), "macs": set(), "sources": set()})
+    rec["count"] = int(rec["count"]) + 1
+    rec["deployed"] = int(rec["deployed"]) + (1 if deployed else 0)
+    rec["hosts"].add(host)
+    rec["macs"].add(mac)
+    rec["sources"].add(source)
+
+
+def duplicate_exceptions(identifier_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
+    for row in identifier_rows:
+        for kind in ("host", "serial", "mac"):
+            value = row[kind]
+            if value:
+                grouped[(kind, value)].append(row)
+
+    exceptions = []
+    for (kind, value), rows in sorted(grouped.items()):
+        deployed_count = sum(1 for row in rows if row["deployed"] == "YES")
+        if deployed_count <= 1:
+            continue
+        exceptions.append({
+            "IdentifierKind": kind,
+            "Identifier": value,
+            "DeployedYesCount": str(deployed_count),
+            "TrackerRowCount": str(len(rows)),
+            "HostNames": joined({row["host"] for row in rows}),
+            "Serials": joined({row["serial"] for row in rows}),
+            "MACAddresses": joined({row["mac"] for row in rows}),
+            "Sources": joined({row["source"] for row in rows}),
+        })
+    return exceptions
+
+
+def alejandro_rows(alejandro: dict[str, dict[str, object]]) -> list[dict[str, str]]:
+    rows = []
+    for serial, rec in sorted(alejandro.items()):
+        hosts = rec["hosts"]
+        rows.append({
+            "Serial": serial,
+            "RowCount": str(rec["count"]),
+            "HostNames": joined(hosts),
+            "Sources": joined(rec["sources"]),
+            "ProbeReady": "Yes" if any(hosts) else "No",
+        })
+    return rows
+
+
+def tracker_rows(tracker: dict[str, dict[str, object]]) -> list[dict[str, str]]:
+    return [{
+        "Serial": serial,
+        "TrackerRowCount": str(rec["count"]),
+        "DeployedYesCount": str(rec["deployed"]),
+        "HostNames": joined(rec["hosts"]),
+        "MACAddresses": joined(rec["macs"]),
+        "Sources": joined(rec["sources"]),
+    } for serial, rec in sorted(tracker.items())]
+
+
+def already_tracked_rows(alejandro: dict[str, dict[str, object]], tracker: dict[str, dict[str, object]]) -> list[dict[str, str]]:
+    rows = []
+    for serial in sorted(set(alejandro) & set(tracker)):
+        arec, trec = alejandro[serial], tracker[serial]
+        rows.append({
+            "Serial": serial,
+            "AlejandroRowCount": str(arec["count"]),
+            "AlejandroHostNames": joined(arec["hosts"]),
+            "TrackerRowCount": str(trec["count"]),
+            "TrackerDeployedYesCount": str(trec["deployed"]),
+            "TrackerHostNames": joined(trec["hosts"]),
+            "TrackerMACAddresses": joined(trec["macs"]),
+            "Sources": joined(arec["sources"] | trec["sources"]),
+        })
+    return rows
+
+
+def untracked_manifest(alejandro: dict[str, dict[str, object]], tracker: dict[str, dict[str, object]], device_type: str) -> list[dict[str, str]]:
+    rows = []
+    for serial in sorted(set(alejandro) - set(tracker)):
+        rec = alejandro[serial]
+        host = sorted(h for h in rec["hosts"] if h)
+        hostname = host[0] if host else ""
+        rows.append({
+            "Identifier": hostname or serial,
+            "IdentifierType": "HostName" if hostname else "Serial",
+            "DeviceType": device_type,
+            "HostName": hostname,
+            "Serial": serial,
+            "MACAddress": "",
+            "Source": joined(rec["sources"]),
+        })
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Diff Alejandro Cybernet serials against deployment tracker serial inventory")
+    parser.add_argument("--alejandro", required=True, help="Alejandro-style Cybernet workbook")
+    parser.add_argument("--tracker", required=True, help="Deployment tracker workbook")
+    parser.add_argument("--tracker-sheet", default="Deployments")
+    parser.add_argument("--output-prefix", default="survey/output/cybernet")
+    parser.add_argument("--device-type", default="Cybernet")
+    parser.add_argument("--header-scan-rows", type=int, default=40)
+    args = parser.parse_args()
+
+    alejandro_path, tracker_path = Path(args.alejandro), Path(args.tracker)
+    if not alejandro_path.is_file():
+        print(f"[sas-cybernet-tracker-diff] ERROR: Alejandro workbook not found: {alejandro_path}", file=sys.stderr)
+        return 1
+    if not tracker_path.is_file():
+        print(f"[sas-cybernet-tracker-diff] ERROR: tracker workbook not found: {tracker_path}", file=sys.stderr)
+        return 1
+
+    try:
+        alejandro = parse_alejandro(alejandro_path)
+        tracker, identifier_rows = parse_tracker(tracker_path, args.tracker_sheet, args.header_scan_rows)
+    except ValueError as exc:
+        print(f"[sas-cybernet-tracker-diff] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    prefix = Path(args.output_prefix)
+    outputs = {
+        f"{prefix}_alejandro_unique_serials.csv": (ALEJANDRO_FIELDS, alejandro_rows(alejandro)),
+        f"{prefix}_tracker_unique_serials.csv": (TRACKER_FIELDS, tracker_rows(tracker)),
+        f"{prefix}_alejandro_already_tracked.csv": (TRACKED_FIELDS, already_tracked_rows(alejandro, tracker)),
+        f"{prefix}_alejandro_untracked.csv": (MANIFEST_FIELDS, untracked_manifest(alejandro, tracker, args.device_type)),
+        f"{prefix}_tracker_duplicate_exceptions.csv": (DUP_FIELDS, duplicate_exceptions(identifier_rows)),
+    }
+    for path_str, (fields, rows) in outputs.items():
+        write_csv(Path(path_str), fields, rows)
+        print(f"[sas-cybernet-tracker-diff] wrote {path_str} rows={len(rows)}")
+
+    print(
+        "[sas-cybernet-tracker-diff] "
+        f"alejandro_unique_serials={len(alejandro)} "
+        f"tracker_unique_serials={len(tracker)} "
+        f"already_tracked={len(set(alejandro) & set(tracker))} "
+        f"untracked={len(set(alejandro) - set(tracker))}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/survey/sas-cybernet-tracker-diff.py
+++ b/survey/sas-cybernet-tracker-diff.py
@@ -17,6 +17,16 @@ except ImportError:
 
 EMPTY = {"", "N/A", "NA", "NONE", "NULL", "-", "--", "TBD", "UNKNOWN", "#N/A", "#REF!"}
 MAC_RE = re.compile(r"(?i)(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}|[0-9a-f]{12}")
+HOSTNAME_RE = re.compile(r"^[A-Za-z]{2,6}\d{2,}[A-Za-z0-9_-]*$|^[A-Za-z0-9]+[-_][A-Za-z0-9]+")
+HEADER_TOKENS = {
+    "serial", "serial number", "cybernet serial", "cybernet serial number",
+    "pc / cybernet serial no", "service tag",
+    "host", "hostname", "host name", "cybernet host", "cybernet hostname",
+    "computer name", "pc name",
+    "mac", "mac address", "cybernet mac", "cybernet mac address",
+    "neuron mac", "neuron mac address", "neuron s/n", "neuron serial", "neuron serial number",
+    "device type", "deployed",
+}
 MANIFEST_FIELDS = ["Identifier", "IdentifierType", "DeviceType", "HostName", "Serial", "MACAddress", "Source"]
 ALEJANDRO_FIELDS = ["Serial", "RowCount", "HostNames", "Sources", "ProbeReady"]
 TRACKER_FIELDS = ["Serial", "TrackerRowCount", "DeployedYesCount", "HostNames", "MACAddresses", "Sources"]
@@ -26,8 +36,9 @@ TRACKED_FIELDS = [
 ]
 DUP_FIELDS = [
     "IdentifierKind", "Identifier", "DeployedYesCount", "TrackerRowCount",
-    "HostNames", "Serials", "MACAddresses", "Sources",
+    "HostNames", "Serials", "MACAddresses", "NeuronMACAddresses", "NeuronSerials", "Sources",
 ]
+DUP_IDENTIFIER_KINDS = ("host", "serial", "mac", "neuron_mac", "neuron_sn")
 
 
 def clean(value: object) -> str:
@@ -43,7 +54,8 @@ def norm_serial(value: object) -> str:
 
 
 def norm_host(value: object) -> str:
-    return re.sub(r"\s+", "", clean(value)).upper()
+    text = re.sub(r"\s+", "", clean(value)).upper()
+    return text if text and HOSTNAME_RE.search(text) else ""
 
 
 def norm_mac(value: object) -> str:
@@ -56,6 +68,10 @@ def norm_mac(value: object) -> str:
 
 def norm_header(value: object) -> str:
     return re.sub(r"\s+", " ", str(value or "").strip()).lower()
+
+
+def is_header_label(value: object) -> bool:
+    return norm_header(value) in HEADER_TOKENS
 
 
 def joined(values: set[str]) -> str:
@@ -79,13 +95,20 @@ def parse_alejandro(path: Path) -> dict[str, dict[str, object]]:
             upper = title.upper()
             if "AKBAR WAVE" in upper:
                 for row_index, row in enumerate(ws.iter_rows(values_only=True), start=1):
-                    serial = norm_serial(row[0] if row else "")
+                    cell = row[0] if row else ""
+                    if is_header_label(cell):
+                        continue
+                    serial = norm_serial(cell)
                     if serial:
                         add_alejandro(serials, serial, "", f"{path.name}:{title}:R{row_index}")
             elif upper.startswith("PO"):
                 for row_index, row in enumerate(ws.iter_rows(values_only=True), start=1):
-                    host = norm_host(row[0] if len(row) > 0 else "")
-                    serial = norm_serial(row[1] if len(row) > 1 else "")
+                    host_cell = row[0] if len(row) > 0 else ""
+                    serial_cell = row[1] if len(row) > 1 else ""
+                    if is_header_label(host_cell) or is_header_label(serial_cell):
+                        continue
+                    host = norm_host(host_cell)
+                    serial = norm_serial(serial_cell)
                     if serial:
                         add_alejandro(serials, serial, host, f"{path.name}:{title}:R{row_index}")
     finally:
@@ -116,6 +139,11 @@ def find_header_row(rows: list[tuple[object, ...]], scan_limit: int) -> tuple[in
         "cybernet mac address": "mac",
         "mac address": "mac",
         "mac": "mac",
+        "neuron mac": "neuron_mac",
+        "neuron mac address": "neuron_mac",
+        "neuron s/n": "neuron_sn",
+        "neuron serial": "neuron_sn",
+        "neuron serial number": "neuron_sn",
     }
     for index, row in enumerate(rows[:scan_limit]):
         mapped: dict[str, int] = {}
@@ -152,13 +180,19 @@ def parse_tracker(path: Path, sheet_name: str, header_scan_rows: int) -> tuple[d
         host = norm_host(row_value(row, columns.get("host")))
         serial = norm_serial(row_value(row, columns.get("serial")))
         mac = norm_mac(row_value(row, columns.get("mac")))
+        neuron_mac = norm_mac(row_value(row, columns.get("neuron_mac")))
+        neuron_sn = norm_serial(row_value(row, columns.get("neuron_sn")))
         deployed = row_value(row, columns.get("deployed")).upper() == "YES"
-        if not (host or serial or mac):
+        if not (host or serial or mac or neuron_mac or neuron_sn):
             continue
         source = f"{path.name}:{sheet_name}:R{offset}"
         if serial:
             add_tracker_serial(serials, serial, host, mac, deployed, source)
-        identifier_rows.append({"host": host, "serial": serial, "mac": mac, "deployed": "YES" if deployed else "NO", "source": source})
+        identifier_rows.append({
+            "host": host, "serial": serial, "mac": mac,
+            "neuron_mac": neuron_mac, "neuron_sn": neuron_sn,
+            "deployed": "YES" if deployed else "NO", "source": source,
+        })
     return serials, identifier_rows
 
 
@@ -174,8 +208,8 @@ def add_tracker_serial(serials: dict[str, dict[str, object]], serial: str, host:
 def duplicate_exceptions(identifier_rows: list[dict[str, str]]) -> list[dict[str, str]]:
     grouped: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
     for row in identifier_rows:
-        for kind in ("host", "serial", "mac"):
-            value = row[kind]
+        for kind in DUP_IDENTIFIER_KINDS:
+            value = row.get(kind, "")
             if value:
                 grouped[(kind, value)].append(row)
 
@@ -192,6 +226,8 @@ def duplicate_exceptions(identifier_rows: list[dict[str, str]]) -> list[dict[str
             "HostNames": joined({row["host"] for row in rows}),
             "Serials": joined({row["serial"] for row in rows}),
             "MACAddresses": joined({row["mac"] for row in rows}),
+            "NeuronMACAddresses": joined({row.get("neuron_mac", "") for row in rows}),
+            "NeuronSerials": joined({row.get("neuron_sn", "") for row in rows}),
             "Sources": joined({row["source"] for row in rows}),
         })
     return exceptions
@@ -200,13 +236,15 @@ def duplicate_exceptions(identifier_rows: list[dict[str, str]]) -> list[dict[str
 def alejandro_rows(alejandro: dict[str, dict[str, object]]) -> list[dict[str, str]]:
     rows = []
     for serial, rec in sorted(alejandro.items()):
-        hosts = rec["hosts"]
+        hosts = sorted(h for h in rec["hosts"] if h)
         rows.append({
             "Serial": serial,
             "RowCount": str(rec["count"]),
-            "HostNames": joined(hosts),
+            "HostNames": joined(set(hosts)),
             "Sources": joined(rec["sources"]),
-            "ProbeReady": "Yes" if any(hosts) else "No",
+            # probe-ready only when exactly one resolved hostname; multiple
+            # hostnames stay review-required rather than crowning one.
+            "ProbeReady": "Yes" if len(hosts) == 1 else "No",
         })
     return rows
 
@@ -243,16 +281,27 @@ def untracked_manifest(alejandro: dict[str, dict[str, object]], tracker: dict[st
     rows = []
     for serial in sorted(set(alejandro) - set(tracker)):
         rec = alejandro[serial]
-        host = sorted(h for h in rec["hosts"] if h)
-        hostname = host[0] if host else ""
+        hosts = sorted(h for h in rec["hosts"] if h)
+        source = joined(rec["sources"])
+        if len(hosts) == 1:
+            # exactly one resolved hostname: probe-ready
+            hostname = hosts[0]
+            identifier, identifier_type = hostname, "HostName"
+        else:
+            # zero or multiple hostnames: do not crown one; keep serial-keyed and
+            # not probe-ready. Surface ambiguous candidates for human review.
+            hostname = ""
+            identifier, identifier_type = serial, "Serial"
+            if len(hosts) > 1:
+                source = f"{source};review:ambiguous_hostnames={'|'.join(hosts)}"
         rows.append({
-            "Identifier": hostname or serial,
-            "IdentifierType": "HostName" if hostname else "Serial",
+            "Identifier": identifier,
+            "IdentifierType": identifier_type,
             "DeviceType": device_type,
             "HostName": hostname,
             "Serial": serial,
             "MACAddress": "",
-            "Source": joined(rec["sources"]),
+            "Source": source,
         })
     return rows
 

--- a/survey/sas-cybernet-tracker-diff.sh
+++ b/survey/sas-cybernet-tracker-diff.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SysAdminSuite Alejandro-vs-tracker Cybernet serial diff (read-only workbook inputs)
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Cybernet Alejandro/tracker serial diff
+
+Usage:
+  bash survey/sas-cybernet-tracker-diff.sh --alejandro PATH.xlsx --tracker PATH.xlsx [options]
+
+Options:
+  --alejandro PATH          Alejandro-style Cybernet workbook (required)
+  --tracker PATH            Deployment tracker workbook (required)
+  --tracker-sheet NAME      Default: Deployments
+  --output-prefix PREFIX    Default: survey/output/cybernet
+  --device-type TYPE        Default: Cybernet
+  --header-scan-rows N      Default: 40
+  -h, --help                Show help
+
+Outputs:
+  PREFIX_alejandro_unique_serials.csv
+  PREFIX_tracker_unique_serials.csv
+  PREFIX_alejandro_already_tracked.csv
+  PREFIX_alejandro_untracked.csv
+  PREFIX_tracker_duplicate_exceptions.csv
+USAGE
+}
+
+ALEJANDRO=""
+TRACKER=""
+TRACKER_SHEET="Deployments"
+OUTPUT_PREFIX="survey/output/cybernet"
+DEVICE_TYPE="Cybernet"
+HEADER_SCAN_ROWS="40"
+PYTHON_CMD=()
+
+find_python() {
+  if [[ ${#PYTHON_CMD[@]} -gt 0 ]]; then return 0; fi
+  if command -v python3 >/dev/null 2>&1; then PYTHON_CMD=(python3); return 0; fi
+  if command -v python >/dev/null 2>&1; then PYTHON_CMD=(python); return 0; fi
+  if command -v py >/dev/null 2>&1; then PYTHON_CMD=(py -3); return 0; fi
+  echo "[sas-cybernet-tracker-diff] ERROR: Python 3 required" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --alejandro) ALEJANDRO="${2:?}"; shift 2 ;;
+    --tracker) TRACKER="${2:?}"; shift 2 ;;
+    --tracker-sheet) TRACKER_SHEET="${2:?}"; shift 2 ;;
+    --output-prefix) OUTPUT_PREFIX="${2:?}"; shift 2 ;;
+    --device-type) DEVICE_TYPE="${2:?}"; shift 2 ;;
+    --header-scan-rows) HEADER_SCAN_ROWS="${2:?}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "[sas-cybernet-tracker-diff] ERROR: unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+[[ -n "$ALEJANDRO" ]] || { echo "[sas-cybernet-tracker-diff] ERROR: --alejandro required" >&2; exit 1; }
+[[ -n "$TRACKER" ]] || { echo "[sas-cybernet-tracker-diff] ERROR: --tracker required" >&2; exit 1; }
+[[ "$HEADER_SCAN_ROWS" =~ ^[0-9]+$ && "$HEADER_SCAN_ROWS" -ge 1 ]] || {
+  echo "[sas-cybernet-tracker-diff] ERROR: --header-scan-rows must be a positive integer" >&2
+  exit 1
+}
+
+find_python
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${PYTHON_CMD[@]}" "$SCRIPT_DIR/sas-cybernet-tracker-diff.py" \
+  --alejandro "$ALEJANDRO" \
+  --tracker "$TRACKER" \
+  --tracker-sheet "$TRACKER_SHEET" \
+  --output-prefix "$OUTPUT_PREFIX" \
+  --device-type "$DEVICE_TYPE" \
+  --header-scan-rows "$HEADER_SCAN_ROWS"


### PR DESCRIPTION
## Summary
- Add Cybernet tracker-diff tooling that compares Alejandro unique serials against tracker `Cybernet Serial` inventory.
- Preserve Deployment Tracker duplicate doctrine: only the same normalized identifier marked `Deployed = Yes` more than once is treated as a duplicate; repeated non-deployed identifiers are not duplicates.
- Add registry-evidence hygiene so raw `logs/registry/` outputs remain local and ignored.

## Safety / Scope
- Serial-only rows are retained for reconciliation but are not probe-ready for live identity checks.
- Generated tracker-diff outputs belong under gitignored `survey/output/`.
- Raw registry evidence belongs under gitignored `logs/registry/`.
- No live hostnames, serials, MACs, IPs, XLSX, ZIP, dashboard exports, Nmap/Naabu output, or raw registry output are committed.
- PR #80 is unrelated and intentionally untouched.

## Validation
- `git status --short` clean
- `git diff --check` clean
- `git ls-files --others --exclude-standard` empty
- `bash Tests/bash/test-cybernet-xlsx-targets-contracts.sh` PASS
- `bash Tests/bash/test_northwell_registry_verification_contracts.sh` PASS