### PR TITLE
feat(ui): add obvious dashboard entry point

### DIFF
--- a/Launch-SysAdminSuiteDashboard.Host.bat
+++ b/Launch-SysAdminSuiteDashboard.Host.bat
@@ -14,19 +14,25 @@ if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
     exit /b 0
 )
 
-:: 2) Documented publish output (run dotnet publish to populate)
+:: 2) Friendly field publish output (tools\publish-dashboard-entrypoint.ps1)
+if exist "%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe" (
+    start "" /B "%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe" %*
+    exit /b 0
+)
+
+:: 3) Documented publish output (run dotnet publish to populate)
 if exist "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" (
     start "" /B "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" %*
     exit /b 0
 )
 
-:: 3) Dev tree fallback (Release build)
+:: 4) Dev tree fallback (Release build)
 if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" (
     start "" /B "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" %*
     exit /b 0
 )
 
-:: 4) Dev tree fallback (Debug build)
+:: 5) Dev tree fallback (Debug build)
 if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" (
     start "" /B "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" %*
     exit /b 0
@@ -34,5 +40,7 @@ if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdmi
 
 echo Unable to locate SysAdminSuite.DashboardHost.exe.
 echo Build with:
+echo     powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
+echo Or:
 echo     dotnet publish src\SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false -o tools\publish\SysAdminSuite.DashboardHost
 exit /b 1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
 
 ---
 
+## Start here
+
+For most users, do not start with command-line tools.
+
+Double-click:
+
+`START-HERE-SysAdminSuite-Dashboard.bat`
+
+This opens the local dashboard and tutorial page at `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
+
+Read [`START-HERE-SysAdminSuite.md`](START-HERE-SysAdminSuite.md) for plain-language steps, troubleshooting, and when CLI is appropriate.
+
+Use CLI tools only when the dashboard tells you to copy a specific command or when a runbook specifically asks for it.
+
+---
+
 ## Runtime policy (C# / native first)
 
 - **Primary supported path for restricted endpoints:** **compiled** tooling — **.NET (C#)** for the GUI and most automation, and **native C++** under [`mapping/native`](mapping/native/README.md) for printer mapping where `powershell.exe` is blocked or scripting policy is strict. Artifact and CLI contracts are documented in [`mapping/native/CONTRACT.md`](mapping/native/CONTRACT.md).
@@ -120,6 +136,16 @@ SysAdminSuite/
 
 ## Quick Start
 
+### Field Survey — Cybernet / Neuron (advanced CLI)
+
+When a lead or runbook asks for Bash subnet orchestration:
+
+- [`START-HERE-CYBERNET-NEURON-SURVEY.md`](START-HERE-CYBERNET-NEURON-SURVEY.md) — urgent CLI orchestrator commands
+- [`docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md) — full step-by-step tutorial
+- [`survey/README.md`](survey/README.md) — script reference and contract tests
+
+Most field users should start with [`START-HERE-SysAdminSuite-Dashboard.bat`](START-HERE-SysAdminSuite-Dashboard.bat) instead.
+
 ### Launch the GUI (recommended starting point)
 
 The easiest way to launch the GUI is to **double-click** the batch file at the repo root:
@@ -139,7 +165,11 @@ powershell.exe -STA -File .\GUI\Start-SysAdminSuiteGui.ps1
 ### Launch the Web Dashboard (no PowerShell)
 
 For endpoints where `powershell.exe` is blocked or constrained, the dashboard ships
-as a standalone .NET 8 tray host. Double-click:
+as a standalone .NET 8 tray host.
+
+**Field users:** double-click [`START-HERE-SysAdminSuite-Dashboard.bat`](START-HERE-SysAdminSuite-Dashboard.bat).
+
+**IT / developers:** double-click:
 
 ```
 Launch-SysAdminSuiteDashboard.Host.bat
@@ -149,7 +179,8 @@ Or pick `[3]` in `Launch-SysAdminSuite-Runtime.bat`. The host serves
 `http://127.0.0.1:5000/dashboard/` and shows a NotifyIcon with Open / Copy URL /
 Stop. The original PowerShell + Python dashboard launcher
 (`Launch-SysAdminSuiteDashboard.bat`) is preserved for permissive sites. See
