### PR TITLE
docs(survey): add Cybernet field workflow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ SysAdminSuite/
 
 ## Quick Start
 
+### Field Survey — Cybernet / Neuron (Bash-first)
+
+For approved Cybernet or Neuron site surveys, start with the field workflow diagram and urgent CLI path:
+
+- [`START-HERE-CYBERNET-NEURON-SURVEY.md`](START-HERE-CYBERNET-NEURON-SURVEY.md) — workflow diagram plus orchestrator commands
+- [`docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md) — full step-by-step tutorial
+- [`survey/README.md`](survey/README.md) — script reference and contract tests
+
 ### Launch the GUI (recommended starting point)
 
 The easiest way to launch the GUI is to **double-click** the batch file at the repo root:

--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -4,6 +4,60 @@ This is the current priority field workflow for SysAdminSuite technicians.
 
 Use it when you need to locate Cybernet or Neuron devices from approved deployment documentation using a local admin workstation, target manifests, and conservative approved network discovery.
 
+## Workflow at a glance
+
+Use this diagram to keep the field path straight: approved population first, local context and reachability second, local evidence package last. Mermaid source: [`docs/diagrams/cybernet-neuron-survey-flow.mmd`](docs/diagrams/cybernet-neuron-survey-flow.mmd).
+
+Each orchestrator mode is a separate `--mode` run, not a single chained pipeline. The numbered order below is the typical progression, but you invoke one mode at a time.
+
+```mermaid
+flowchart TD
+    subgraph entryPaths [Entry Paths]
+        dashboard["Dashboard: Start Cybernet Survey"]
+        cli["CLI: survey/sas-cybernet-subnet-survey.sh --mode MODE"]
+    end
+
+    subgraph populationAuthority [Population Authority]
+        approvedInputs["AD export or approved manifests"]
+        adReconcile["survey/sas-ad-reconcile.sh"]
+        manifests["Resolved target manifests (survey/output/ad_reconcile)"]
+        approvedInputs --> adReconcile --> manifests
+    end
+
+    subgraph orchestratorModes [Orchestrator modes: pick one --mode per run]
+        localContext["local-context-only"]
+        dnsList["dns-list-only"]
+        discover["discover"]
+        resolveOnly["resolve-only"]
+        confirmWindows["confirm-windows (optional)"]
+        parseNaabu["parse-naabu-only"]
+        packageOnly["package-only"]
+    end
+
+    typicalOrder["Typical order: local-context-only -> dns-list-only -> discover -> resolve-only -> confirm-windows (optional) -> parse-naabu-only -> package-only"]
+
+    subgraph localEvidence [Local Evidence Only]
+        surveyOutputs["survey/output and survey/artifacts"]
+        networkLogs["logs/nmap and logs/network_context"]
+    end
+
+    subgraph guardrails [Guardrails]
+        populationRule["AD or approved manifests define population"]
+        reachabilityRule["Nmap and Naabu validate reachability only"]
+        evidenceRule["Do not commit live evidence"]
+    end
+
+    dashboard --> manifests
+    cli --> orchestratorModes
+    orchestratorModes --> typicalOrder
+    manifests --> resolveOnly
+    packageOnly --> surveyOutputs
+    packageOnly --> networkLogs
+    populationRule --> approvedInputs
+    reachabilityRule --> confirmWindows
+    evidenceRule --> localEvidence
+```
+
 ## Dashboard quick path
 
 Use the Cybernet-first dashboard when you want a guided wizard instead of memorizing CLI steps. Live Mode is **not** the front door — it lives under **Advanced Tools → Generate Survey Commands**.

--- a/docs/diagrams/cybernet-neuron-survey-flow.mmd
+++ b/docs/diagrams/cybernet-neuron-survey-flow.mmd
@@ -1,0 +1,45 @@
+flowchart TD
+    subgraph entryPaths [Entry Paths]
+        dashboard["Dashboard: Start Cybernet Survey"]
+        cli["CLI: survey/sas-cybernet-subnet-survey.sh --mode MODE"]
+    end
+
+    subgraph populationAuthority [Population Authority]
+        approvedInputs["AD export or approved manifests"]
+        adReconcile["survey/sas-ad-reconcile.sh"]
+        manifests["Resolved target manifests (survey/output/ad_reconcile)"]
+        approvedInputs --> adReconcile --> manifests
+    end
+
+    subgraph orchestratorModes [Orchestrator modes: pick one --mode per run]
+        localContext["local-context-only"]
+        dnsList["dns-list-only"]
+        discover["discover"]
+        resolveOnly["resolve-only"]
+        confirmWindows["confirm-windows (optional)"]
+        parseNaabu["parse-naabu-only"]
+        packageOnly["package-only"]
+    end
+
+    typicalOrder["Typical order: local-context-only -> dns-list-only -> discover -> resolve-only -> confirm-windows (optional) -> parse-naabu-only -> package-only"]
+
+    subgraph localEvidence [Local Evidence Only]
+        surveyOutputs["survey/output and survey/artifacts"]
+        networkLogs["logs/nmap and logs/network_context"]
+    end
+
+    subgraph guardrails [Guardrails]
+        populationRule["AD or approved manifests define population"]
+        reachabilityRule["Nmap and Naabu validate reachability only"]
+        evidenceRule["Do not commit live evidence"]
+    end
+
+    dashboard --> manifests
+    cli --> orchestratorModes
+    orchestratorModes --> typicalOrder
+    manifests --> resolveOnly
+    packageOnly --> surveyOutputs
+    packageOnly --> networkLogs
+    populationRule --> approvedInputs
+    reachabilityRule --> confirmWindows
+    evidenceRule --> localEvidence

--- a/survey/README.md
+++ b/survey/README.md
@@ -12,7 +12,7 @@ The current priority tutorial for field technicians is:
 - [`../START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md) — advanced CLI orchestrator path
 - [`../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md) — full step-by-step runbook
 
-Use the CLI path below only when the dashboard or a lead explicitly asks for Bash orchestration. The workflow is:
+Use the CLI path below only when the dashboard or a lead explicitly asks for Bash orchestration. Start with the workflow diagram in `../START-HERE-CYBERNET-NEURON-SURVEY.md` when you need the one-page field path before the command details. Mermaid source: [`../docs/diagrams/cybernet-neuron-survey-flow.mmd`](../docs/diagrams/cybernet-neuron-survey-flow.mmd). The workflow is:
 
 1. Copy approved local target CSVs into `survey/input/`.
 2. Run the Bash runtime smoke test.


### PR DESCRIPTION
## Summary
- Add a one-page Cybernet/Neuron field survey Mermaid workflow diagram.
- Embed the diagram in `START-HERE-CYBERNET-NEURON-SURVEY.md` before the command path.
- Add pointers from `README.md` and `survey/README.md` so technicians can find the diagram quickly.

## Test plan
- `git diff --check`
- `git grep -n "cybernet-neuron-survey-flow\|Workflow at a glance\|Field Survey\|workflow diagram" -- README.md START-HERE-CYBERNET-NEURON-SURVEY.md survey/README.md docs/diagrams/cybernet-neuron-survey-flow.mmd`
- Markdown/Mermaid syntax reviewed for simple GitHub rendering rules.