### PR TITLE
feat(survey): serial-first Cybernet survey progress summary

### DIFF
--- a/Tests/bash/test-cybernet-serial-progress-contracts.sh
+++ b/Tests/bash/test-cybernet-serial-progress-contracts.sh
@@ -19,6 +19,7 @@ bash -n "$DIFF_RUNNER"
 PYTHON_CMD=(python3)
 command -v python3 >/dev/null 2>&1 || PYTHON_CMD=(python)
 command -v "${PYTHON_CMD[0]}" >/dev/null 2>&1 || { echo "python required for progress contract test"; exit 1; }
+"${PYTHON_CMD[@]}" -c 'import openpyxl' >/dev/null 2>&1 || { echo "openpyxl required for progress contract test (pip install openpyxl)"; exit 1; }
 
 fail() { printf '[cybernet-progress-contracts] FAIL: %s\n' "$*" >&2; exit 1; }
 pass() { printf '[cybernet-progress-contracts] PASS: %s\n' "$*"; }
@@ -31,6 +32,7 @@ ALEJANDRO="$TMP_DIR/alejandro-progress.xlsx"
 TRACKER="$TMP_DIR/tracker-progress.xlsx"
 IDENTITY_CSV="$TMP_DIR/workstation_identity.csv"
 PREFLIGHT_CSV="$TMP_DIR/network_preflight.csv"
+AD_CSV="$TMP_DIR/ad_live_serial.csv"
 
 # --- build synthetic fixtures ---
 "${PYTHON_CMD[@]}" - "$ALEJANDRO" "$TRACKER" "$IDENTITY_CSV" "$PREFLIGHT_CSV" <<'PY'
@@ -68,6 +70,15 @@ with open(preflight_csv, "w", newline="", encoding="utf-8") as fh:
     fh.write("Target,ResolvedAddress,PingStatus,Port,PortStatus,Timestamp\n")
     fh.write("WTS001OPR501,10.0.0.5,Reachable,445,Open,2026-06-25T00:00:00Z\n")
 PY