-[`docs/GUI_HOST_MIGRATION.md`](docs/GUI_HOST_MIGRATION.md) for the lane diagram,
+[`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md) and
+[`docs/GUI_HOST_MIGRATION.md`](docs/GUI_HOST_MIGRATION.md) for the entry-point guide,
 launcher matrix, and host CLI flags.
 
 On first launch a **menu-based tutorial** appears with 12 use-case tracks. Pick the one you need and follow 3-5 focused steps that end with real example output. Reopen anytime with **Ctrl+T** or the **Tutorial** button in the status bar.

--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -8,7 +8,7 @@ Use it when you need to locate Cybernet or Neuron devices from approved deployme
 
 Use the Cybernet-first dashboard when you want a guided wizard instead of memorizing CLI steps. Live Mode is **not** the front door — it lives under **Advanced Tools → Generate Survey Commands**.
 
-1. **Open the dashboard** — from the repo root: `python3 -m http.server 8000`, then browse to `http://localhost:8000/dashboard/` (see [`dashboard/README.md`](dashboard/README.md)).
+1. **Open the dashboard** — double-click [`START-HERE-SysAdminSuite-Dashboard.bat`](START-HERE-SysAdminSuite-Dashboard.bat) at the repo root. This starts the local host and opens `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`. See [`START-HERE-SysAdminSuite.md`](START-HERE-SysAdminSuite.md) and [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).
 2. **Start Cybernet Survey** — opens the wizard (progress rail: Targets → Network posture → Identity evidence → Reachability → Review package).
 3. **Copy posture and identity commands** — run network preflight and workstation identity on the admin box; keep output local.
 4. **Optional reachability** — wizard step 4 is skippable; uses profile `keyports_cybernet_json` when you need low-noise port confirmation.

--- a/START-HERE-SysAdminSuite-Dashboard.bat
+++ b/START-HERE-SysAdminSuite-Dashboard.bat
@@ -1,0 +1,65 @@
+@echo off
+setlocal
+title SysAdminSuite Dashboard
+
+echo.
+echo ==========================================
+echo   SysAdminSuite Dashboard
+echo ==========================================
+echo.
+echo This opens the local dashboard and tutorial.
+echo No internet is required after the repo is downloaded.
+echo.
+echo Starting the local dashboard at http://127.0.0.1:5000/dashboard/
+echo.
+
+set "ROOT=%~dp0"
+cd /d "%ROOT%"
+
+if not exist "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" (
+    echo Could not find Launch-SysAdminSuiteDashboard.Host.bat.
+    echo Make sure you are running this from the SysAdminSuite repo root.
+    echo.
+    echo Press any key to close...
+    pause >nul
+    exit /b 1
+)
+
+echo Starting dashboard host...
+call "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" --no-browser
+if errorlevel 1 (
+    echo.
+    echo The dashboard host could not start.
+    echo.
+    echo Try this once from a developer machine with .NET 8 SDK installed:
+    echo   powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
+    echo.
+    echo Or build manually:
+    echo   dotnet publish src\SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false -o tools\publish\SysAdminSuite.DashboardHost
+    echo.
+    echo Then double-click this file again.
+    echo.
+    echo Advanced launchers are still available:
+    echo   Launch-SysAdminSuiteDashboard.Host.bat
+    echo   Launch-SysAdminSuite-Runtime.bat
+    echo.
+    echo Press any key to close...
+    pause >nul
+    exit /b 1
+)
+
+echo Waiting for the dashboard host to start...
+timeout /t 3 /nobreak >nul
+
+echo Opening dashboard and Cybernet tutorial in your browser...
+start "" "http://127.0.0.1:5000/dashboard/?tutorial=cybernet"
+
+echo.
+echo If the page did not open, paste this into your browser:
+echo   http://127.0.0.1:5000/dashboard/?tutorial=cybernet
+echo.
+echo A tray icon should appear. Right-click it for Open Dashboard, Copy URL, or Stop.
+echo.
+echo Press any key to close this window. The dashboard keeps running in the tray.
+pause >nul
+exit /b 0

--- a/START-HERE-SysAdminSuite.md
+++ b/START-HERE-SysAdminSuite.md
@@ -1,0 +1,94 @@
+# Start Here — SysAdminSuite
+
+You do **not** need to memorize command-line tools to use SysAdminSuite.
+
+## I just downloaded or cloned the repo. What do I click?
+
+Double-click this file at the repo root:
+
+**`START-HERE-SysAdminSuite-Dashboard.bat`**
+
+That is the normal front door for field users.
+
+## What opens?
+
+1. A small dashboard host starts on your computer (look for a tray icon near the clock).
+2. Your browser opens the local dashboard at:
+
+   `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`
+
+3. Click **Start Cybernet Survey** in the dashboard to follow the guided tutorial.
+
+No internet is required after the repo is on your machine.
+
+## What if it does not open?
+
+Try these steps in order:
+
+1. Make sure you double-clicked `START-HERE-SysAdminSuite-Dashboard.bat` from the **repo root**, not from inside a subfolder.
+2. Wait a few seconds, then paste this into your browser:
+
+   `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`
+
+3. If you see a message that the dashboard host could not start, a developer needs to build the host once on that machine:
+
+   ```powershell
+   powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
+   ```
+
+   That creates a local `SysAdminSuite Dashboard.exe` under `dist/SysAdminSuiteDashboard/` (gitignored). Then double-click `START-HERE-SysAdminSuite-Dashboard.bat` again.
+
+4. Advanced fallback launchers (for IT staff):
+
+   - `Launch-SysAdminSuiteDashboard.Host.bat`
+   - `Launch-SysAdminSuite-Runtime.bat` (choose option 3)
+
+5. Still stuck? Read [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).
+
+## When do I use CLI commands?
+
+Use command-line tools only when:
+
+- the dashboard tells you to copy a specific command, or
+- a runbook or lead explicitly asks for a Bash survey step.
+
+CLI is for advanced survey work, not the default starting point.
+
+For Cybernet / Neuron subnet survey CLI steps, see [`START-HERE-CYBERNET-NEURON-SURVEY.md`](START-HERE-CYBERNET-NEURON-SURVEY.md).
+
+## Where is the Cybernet / Neuron survey tutorial?
+
+- **Dashboard path (default):** double-click `START-HERE-SysAdminSuite-Dashboard.bat`, then use **Start Cybernet Survey**.
+- **Full field runbook:** [`docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md)
+- **CLI urgent path:** [`START-HERE-CYBERNET-NEURON-SURVEY.md`](START-HERE-CYBERNET-NEURON-SURVEY.md)
+
+## What files should I never commit?
+
+Do not commit live operational evidence, including:
+
+- target CSVs with real hostnames, serials, or MACs
+- scan output under `logs/nmap/` or `survey/output/`
+- packaged ZIPs under `survey/artifacts/`
+- dashboards or reports containing site evidence
+
+Keep those files on your admin workstation only.
+
+## Workflow at a glance
+
+```mermaid
+flowchart TD
+    A[Download or clone repo] --> B[Double-click START-HERE dashboard launcher]
+    B --> C[Local dashboard opens in browser]
+    C --> D[Pick tutorial track]
+    D --> E[Load approved target/evidence files]
+    E --> F[Review guided output]
+    F --> G{Need advanced work?}
+    G -->|No| H[Use dashboard/report results]
+    G -->|Yes| I[Copy exact CLI command from runbook or dashboard]
+```
+
+## More help
+
+- Dashboard details: [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md)
+- Dashboard UI notes: [`dashboard/README.md`](dashboard/README.md)
+- Survey scripts (advanced): [`survey/README.md`](survey/README.md)

--- a/Tests/bash/test_dashboard_entrypoint_contracts.sh
+++ b/Tests/bash/test_dashboard_entrypoint_contracts.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+start_here_bat="$repo_root/START-HERE-SysAdminSuite-Dashboard.bat"
+start_here_md="$repo_root/START-HERE-SysAdminSuite.md"
+entry_doc="$repo_root/docs/DASHBOARD_ENTRYPOINT.md"
+host_bat="$repo_root/Launch-SysAdminSuiteDashboard.Host.bat"
+publish_script="$repo_root/tools/publish-dashboard-entrypoint.ps1"
+readme="$repo_root/README.md"
+survey_readme="$repo_root/survey/README.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$start_here_bat" ]] || fail "START-HERE-SysAdminSuite-Dashboard.bat is missing"
+[[ -f "$start_here_md" ]] || fail "START-HERE-SysAdminSuite.md is missing"
+[[ -f "$entry_doc" ]] || fail "docs/DASHBOARD_ENTRYPOINT.md is missing"
+[[ -f "$host_bat" ]] || fail "Launch-SysAdminSuiteDashboard.Host.bat is missing"
+[[ -f "$publish_script" ]] || fail "tools/publish-dashboard-entrypoint.ps1 is missing"
+
+grep -Fq 'Launch-SysAdminSuiteDashboard.Host.bat' "$start_here_bat" \
+  || fail "START-HERE launcher does not reference Launch-SysAdminSuiteDashboard.Host.bat"
+grep -Fq 'http://127.0.0.1:5000/dashboard/' "$start_here_bat" \
+  || fail "START-HERE launcher does not mention dashboard URL"
+grep -Fq 'tutorial=cybernet' "$start_here_bat" \
+  || fail "START-HERE launcher does not open Cybernet tutorial entry"
+grep -Fq 'Press any key to close' "$start_here_bat" \
+  || fail "START-HERE launcher does not pause on failure"
+
+grep -Fq 'START-HERE-SysAdminSuite-Dashboard.bat' "$readme" \
+  || fail "README.md does not point to START-HERE-SysAdminSuite-Dashboard.bat"
+grep -Fq '## Start here' "$readme" \
+  || fail "README.md is missing Start here section"
+grep -Fq 'http://127.0.0.1:5000/dashboard/' "$entry_doc" \
+  || fail "docs/DASHBOARD_ENTRYPOINT.md does not mention dashboard URL"
+grep -Fq 'START-HERE-SysAdminSuite-Dashboard.bat' "$survey_readme" \
+  || fail "survey/README.md does not point to START-HERE dashboard launcher"
+
+if git -C "$repo_root" ls-files --error-unmatch dist >/dev/null 2>&1; then
+  fail "dist/ must not be committed"
+fi
+
+echo "PASS: dashboard entrypoint contracts"

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -1,0 +1,98 @@
+# Dashboard Entry Point
+
+Plain-language guide for field users and help desk staff.
+
+## Default front door
+
+| What | Where |
+|------|-------|
+| Double-click this | `START-HERE-SysAdminSuite-Dashboard.bat` (repo root) |
+| Read this first | [`START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) |
+| Browser URL | `http://127.0.0.1:5000/dashboard/` |
+| Cybernet tutorial URL | `http://127.0.0.1:5000/dashboard/?tutorial=cybernet` |
+
+The START-HERE launcher:
+
+1. Starts the PS-independent dashboard host (`.NET 8` tray + local web server).
+2. Waits a few seconds for the host to bind port `5000`.
+3. Opens the browser to the Cybernet tutorial entry point.
+4. Leaves the host running in the system tray.
+
+CLI survey tools are **not** the default front door.
+
+## What the user should see
+
+1. A console window with a friendly title: **SysAdminSuite Dashboard**.
+2. A tray icon near the clock.
+3. A browser tab on the local dashboard.
+4. A **Start Cybernet Survey** button or wizard rail for guided work.
+
+If the tray icon is present, the dashboard is running even after the console window closes.
+
+## Host lookup order
+
+`Launch-SysAdminSuiteDashboard.Host.bat` (called by the START-HERE launcher) searches for the host executable in this order:
+
+1. `app/bin/SysAdminSuite.DashboardHost.exe` (portable zip layout)
+2. `dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe` (friendly local publish)
+3. `tools/publish/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.exe`
+4. `src/SysAdminSuite.DashboardHost/bin/Release/net8.0-windows/...`
+5. `src/SysAdminSuite.DashboardHost/bin/Debug/net8.0-windows/...`
+
+## Building the friendly executable locally
+
+The repo does **not** commit dashboard host binaries. Build them on the workstation:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
+```
+
+Output (gitignored):
+
+- `dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe`
+- `dist/SysAdminSuiteDashboard/SysAdminSuite.DashboardHost.exe`
+- `tools/publish/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.exe` (compatibility copy)
+
+Requires **.NET 8 runtime** on the target machine (framework-dependent publish).
+
+## Advanced launchers (preserved)
+
+| Launcher | Audience | Notes |
+|----------|----------|-------|
+| `START-HERE-SysAdminSuite-Dashboard.bat` | Field users | Friendly title, browser open, fallback help |
+| `Launch-SysAdminSuiteDashboard.Host.bat` | IT / developers | Direct host spawn, no extra messaging |
+| `Launch-SysAdminSuiteDashboard.bat` | Permissive sites | PowerShell + Python legacy path |
+| `Launch-SysAdminSuite-Runtime.bat` | Portable zip | Menu: GUI, PS dashboard, .NET host |
+| `Start-CybernetSurveyTutorial.cmd` | Legacy | Opens `file://` dashboard; prefer START-HERE host path |
+
+## Troubleshooting
+
+### Browser did not open
+
+Paste manually:
+
+```text
+http://127.0.0.1:5000/dashboard/?tutorial=cybernet
+```
+
+### Host executable not found
+
+Run the publish script once, then retry START-HERE.
+
+### Port 5000 already in use
+
+Stop the other dashboard instance from the tray icon (**Stop Dashboard**), or ask IT to free the port.
+
+### Dashboard folder not found
+
+Run START-HERE from the cloned repo root. The host expects a `dashboard/` folder beside the executable or in a parent directory.
+
+### When to escalate to CLI
+
+Use [`START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md) when the lead approves subnet discovery orchestration beyond the dashboard wizard.
+
+## Related docs
+
+- [`docs/GUI_HOST_MIGRATION.md`](GUI_HOST_MIGRATION.md) — launcher matrix and host flags
+- [`docs/WAB_TEST_READINESS.md`](WAB_TEST_READINESS.md) — local smoke classification
+- [`dashboard/README.md`](../dashboard/README.md) — dashboard panels and samples

--- a/survey/README.md
+++ b/survey/README.md
@@ -4,12 +4,15 @@ This directory contains Bash-first survey tooling for SysAdminSuite.
 
 ## Primary Field Tutorial: Cybernet / Neuron Network Survey
 
+**Default front door:** double-click [`../START-HERE-SysAdminSuite-Dashboard.bat`](../START-HERE-SysAdminSuite-Dashboard.bat) and use **Start Cybernet Survey** in the dashboard. Read [`../START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) for plain-language steps.
+
 The current priority tutorial for field technicians is:
 
-- [`../START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md)
-- [`../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md)
+- [`../START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) — what to double-click and what opens
+- [`../START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md) — advanced CLI orchestrator path
+- [`../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md) — full step-by-step runbook
 
-Use that path when a technician needs to survey an approved site subnet for Cybernet or Neuron targets from deployment documentation. The workflow is:
+Use the CLI path below only when the dashboard or a lead explicitly asks for Bash orchestration. The workflow is:
 
 1. Copy approved local target CSVs into `survey/input/`.
 2. Run the Bash runtime smoke test.

--- a/tools/publish-dashboard-entrypoint.ps1
+++ b/tools/publish-dashboard-entrypoint.ps1
@@ -1,0 +1,56 @@
+# Publish the PS-independent dashboard tray host for field use.
+# Output is local-only (gitignored). Not committed to the repo.
+#
+# Usage (from repo root):
+#   powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
+#
+# Produces:
+#   dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe
+#   dist/SysAdminSuiteDashboard/SysAdminSuite.DashboardHost.exe (same binary, technical name)
+
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Release',
+    [string]$RuntimeIdentifier = 'win-x64',
+    [string]$OutputRoot = 'dist/SysAdminSuiteDashboard'
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$project = Join-Path $repoRoot 'src/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.csproj'
+$publishDir = Join-Path $repoRoot ($OutputRoot -replace '/', [IO.Path]::DirectorySeparatorChar)
+$friendlyName = 'SysAdminSuite Dashboard.exe'
+$technicalName = 'SysAdminSuite.DashboardHost.exe'
+
+if (-not (Test-Path -LiteralPath $project)) {
+    throw "Dashboard host project not found: $project"
+}
+
+Write-Host "Publishing dashboard host to $publishDir ..."
+dotnet publish $project -c $Configuration -r $RuntimeIdentifier --self-contained false -o $publishDir
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet publish failed with exit code $LASTEXITCODE"
+}
+
+$technicalPath = Join-Path $publishDir $technicalName
+if (-not (Test-Path -LiteralPath $technicalPath)) {
+    throw "Expected publish output missing: $technicalPath"
+}
+
+$friendlyPath = Join-Path $publishDir $friendlyName
+Copy-Item -LiteralPath $technicalPath -Destination $friendlyPath -Force
+
+$toolsPublish = Join-Path $repoRoot 'tools/publish/SysAdminSuite.DashboardHost'
+New-Item -ItemType Directory -Force -Path $toolsPublish | Out-Null
+Copy-Item -LiteralPath $technicalPath -Destination (Join-Path $toolsPublish $technicalName) -Force
+
+Write-Host ""
+Write-Host "Published:"
+Write-Host "  $friendlyPath"
+Write-Host "  $technicalPath"
+Write-Host "  $(Join-Path $toolsPublish $technicalName)"
+Write-Host ""
+Write-Host "Field users can double-click:"
+Write-Host "  START-HERE-SysAdminSuite-Dashboard.bat"
+Write-Host ""
+Write-Host "Requires .NET 8 runtime on the workstation."


### PR DESCRIPTION
## Summary
- Add `START-HERE-SysAdminSuite-Dashboard.bat` as the obvious double-click front door for field users.
- Add plain-language guides: `START-HERE-SysAdminSuite.md` and `docs/DASHBOARD_ENTRYPOINT.md`.
- Add `tools/publish-dashboard-entrypoint.ps1` to build a local friendly `SysAdminSuite Dashboard.exe` under gitignored `dist/SysAdminSuiteDashboard/`.
- Point `README.md`, `survey/README.md`, and `START-HERE-CYBERNET-NEURON-SURVEY.md` at the dashboard launcher instead of raw CLI/Python steps.

## What Khadejah should double-click
`START-HERE-SysAdminSuite-Dashboard.bat`

Opens: `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`

## EXE status
- No binary committed.
- Local publish script produces `dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe` (gitignored).

## Test plan
- `bash Tests/bash/test_dashboard_entrypoint_contracts.sh`
- `bash Tests/bash/test_dashboard_tutorial_launcher_contracts.sh`
- `git diff --check`
- `git ls-files --others --exclude-standard`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1` (local smoke)