+
+# AD live-serial export evidence uses the exporter's real columns
+# (ADHostname/DNSHostName/ADSerial). Row 1 resolves a host only from an FQDN
+# DNSHostName; row 2 matches purely on ADSerial.
+cat > "$AD_CSV" <<'CSV'
+ADHostname,DNSHostName,ADSerial,ADMAC,ADEnabled,Notes
+,WTS001OPR501.med.example.com,,,True,synthetic-ad-host
+,,MEDTEST24-AMB01,,True,synthetic-ad-serial
+CSV
 
 json_field() {
   local path="$1" field="$2"
@@ -154,6 +165,18 @@ C_JSON="${C_PREFIX}_progress_summary.json"
 [[ "$(json_field "$C_JSON" SurveyedSerials)" == "1" ]] || fail "ping reachability alone must not mark a serial surveyed"
 [[ "$(json_field "$C_JSON" PercentComplete)" == "25.0" ]] || fail "ping-only evidence must not raise percent complete"
 pass "ping reachability stays candidate-only (not serial proof)"
+
+# --- Case D: AD live-serial export feeds ADCandidateSerials (exporter columns) ---
+D_PREFIX="$TMP_DIR/e/cybernet"
+bash "$DIFF_RUNNER" --alejandro "$ALEJANDRO" --tracker "$TRACKER" --output-prefix "$D_PREFIX" \
+  --device-type Cybernet --ad-serial-csv "$AD_CSV" >/dev/null
+D_JSON="${D_PREFIX}_progress_summary.json"
+# ADHostname/DNSHostName/ADSerial aliases must be read (host from FQDN + serial)
+[[ "$(json_field "$D_JSON" ADCandidateSerials)" == "2" ]] || fail "AD evidence (ADHostname/DNSHostName/ADSerial) must yield 2 AD candidate serials"
+# AD evidence is candidate-only and must never confirm a serial as surveyed
+[[ "$(json_field "$D_JSON" SurveyedSerials)" == "1" ]] || fail "AD candidates must not mark a serial surveyed"
+[[ "$(json_field "$D_JSON" PercentComplete)" == "25.0" ]] || fail "AD candidate evidence must not raise percent complete"
+pass "AD live-serial export populates AD candidates (exporter schema, candidate-only)"
 
 # 8. generated operational progress output is gitignored under survey/output/
 OUT_PREFIX="survey/output/progress_contract_cybernet"

--- a/Tests/bash/test-cybernet-serial-progress-contracts.sh
+++ b/Tests/bash/test-cybernet-serial-progress-contracts.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Contract tests for serial-first Cybernet survey progress reporting.
+#
+# All fixtures are synthetic (MEDTEST24-* serials, WTS001OPR* hostnames). The
+# denominator for every progress metric must be unique Alejandro serials, never
+# hostname rows. Ping/AD evidence is enrichment only; only IdentityCollected
+# expands SurveyedSerials for an untracked serial.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+DIFF_RUNNER="survey/sas-cybernet-tracker-diff.sh"
+DIFF_PY="survey/sas-cybernet-tracker-diff.py"
+[[ -f "$DIFF_RUNNER" ]] || { echo "missing tracker diff runner: $DIFF_RUNNER"; exit 1; }
+[[ -f "$DIFF_PY" ]] || { echo "missing tracker diff python: $DIFF_PY"; exit 1; }
+bash -n "$DIFF_RUNNER"
+
+PYTHON_CMD=(python3)
+command -v python3 >/dev/null 2>&1 || PYTHON_CMD=(python)
+command -v "${PYTHON_CMD[0]}" >/dev/null 2>&1 || { echo "python required for progress contract test"; exit 1; }
+
+fail() { printf '[cybernet-progress-contracts] FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf '[cybernet-progress-contracts] PASS: %s\n' "$*"; }
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+ALEJANDRO="$TMP_DIR/alejandro-progress.xlsx"
+TRACKER="$TMP_DIR/tracker-progress.xlsx"
+IDENTITY_CSV="$TMP_DIR/workstation_identity.csv"
+PREFLIGHT_CSV="$TMP_DIR/network_preflight.csv"
+
+# --- build synthetic fixtures ---
+"${PYTHON_CMD[@]}" - "$ALEJANDRO" "$TRACKER" "$IDENTITY_CSV" "$PREFLIGHT_CSV" <<'PY'
+import sys
+from openpyxl import Workbook
+
+alejandro, tracker, identity_csv, preflight_csv = sys.argv[1:5]
+
+wb = Workbook()
+wave = wb.active
+wave.title = "AKBAR WAVE 1"
+wave["A1"] = "MEDTEST24-TRK01"   # overlaps tracker -> surveyed via tracker
+wave["A2"] = "MEDTEST24-SO01"    # serial-only, zero host -> review-required
+po = wb.create_sheet("PO 1")
+po["A1"] = "WTS001OPR501"        # exactly one host -> host-resolved / probe-ready
+po["B1"] = "MEDTEST24-ONE01"
+po["A2"] = "WTS001OPR601"        # ambiguous: two hosts, one serial
+po["B2"] = "MEDTEST24-AMB01"
+po["A3"] = "WTS001OPR602"
+po["B3"] = "MEDTEST24-AMB01"
+wb.save(alejandro)
+
+twb = Workbook()
+dep = twb.active
+dep.title = "Deployments"
+dep.append(["Device Type", "Cybernet Hostname", "Cybernet Serial", "Cybernet MAC", "Neuron S/N", "Deployed"])
+dep.append(["Cybernet-Neuron", "WTS001OPR401", "MEDTEST24-TRK01", "000D050AA401", "NEU-TRK01", "Yes"])
+twb.save(tracker)
+
+with open(identity_csv, "w", newline="", encoding="utf-8") as fh:
+    fh.write("Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes\n")
+    fh.write("2026-06-25T00:00:00Z,WTS001OPR501,10.0.0.5,Reachable,WTS001OPR501,WTS001OPR501,MEDTEST24-ONE01,000D050AA501,WMI,IdentityCollected,synthetic\n")
+
+with open(preflight_csv, "w", newline="", encoding="utf-8") as fh:
+    fh.write("Target,ResolvedAddress,PingStatus,Port,PortStatus,Timestamp\n")
+    fh.write("WTS001OPR501,10.0.0.5,Reachable,445,Open,2026-06-25T00:00:00Z\n")
+PY
+
+json_field() {
+  local path="$1" field="$2"
+  "${PYTHON_CMD[@]}" - "$path" "$field" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+print(data[sys.argv[2]])
+PY
+}
+
+# --- Case A: no optional evidence (baseline serial-first denominator) ---
+A_PREFIX="$TMP_DIR/a/cybernet"
+bash "$DIFF_RUNNER" --alejandro "$ALEJANDRO" --tracker "$TRACKER" --output-prefix "$A_PREFIX" --device-type Cybernet >/dev/null
+A_JSON="${A_PREFIX}_progress_summary.json"
+A_CSV="${A_PREFIX}_progress_summary.csv"
+[[ -f "$A_JSON" ]] || fail "missing progress JSON summary"
+[[ -f "$A_CSV" ]] || fail "missing progress CSV summary"
+
+# 1. denominator is unique Alejandro serial count (4 serials despite 5 hostname rows)
+[[ "$(json_field "$A_JSON" TotalSerialTargets)" == "4" ]] || fail "TotalSerialTargets must equal unique Alejandro serials (4)"
+[[ "$(json_field "$A_JSON" PopulationAuthority)" == "alejandro_serials" ]] || fail "PopulationAuthority must be alejandro_serials"
+
+# 2 + 3 + 4. host-resolved / serial-only / ambiguous bucket counts
+[[ "$(json_field "$A_JSON" HostResolvedSerials)" == "1" ]] || fail "exactly-one-host serial must count as host-resolved"
+[[ "$(json_field "$A_JSON" SerialOnlyReviewRequired)" == "2" ]] || fail "zero-host serials must count as serial-only review-required"
+[[ "$(json_field "$A_JSON" AmbiguousHostnameSerials)" == "1" ]] || fail "multi-host serial must count as ambiguous"
+
+# 5. percent complete derived from serial targets (1 tracked / 4 total = 25.0), not hostname rows
+[[ "$(json_field "$A_JSON" SurveyedSerials)" == "1" ]] || fail "baseline surveyed must equal tracker overlap (1)"
+[[ "$(json_field "$A_JSON" PercentComplete)" == "25.0" ]] || fail "PercentComplete must be serial-based 25.0"
+
+# 6. remaining count visible in summary output
+[[ "$(json_field "$A_JSON" RemainingSerials)" == "3" ]] || fail "RemainingSerials must be visible and equal 3"
+grep -q 'RemainingSerials' "$A_CSV" || fail "RemainingSerials must appear in CSV summary header"
+
+# untracked manifest keeps serial-first identifier discipline
+A_UNTRACKED="${A_PREFIX}_alejandro_untracked.csv"
+"${PYTHON_CMD[@]}" - "$A_UNTRACKED" <<'PY'
+import csv, sys
+rows = {r["Serial"]: r for r in csv.DictReader(open(sys.argv[1], newline="", encoding="utf-8"))}
+one = rows.get("MEDTEST24-ONE01") or {}
+if one.get("IdentifierType") != "HostName" or not one.get("HostName"):
+    raise SystemExit("exactly-one-host serial must be probe-ready HostName in untracked manifest")
+so = rows.get("MEDTEST24-SO01") or {}
+if so.get("IdentifierType") != "Serial" or so.get("HostName"):
+    raise SystemExit("zero-host serial must stay Serial-keyed (review-required)")
+amb = rows.get("MEDTEST24-AMB01") or {}
+if amb.get("IdentifierType") != "Serial" or amb.get("HostName"):
+    raise SystemExit("multi-host serial must stay Serial-keyed (no arbitrary host pick)")
+if "ambiguous_hostnames" not in amb.get("Source", ""):
+    raise SystemExit("ambiguous serial must surface review candidates in Source")
+PY
+pass "serial-first denominator and bucket classification (Total=4, host/serial-only/ambiguous)"
+
+# 7. progress output is self-contained: console line carries percent + bar + remaining
+CONSOLE_OUT="$(bash "$DIFF_RUNNER" --alejandro "$ALEJANDRO" --tracker "$TRACKER" --output-prefix "$TMP_DIR/c/cybernet" --device-type Cybernet)"
+echo "$CONSOLE_OUT" | grep -q '%' || fail "console output must show a percentage"
+echo "$CONSOLE_OUT" | grep -q '\[#' || fail "console output must show a progress bar"
+echo "$CONSOLE_OUT" | grep -qi 'remaining' || fail "console output must show remaining serials without reading logs"
+
+# --no-progress suppresses the bar line but still writes summary files
+NP_OUT="$(bash "$DIFF_RUNNER" --alejandro "$ALEJANDRO" --tracker "$TRACKER" --output-prefix "$TMP_DIR/np/cybernet" --device-type Cybernet --no-progress)"
+echo "$NP_OUT" | grep -q '\[#' && fail "--no-progress must suppress the progress bar line"
+[[ -f "$TMP_DIR/np/cybernet_progress_summary.json" ]] || fail "--no-progress must still write JSON summary"
+pass "tech-visible console progress (percent + bar + remaining) and --no-progress toggle"
+
+# --- Case B: identity evidence expands SurveyedSerials for an untracked serial ---
+B_PREFIX="$TMP_DIR/b/cybernet"
+bash "$DIFF_RUNNER" --alejandro "$ALEJANDRO" --tracker "$TRACKER" --output-prefix "$B_PREFIX" \
+  --device-type Cybernet --identity-csv "$IDENTITY_CSV" >/dev/null
+B_JSON="${B_PREFIX}_progress_summary.json"
+[[ "$(json_field "$B_JSON" SurveyedSerials)" == "2" ]] || fail "IdentityCollected must expand surveyed to 2"
+[[ "$(json_field "$B_JSON" PercentComplete)" == "50.0" ]] || fail "identity-confirmed serial must lift percent to 50.0"
+[[ "$(json_field "$B_JSON" NeedsPrivilegedIdentity)" == "0" ]] || fail "identity-confirmed reachable serial must not need privileged identity"
+pass "identity evidence expands surveyed serials (serial-first, not hostname-first)"
+
+# --- Case C: ping reachability is a candidate signal, never serial proof ---
+C_PREFIX="$TMP_DIR/d/cybernet"
+bash "$DIFF_RUNNER" --alejandro "$ALEJANDRO" --tracker "$TRACKER" --output-prefix "$C_PREFIX" \
+  --device-type Cybernet --preflight-csv "$PREFLIGHT_CSV" >/dev/null
+C_JSON="${C_PREFIX}_progress_summary.json"
+[[ "$(json_field "$C_JSON" PingReachableCandidates)" == "1" ]] || fail "reachable host must count as ping candidate"
+[[ "$(json_field "$C_JSON" NeedsPrivilegedIdentity)" == "1" ]] || fail "reachable-but-unconfirmed serial must need privileged identity"
+[[ "$(json_field "$C_JSON" SurveyedSerials)" == "1" ]] || fail "ping reachability alone must not mark a serial surveyed"
+[[ "$(json_field "$C_JSON" PercentComplete)" == "25.0" ]] || fail "ping-only evidence must not raise percent complete"
+pass "ping reachability stays candidate-only (not serial proof)"
+
+# 8. generated operational progress output is gitignored under survey/output/
+OUT_PREFIX="survey/output/progress_contract_cybernet"
+bash "$DIFF_RUNNER" --alejandro "$ALEJANDRO" --tracker "$TRACKER" --output-prefix "$OUT_PREFIX" --device-type Cybernet >/dev/null
+PROGRESS_JSON="${OUT_PREFIX}_progress_summary.json"
+PROGRESS_CSV="${OUT_PREFIX}_progress_summary.csv"
+git check-ignore -v "$PROGRESS_JSON" >/dev/null || { rm -f "${OUT_PREFIX}"_*; fail "generated progress JSON must be gitignored"; }
+git check-ignore -v "$PROGRESS_CSV" >/dev/null || { rm -f "${OUT_PREFIX}"_*; fail "generated progress CSV must be gitignored"; }
+rm -f "${OUT_PREFIX}"_*
+pass "generated progress summaries are gitignored operational output"
+
+printf 'Cybernet serial-first progress contracts passed.\n'

--- a/docs/CYBERNET_XLSX_TARGET_INGESTION.md
+++ b/docs/CYBERNET_XLSX_TARGET_INGESTION.md
@@ -104,6 +104,8 @@ The diff is read-only against both workbooks and writes local operational CSVs:
 - `survey/output/cybernet_alejandro_already_tracked.csv`
 - `survey/output/cybernet_alejandro_untracked.csv`
 - `survey/output/cybernet_tracker_duplicate_exceptions.csv`
+- `survey/output/cybernet_progress_summary.json`
+- `survey/output/cybernet_progress_summary.csv`
 
 Comparison rules:
 
@@ -114,6 +116,64 @@ Comparison rules:
 - Repeated non-deployed tracker identifiers are planning history, not duplicate exceptions.
 
 `cybernet_alejandro_untracked.csv` uses the same manifest schema as the ingester. Serial-only rows are retained for tracking, but only rows with a resolved `HostName` are ready for live WMI/ping identity checks. When one Alejandro serial maps to more than one hostname, the row stays serial-keyed (not probe-ready) and the candidate hostnames are preserved in `Source` as `review:ambiguous_hostnames=...`; the tool does not arbitrarily pick one hostname.
+
+## Serial-first progress summary
+
+Every diff run also emits a serial-first progress summary so a technician can answer
+"how many Cybernets are left?" without reading raw logs. The **denominator is always unique
+Alejandro serials**, never hostname rows. A console progress bar prints by default:
+
+```text
+[sas-cybernet-tracker-diff] [##########----------] 52.4% 129/246 serials surveyed | 117 remaining | 38 need identity | 12 ambiguous
+```
+
+The same numbers are written to machine-readable files (gitignored under `survey/output/`):
+
+- `cybernet_progress_summary.json`
+- `cybernet_progress_summary.csv`
+
+Stable fields (documented; safe for a future dashboard to consume):
+
+| Field | Meaning |
+|---|---|
+| `TotalSerialTargets` | Unique Alejandro serials (the survey population denominator) |
+| `SurveyedSerials` | Serials present in the deployment tracker, plus untracked serials confirmed by identity evidence |
+| `RemainingSerials` | `TotalSerialTargets - SurveyedSerials` |
+| `HostResolvedSerials` | Serials with exactly one validated hostname (probe-ready) |
+| `SerialOnlyReviewRequired` | Serials with zero hostnames (stay serial-keyed, review-required) |
+| `AmbiguousHostnameSerials` | Serials with two or more hostnames (never auto-picked) |
+| `ADCandidateSerials` | Serials with an AD candidate hostname/serial (enrichment only, not proof) |
+| `PingReachableCandidates` | Serials whose hostname is ping-reachable (reachability only, not proof) |
+| `NeedsPrivilegedIdentity` | Reachable serials still lacking identity confirmation |
+| `PercentComplete` | `100 * SurveyedSerials / TotalSerialTargets` (one decimal) |
+| `PopulationAuthority` | Always `alejandro_serials` |
+| `GeneratedAt` | UTC ISO-8601 timestamp |
+
+Doctrine guardrails baked into these counts:
+
+- A serial with exactly one validated hostname is probe-ready; zero or multiple hostnames stay
+  serial-keyed and review-required.
+- Only `IdentityCollected` evidence (via `--identity-csv`) can mark an **untracked** serial surveyed.
+  Ping reachability (`--preflight-csv`) and AD candidates (`--ad-serial-csv`) raise candidate
+  confidence but never confirm a serial.
+- Optional evidence inputs are read-only and enrichment-only; the population authority is the
+  Alejandro serial inventory.
+
+Flags:
+
+```bash
+bash survey/sas-cybernet-tracker-diff.sh \
+  --alejandro "<alejandro-workbook>.xlsx" \
+  --tracker "<deployment-tracker-workbook>.xlsx" \
+  --output-prefix survey/output/cybernet \
+  --identity-csv survey/output/cybernet_workstation_identity.csv \
+  --preflight-csv survey/output/cybernet_network_preflight.csv \
+  --ad-serial-csv survey/output/cybernet_ad_serials.csv
+```
+
+Use `--no-progress` to suppress the console bar (summary files are still written). All progress
+outputs are operational and remain gitignored under `survey/output/`; a dashboard can consume the
+JSON/CSV in a later sprint.
 
 ## Command
 

--- a/survey/sas-cybernet-tracker-diff.py
+++ b/survey/sas-cybernet-tracker-diff.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import csv
+import datetime as dt
+import json
 import re
 import sys
 from collections import defaultdict
@@ -39,6 +41,23 @@ DUP_FIELDS = [
     "HostNames", "Serials", "MACAddresses", "NeuronMACAddresses", "NeuronSerials", "Sources",
 ]
 DUP_IDENTIFIER_KINDS = ("host", "serial", "mac", "neuron_mac", "neuron_sn")
+# Serial-first progress buckets. Denominator is always unique Alejandro serials,
+# never hostname rows. Optional evidence CSVs are enrichment only and never
+# upgrade a serial to confirmed on their own (ping/AD are not serial proof).
+PROGRESS_FIELDS = [
+    "TotalSerialTargets",
+    "SurveyedSerials",
+    "RemainingSerials",
+    "HostResolvedSerials",
+    "SerialOnlyReviewRequired",
+    "AmbiguousHostnameSerials",
+    "ADCandidateSerials",
+    "PingReachableCandidates",
+    "NeedsPrivilegedIdentity",
+    "PercentComplete",
+]
+PROGRESS_META_FIELDS = ["PopulationAuthority", "GeneratedAt"]
+REACHABLE_TOKENS = {"REACHABLE", "UP", "ONLINE", "YES", "OPEN"}
 
 
 def clean(value: object) -> str:
@@ -306,6 +325,153 @@ def untracked_manifest(alejandro: dict[str, dict[str, object]], tracker: dict[st
     return rows
 
 
+def read_csv_optional(path_value: str | None) -> list[dict[str, str]]:
+    if not path_value:
+        return []
+    path = Path(path_value)
+    if not path.is_file():
+        print(f"[sas-cybernet-tracker-diff] WARN: optional evidence not found: {path}", file=sys.stderr)
+        return []
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        return list(csv.DictReader(handle))
+
+
+def cell(row: dict[str, str], *names: str) -> str:
+    lowered = {str(key).lower(): value for key, value in row.items() if key}
+    for name in names:
+        value = lowered.get(name.lower())
+        if value not in (None, ""):
+            return clean(value)
+    return ""
+
+
+def is_reachable(value: str) -> bool:
+    return value.strip().upper() in REACHABLE_TOKENS
+
+
+def is_identity_collected(value: str) -> bool:
+    return "IDENTITYCOLLECTED" in re.sub(r"\s+", "", value).upper()
+
+
+def render_progress_bar(percent: float, width: int = 20) -> str:
+    filled = max(0, min(width, round(width * percent / 100)))
+    return f"[{'#' * filled}{'-' * (width - filled)}] {percent:.1f}%"
+
+
+def build_progress_summary(
+    alejandro: dict[str, dict[str, object]],
+    tracker: dict[str, dict[str, object]],
+    identity_rows: list[dict[str, str]],
+    preflight_rows: list[dict[str, str]],
+    ad_rows: list[dict[str, str]],
+) -> dict[str, object]:
+    total = len(alejandro)
+    tracked = set(alejandro) & set(tracker)
+
+    observed_serials: set[str] = set()
+    reachable_hosts: set[str] = set()
+    identity_collected_hosts: set[str] = set()
+    for row in identity_rows:
+        host = norm_host(cell(row, "ObservedHostName", "HostName", "DnsName"))
+        target_host = norm_host(cell(row, "Target", "HostName"))
+        ping = cell(row, "PingStatus")
+        status = cell(row, "IdentityStatus")
+        observed_serial = norm_serial(cell(row, "ObservedSerial", "Serial"))
+        for key in {host, target_host}:
+            if not key:
+                continue
+            if is_reachable(ping):
+                reachable_hosts.add(key)
+            if is_identity_collected(status):
+                identity_collected_hosts.add(key)
+        if observed_serial:
+            observed_serials.add(observed_serial)
+
+    for row in preflight_rows:
+        host = norm_host(cell(row, "Target", "HostName"))
+        if host and is_reachable(cell(row, "PingStatus")):
+            reachable_hosts.add(host)
+
+    ad_serials: set[str] = set()
+    ad_hosts: set[str] = set()
+    for row in ad_rows:
+        ad_serial = norm_serial(cell(row, "Serial", "ObservedSerial", "ExpectedSerial"))
+        ad_host = norm_host(cell(row, "HostName", "Host", "Name", "DNSHostName"))
+        if ad_serial:
+            ad_serials.add(ad_serial)
+        if ad_host:
+            ad_hosts.add(ad_host)
+
+    host_resolved = serial_only = ambiguous = 0
+    ad_candidates = ping_candidates = needs_identity = 0
+    surveyed: set[str] = set(tracked)
+
+    for serial, rec in alejandro.items():
+        hosts = sorted(h for h in rec["hosts"] if h)
+        if len(hosts) == 1:
+            host_resolved += 1
+        elif not hosts:
+            serial_only += 1
+        else:
+            ambiguous += 1
+
+        # Identity is the only optional signal that can mark an untracked serial
+        # surveyed; ping/AD raise candidate confidence but never confirm.
+        confirmed = serial in observed_serials or any(h in identity_collected_hosts for h in hosts)
+        if serial not in tracker and confirmed:
+            surveyed.add(serial)
+
+        if serial in ad_serials or any(h in ad_hosts for h in hosts):
+            ad_candidates += 1
+
+        if any(h in reachable_hosts for h in hosts):
+            ping_candidates += 1
+            if serial not in surveyed:
+                needs_identity += 1
+
+    surveyed_count = len(surveyed)
+    remaining = total - surveyed_count
+    percent = round(100 * surveyed_count / total, 1) if total else 0.0
+
+    summary: dict[str, object] = {
+        "TotalSerialTargets": total,
+        "SurveyedSerials": surveyed_count,
+        "RemainingSerials": remaining,
+        "HostResolvedSerials": host_resolved,
+        "SerialOnlyReviewRequired": serial_only,
+        "AmbiguousHostnameSerials": ambiguous,
+        "ADCandidateSerials": ad_candidates,
+        "PingReachableCandidates": ping_candidates,
+        "NeedsPrivilegedIdentity": needs_identity,
+        "PercentComplete": percent,
+        "PopulationAuthority": "alejandro_serials",
+        "GeneratedAt": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    return summary
+
+
+def format_progress_line(summary: dict[str, object]) -> str:
+    bar = render_progress_bar(float(summary["PercentComplete"]))
+    return (
+        f"{bar} "
+        f"{summary['SurveyedSerials']}/{summary['TotalSerialTargets']} serials surveyed | "
+        f"{summary['RemainingSerials']} remaining | "
+        f"{summary['NeedsPrivilegedIdentity']} need identity | "
+        f"{summary['AmbiguousHostnameSerials']} ambiguous"
+    )
+
+
+def write_progress_json(path: Path, summary: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2)
+        handle.write("\n")
+
+
+def progress_csv_row(summary: dict[str, object]) -> dict[str, str]:
+    return {field: str(summary.get(field, "")) for field in PROGRESS_FIELDS + PROGRESS_META_FIELDS}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Diff Alejandro Cybernet serials against deployment tracker serial inventory")
     parser.add_argument("--alejandro", required=True, help="Alejandro-style Cybernet workbook")
@@ -314,6 +480,10 @@ def main() -> int:
     parser.add_argument("--output-prefix", default="survey/output/cybernet")
     parser.add_argument("--device-type", default="Cybernet")
     parser.add_argument("--header-scan-rows", type=int, default=40)
+    parser.add_argument("--identity-csv", help="optional workstation_identity.csv (enrichment evidence; only IdentityCollected confirms a serial)")
+    parser.add_argument("--preflight-csv", help="optional network_preflight.csv (ping reachability; not serial proof)")
+    parser.add_argument("--ad-serial-csv", help="optional AD live-serial export (enrichment candidates; not serial proof)")
+    parser.add_argument("--no-progress", action="store_true", help="suppress the tech-visible progress bar line")
     args = parser.parse_args()
 
     alejandro_path, tracker_path = Path(args.alejandro), Path(args.tracker)
@@ -343,6 +513,20 @@ def main() -> int:
         write_csv(Path(path_str), fields, rows)
         print(f"[sas-cybernet-tracker-diff] wrote {path_str} rows={len(rows)}")
 
+    summary = build_progress_summary(
+        alejandro,
+        tracker,
+        read_csv_optional(args.identity_csv),
+        read_csv_optional(args.preflight_csv),
+        read_csv_optional(args.ad_serial_csv),
+    )
+    progress_json = f"{prefix}_progress_summary.json"
+    progress_csv = f"{prefix}_progress_summary.csv"
+    write_progress_json(Path(progress_json), summary)
+    write_csv(Path(progress_csv), PROGRESS_FIELDS + PROGRESS_META_FIELDS, [progress_csv_row(summary)])
+    print(f"[sas-cybernet-tracker-diff] wrote {progress_json}")
+    print(f"[sas-cybernet-tracker-diff] wrote {progress_csv}")
+
     print(
         "[sas-cybernet-tracker-diff] "
         f"alejandro_unique_serials={len(alejandro)} "
@@ -350,6 +534,8 @@ def main() -> int:
         f"already_tracked={len(set(alejandro) & set(tracker))} "
         f"untracked={len(set(alejandro) - set(tracker))}"
     )
+    if not args.no_progress:
+        print(f"[sas-cybernet-tracker-diff] {format_progress_line(summary)}")
     return 0
 
 

--- a/survey/sas-cybernet-tracker-diff.py
+++ b/survey/sas-cybernet-tracker-diff.py
@@ -74,6 +74,9 @@ def norm_serial(value: object) -> str:
 
 def norm_host(value: object) -> str:
     text = re.sub(r"\s+", "", clean(value)).upper()
+    if "." in text:
+        # Accept FQDNs (e.g. AD DNSHostName) by comparing on the leading label.
+        text = text.split(".", 1)[0]
     return text if text and HOSTNAME_RE.search(text) else ""
 
 
@@ -350,7 +353,10 @@ def is_reachable(value: str) -> bool:
 
 
 def is_identity_collected(value: str) -> bool:
-    return "IDENTITYCOLLECTED" in re.sub(r"\s+", "", value).upper()
+    # Match exact identity-collected tokens only. A substring test would
+    # misclassify negatives such as "NotIdentityCollected" as collected.
+    token = re.sub(r"[\s_\-]+", "", value).upper()
+    return token in {"IDENTITYCOLLECTED", "COLLECTED"}
 
 
 def render_progress_bar(percent: float, width: int = 20) -> str:
@@ -368,24 +374,23 @@ def build_progress_summary(
     total = len(alejandro)
     tracked = set(alejandro) & set(tracker)
 
-    observed_serials: set[str] = set()
     reachable_hosts: set[str] = set()
-    identity_collected_hosts: set[str] = set()
+    identity_confirmed_serials: set[str] = set()
     for row in identity_rows:
         host = norm_host(cell(row, "ObservedHostName", "HostName", "DnsName"))
         target_host = norm_host(cell(row, "Target", "HostName"))
         ping = cell(row, "PingStatus")
         status = cell(row, "IdentityStatus")
         observed_serial = norm_serial(cell(row, "ObservedSerial", "Serial"))
-        for key in {host, target_host}:
-            if not key:
-                continue
-            if is_reachable(ping):
-                reachable_hosts.add(key)
-            if is_identity_collected(status):
-                identity_collected_hosts.add(key)
-        if observed_serial:
-            observed_serials.add(observed_serial)
+        collected = is_identity_collected(status)
+        if is_reachable(ping):
+            for key in {host, target_host}:
+                if key:
+                    reachable_hosts.add(key)
+        # Serial-first doctrine: only an identity-collected row whose observed
+        # serial matches can confirm that serial as surveyed.
+        if observed_serial and collected:
+            identity_confirmed_serials.add(observed_serial)
 
     for row in preflight_rows:
         host = norm_host(cell(row, "Target", "HostName"))
@@ -395,8 +400,8 @@ def build_progress_summary(
     ad_serials: set[str] = set()
     ad_hosts: set[str] = set()
     for row in ad_rows:
-        ad_serial = norm_serial(cell(row, "Serial", "ObservedSerial", "ExpectedSerial"))
-        ad_host = norm_host(cell(row, "HostName", "Host", "Name", "DNSHostName"))
+        ad_serial = norm_serial(cell(row, "ADSerial", "Serial", "ObservedSerial", "ExpectedSerial"))
+        ad_host = norm_host(cell(row, "ADHostname", "HostName", "Host", "Name", "DNSHostName"))
         if ad_serial:
             ad_serials.add(ad_serial)
         if ad_host:
@@ -415,9 +420,11 @@ def build_progress_summary(
         else:
             ambiguous += 1
 
-        # Identity is the only optional signal that can mark an untracked serial
-        # surveyed; ping/AD raise candidate confidence but never confirm.
-        confirmed = serial in observed_serials or any(h in identity_collected_hosts for h in hosts)
+        # Serial-first doctrine: only a matching observed serial on an
+        # identity-collected row can mark an untracked serial surveyed. Host
+        # identity alone cannot confirm (reimaged/tracker-drift hosts), and
+        # ping/AD only raise candidate confidence.
+        confirmed = serial in identity_confirmed_serials
         if serial not in tracker and confirmed:
             surveyed.add(serial)
 

--- a/survey/sas-cybernet-tracker-diff.sh
+++ b/survey/sas-cybernet-tracker-diff.sh
@@ -16,6 +16,10 @@ Options:
   --output-prefix PREFIX    Default: survey/output/cybernet
   --device-type TYPE        Default: Cybernet
   --header-scan-rows N      Default: 40
+  --identity-csv PATH       Optional workstation_identity.csv (enrichment evidence)
+  --preflight-csv PATH      Optional network_preflight.csv (ping reachability)
+  --ad-serial-csv PATH      Optional AD live-serial export (enrichment candidates)
+  --no-progress             Suppress the tech-visible progress bar line
   -h, --help                Show help
 
 Outputs:
@@ -24,6 +28,8 @@ Outputs:
   PREFIX_alejandro_already_tracked.csv
   PREFIX_alejandro_untracked.csv
   PREFIX_tracker_duplicate_exceptions.csv
+  PREFIX_progress_summary.json
+  PREFIX_progress_summary.csv
 USAGE
 }
 
@@ -33,6 +39,10 @@ TRACKER_SHEET="Deployments"
 OUTPUT_PREFIX="survey/output/cybernet"
 DEVICE_TYPE="Cybernet"
 HEADER_SCAN_ROWS="40"
+IDENTITY_CSV=""
+PREFLIGHT_CSV=""
+AD_SERIAL_CSV=""
+NO_PROGRESS=""
 PYTHON_CMD=()
 
 find_python() {
@@ -52,6 +62,10 @@ while [[ $# -gt 0 ]]; do
     --output-prefix) OUTPUT_PREFIX="${2:?}"; shift 2 ;;
     --device-type) DEVICE_TYPE="${2:?}"; shift 2 ;;
     --header-scan-rows) HEADER_SCAN_ROWS="${2:?}"; shift 2 ;;
+    --identity-csv) IDENTITY_CSV="${2:?}"; shift 2 ;;
+    --preflight-csv) PREFLIGHT_CSV="${2:?}"; shift 2 ;;
+    --ad-serial-csv) AD_SERIAL_CSV="${2:?}"; shift 2 ;;
+    --no-progress) NO_PROGRESS="1"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "[sas-cybernet-tracker-diff] ERROR: unknown option: $1" >&2; usage; exit 1 ;;
   esac
@@ -66,10 +80,16 @@ done
 
 find_python
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"${PYTHON_CMD[@]}" "$SCRIPT_DIR/sas-cybernet-tracker-diff.py" \
-  --alejandro "$ALEJANDRO" \
-  --tracker "$TRACKER" \
-  --tracker-sheet "$TRACKER_SHEET" \
-  --output-prefix "$OUTPUT_PREFIX" \
-  --device-type "$DEVICE_TYPE" \
+DIFF_ARGS=(
+  --alejandro "$ALEJANDRO"
+  --tracker "$TRACKER"
+  --tracker-sheet "$TRACKER_SHEET"
+  --output-prefix "$OUTPUT_PREFIX"
+  --device-type "$DEVICE_TYPE"
   --header-scan-rows "$HEADER_SCAN_ROWS"
+)
+[[ -n "$IDENTITY_CSV" ]] && DIFF_ARGS+=(--identity-csv "$IDENTITY_CSV")
+[[ -n "$PREFLIGHT_CSV" ]] && DIFF_ARGS+=(--preflight-csv "$PREFLIGHT_CSV")
+[[ -n "$AD_SERIAL_CSV" ]] && DIFF_ARGS+=(--ad-serial-csv "$AD_SERIAL_CSV")
+[[ -n "$NO_PROGRESS" ]] && DIFF_ARGS+=(--no-progress)
+"${PYTHON_CMD[@]}" "$SCRIPT_DIR/sas-cybernet-tracker-diff.py" "${DIFF_ARGS[@]}"


### PR DESCRIPTION
## Summary

Make the Cybernet survey serial-first and give technicians at-a-glance progress so they do not need to read logs to answer "how many Cybernets are left?". Extends the existing Alejandro tracker diff tooling (no parallel tool).

- Denominator is **unique Alejandro serials**, never hostname rows.
- Every diff run emits `survey/output/cybernet_progress_summary.json` and `.csv` (gitignored operational output) and prints a tech-visible percent + progress bar by default (`--no-progress` to suppress).
- Progress buckets: `TotalSerialTargets`, `SurveyedSerials`, `RemainingSerials`, `HostResolvedSerials`, `SerialOnlyReviewRequired`, `AmbiguousHostnameSerials`, `ADCandidateSerials`, `PingReachableCandidates`, `NeedsPrivilegedIdentity`, `PercentComplete` (+ `PopulationAuthority`, `GeneratedAt`).
- Optional, read-only enrichment inputs: `--identity-csv`, `--preflight-csv`, `--ad-serial-csv`. Only `IdentityCollected` confirms an untracked serial; ping reachability and AD candidates raise candidate confidence but are never serial proof.

Example console output:

```
[sas-cybernet-tracker-diff] [##########----------] 52.4% 129/246 serials surveyed | 117 remaining | 38 need identity | 12 ambiguous
```

## Serial-first doctrine preserved

- One validated hostname -> probe-ready; zero hostnames -> serial-keyed/review-required; multiple hostnames -> serial-keyed/review-required (no arbitrary pick).
- AD/hostname enrichment cannot mark a serial confirmed.
- All generated live output stays under gitignored `survey/output/`; fixtures and serials are synthetic only.

## Test plan

- [x] `bash Tests/bash/test-cybernet-serial-progress-contracts.sh` (new; 8 required behaviors)
- [x] `bash Tests/bash/test-cybernet-xlsx-targets-contracts.sh`
- [x] `bash Tests/bash/test_northwell_registry_verification_contracts.sh`
- [x] `git check-ignore -v` confirms progress JSON/CSV are ignored

Do not merge yet.
