### PR TITLE
Prioritize Cybernet serial identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,10 @@ logs/nmap/*
 logs/targets/*
 !logs/targets/.gitkeep
 
+# Mini-probe/WMI batch runtime evidence (hostnames, serials, IPs, debug traces — live field data)
+logs/mini-probe/*
+!logs/mini-probe/.gitkeep
+
 # Northwell registry-first verification evidence (raw reg.exe output — live field data)
 logs/registry/*
 !logs/registry/.gitkeep

--- a/deployment-audit/sas-build-survey-manifest.sh
+++ b/deployment-audit/sas-build-survey-manifest.sh
@@ -81,7 +81,10 @@ def norm_mac(v):
     return ':'.join(hx[i:i+2] for i in range(0, 12, 2)) if len(hx) == 12 else (v or '').strip().upper()
 
 def choose_target(row, known):
-    for key in ['cybernet hostname', 'cybernet serial', 'cybernet mac']:
+    # Prefer immutable identity first. Hostname remains available as HostName and
+    # can be used by downstream tools as a transport hint when serial cannot be
+    # resolved directly.
+    for key in ['cybernet serial', 'cybernet hostname', 'cybernet mac']:
         if known.get(key):
             return known[key]
     return row.get('SurveyTargetHint') or row.get('ConflictValue') or ''
@@ -101,7 +104,7 @@ with open(requests_path, newline='', encoding='utf-8-sig') as src, open(output_p
         host = known.get('cybernet hostname', '')
         serial = known.get('cybernet serial', '')
         mac = norm_mac(known.get('cybernet mac', '')) if known.get('cybernet mac') else ''
-        identifier = target or host or serial or mac or row.get('ConflictValue', '')
+        identifier = serial or target or host or mac or row.get('ConflictValue', '')
         key = (identifier, row.get('ExcelRow'), row.get('ConflictField'), row.get('ConflictValue'))
         if key in seen:
             continue

--- a/survey/sas-collect-cybernet-evidence.sh
+++ b/survey/sas-collect-cybernet-evidence.sh
@@ -110,8 +110,10 @@ with open(manifest, newline='', encoding='utf-8-sig') as f:
     for row in csv.DictReader(f):
         # Serial is the stable identity, but live network collection still needs
         # a transport hint such as hostname/IP. Prefer explicit probe hints and
-        # hostnames for the adapter, while downstream comparison remains serial-first.
-        target=first(row, ['ProbeTarget','SurveyTargetHint','HostName','Hostname','ComputerName','Computer','Name','Target','Identifier','MACAddress','ExpectedMAC'])
+        # hostnames for the adapter. If no probe hint exists, fall back to serial
+        # so the adapter emits an unreachable/blocked evidence row instead of
+        # failing before the manifest can be reported.
+        target=first(row, ['ProbeTarget','SurveyTargetHint','HostName','Hostname','ComputerName','Computer','Name','Target','Identifier','MACAddress','ExpectedMAC','Serial','SerialNumber','ServiceTag','AssetSerial','ExpectedSerial','Cybernet Serial','Cybernet S/N'])
         if target and target not in seen: seen.append(target)
 with open(out, 'w', encoding='utf-8') as f:
     for target in seen: f.write(target+'\n')
@@ -158,7 +160,7 @@ def stable_target(row):
     return first(row, ['Serial','SerialNumber','ServiceTag','AssetSerial','ExpectedSerial','Cybernet Serial','Cybernet S/N','Identifier','Target','HostName','Hostname','SurveyTargetHint','MACAddress','ExpectedMAC'])
 
 def probe_target(row):
-    return first(row, ['ProbeTarget','SurveyTargetHint','HostName','Hostname','ComputerName','Computer','Name','Target','Identifier','MACAddress','ExpectedMAC'])
+    return first(row, ['ProbeTarget','SurveyTargetHint','HostName','Hostname','ComputerName','Computer','Name','Target','Identifier','MACAddress','ExpectedMAC','Serial','SerialNumber','ServiceTag','AssetSerial','ExpectedSerial','Cybernet Serial','Cybernet S/N'])
 
 def verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, identity_status):
     evidence=[]

--- a/survey/sas-collect-cybernet-evidence.sh
+++ b/survey/sas-collect-cybernet-evidence.sh
@@ -11,6 +11,11 @@ TIMEOUT_SEC=5
 SSH_USER=""
 SSH_KEY=""
 ALLOW_SSH=0
+ALLOW_WMI=0
+WMI_USER=""
+WMI_PASS=""
+WMI_DOMAIN=""
+WMI_ADAPTER=""
 PASS_THRU=0
 IDENTITY_ADAPTER=""
 
@@ -29,13 +34,18 @@ Options:
   --ssh-user USER          Optional SSH username for SSH-capable targets
   --ssh-key PATH           Optional SSH private key
   --allow-ssh              Permit SSH read-only commands through the identity adapter
+  --allow-wmi              Permit read-only WMI identity collection through the identity adapter
+  --wmi-user USER          Optional WMI username. Prefer SAS_WMI_USER
+  --wmi-pass PASS          Optional WMI password. Prefer SAS_WMI_PASS
+  --wmi-domain DOMAIN      Optional WMI domain. Prefer SAS_WMI_DOMAIN
+  --wmi-adapter PATH       Optional WMI adapter path used by the identity adapter
   --pass-thru              Print evidence CSV after writing
   -h, --help               Show help
 
 Safety:
   - Read-only.
   - Does not change devices.
-  - SSH is disabled unless --allow-ssh is passed.
+  - SSH and WMI are disabled unless --allow-ssh/--allow-wmi are passed.
   - If no trusted transport is available, the tool still emits an evidence row with a clear status.
 
 Output columns:
@@ -61,6 +71,11 @@ while [[ $# -gt 0 ]]; do
     --ssh-user) SSH_USER="${2:?missing value for --ssh-user}"; shift 2 ;;
     --ssh-key) SSH_KEY="${2:?missing value for --ssh-key}"; shift 2 ;;
     --allow-ssh) ALLOW_SSH=1; shift ;;
+    --allow-wmi) ALLOW_WMI=1; shift ;;
+    --wmi-user) WMI_USER="${2:?missing value for --wmi-user}"; shift 2 ;;
+    --wmi-pass) WMI_PASS="${2:?missing value for --wmi-pass}"; shift 2 ;;
+    --wmi-domain) WMI_DOMAIN="${2:?missing value for --wmi-domain}"; shift 2 ;;
+    --wmi-adapter) WMI_ADAPTER="${2:?missing value for --wmi-adapter}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) fail "Unknown argument: $1" ;;
@@ -82,16 +97,21 @@ IDENTITY_CSV="$TMP_DIR/workstation_identity.csv"
 python3 - "$MANIFEST" "$TARGETS_FILE" <<'PY'
 import csv, sys
 manifest, out = sys.argv[1:3]
+
 def first(row, names):
-    lower={k.lower():v for k,v in row.items()}
+    lower={str(k).lower():v for k,v in row.items() if k is not None}
     for name in names:
         v=lower.get(name.lower())
         if v and str(v).strip(): return str(v).strip()
     return ''
+
 seen=[]
 with open(manifest, newline='', encoding='utf-8-sig') as f:
     for row in csv.DictReader(f):
-        target=first(row, ['HostName','Target','Identifier','SurveyTargetHint'])
+        # Serial is the stable identity, but live network collection still needs
+        # a transport hint such as hostname/IP. Prefer explicit probe hints and
+        # hostnames for the adapter, while downstream comparison remains serial-first.
+        target=first(row, ['ProbeTarget','SurveyTargetHint','HostName','Hostname','ComputerName','Computer','Name','Target','Identifier','MACAddress','ExpectedMAC'])
         if target and target not in seen: seen.append(target)
 with open(out, 'w', encoding='utf-8') as f:
     for target in seen: f.write(target+'\n')
@@ -104,6 +124,13 @@ if [[ -n "$IDENTITY_ADAPTER" ]]; then
     [[ -n "$SSH_USER" ]] && adapter_args+=(--ssh-user "$SSH_USER")
     [[ -n "$SSH_KEY" ]] && adapter_args+=(--ssh-key "$SSH_KEY")
   fi
+  if [[ "$ALLOW_WMI" -eq 1 ]]; then
+    adapter_args+=(--allow-wmi)
+    [[ -n "$WMI_USER" ]] && adapter_args+=(--wmi-user "$WMI_USER")
+    [[ -n "$WMI_PASS" ]] && adapter_args+=(--wmi-pass "$WMI_PASS")
+    [[ -n "$WMI_DOMAIN" ]] && adapter_args+=(--wmi-domain "$WMI_DOMAIN")
+    [[ -n "$WMI_ADAPTER" ]] && adapter_args+=(--wmi-adapter "$WMI_ADAPTER")
+  fi
   bash "${adapter_args[@]}" >/dev/null
 else
   printf 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes\n' > "$IDENTITY_CSV"
@@ -113,16 +140,26 @@ python3 - "$MANIFEST" "$OUTPUT" "$IDENTITY_CSV" <<'PY'
 import csv, datetime as dt, re, sys
 manifest, output, identity_csv = sys.argv[1:4]
 fields = ['Timestamp','ExcelRow','ConflictField','ConflictValue','InputIdentifier','Target','HostName','ExpectedSerial','ExpectedMAC','ResolvedAddress','PingStatus','DnsName','ObservedHostName','ObservedSerial','ObservedMACs','TransportUsed','EvidenceStatus','RevisitRecommendation','Notes']
+
 def first(row, names):
-    lower={k.lower():v for k,v in row.items()}
+    lower={str(k).lower():v for k,v in row.items() if k is not None}
     for name in names:
         v=lower.get(name.lower())
         if v and str(v).strip(): return str(v).strip()
     return ''
+
 def norm_mac(v):
     hx=re.sub(r'[^0-9A-Fa-f]','',v or '').upper()
     return ':'.join(hx[i:i+2] for i in range(0,12,2)) if len(hx)==12 else (v or '').strip().upper()
+
 def norm_serial(v): return re.sub(r'\s+','',(v or '').strip()).upper()
+
+def stable_target(row):
+    return first(row, ['Serial','SerialNumber','ServiceTag','AssetSerial','ExpectedSerial','Cybernet Serial','Cybernet S/N','Identifier','Target','HostName','Hostname','SurveyTargetHint','MACAddress','ExpectedMAC'])
+
+def probe_target(row):
+    return first(row, ['ProbeTarget','SurveyTargetHint','HostName','Hostname','ComputerName','Computer','Name','Target','Identifier','MACAddress','ExpectedMAC'])
+
 def verdict(ping_status, expected_serial, expected_mac, observed_serial, observed_macs, identity_status):
     evidence=[]
     if expected_serial and observed_serial:
@@ -135,6 +172,7 @@ def verdict(ping_status, expected_serial, expected_mac, observed_serial, observe
     if identity_status == 'IdentityCollected': return 'IdentityCollectedNeedsComparisonData','Collected identity, but tracker lacks expected serial/MAC for hard comparison'
     if ping_status == 'Reachable': return 'ReachableNeedsPrivilegedSurvey','Try approved identity transport before revisit'
     return 'Unreachable','Revisit justified only after network/remote-management path is exhausted'
+
 identity={}
 with open(identity_csv, newline='', encoding='utf-8-sig') as f:
     for row in csv.DictReader(f):
@@ -143,11 +181,12 @@ with open(identity_csv, newline='', encoding='utf-8-sig') as f:
 rows=[]
 with open(manifest, newline='', encoding='utf-8-sig') as f:
     for row in csv.DictReader(f):
-        target=first(row, ['HostName','Target','Identifier','SurveyTargetHint'])
-        host=first(row, ['HostName'])
-        expected_serial=first(row, ['Serial','ExpectedSerial','Cybernet Serial'])
+        target=stable_target(row)
+        probe=probe_target(row)
+        host=first(row, ['HostName','Hostname','ComputerName','Computer','Name'])
+        expected_serial=first(row, ['Serial','SerialNumber','ServiceTag','AssetSerial','ExpectedSerial','Cybernet Serial','Cybernet S/N'])
         expected_mac=norm_mac(first(row, ['MACAddress','ExpectedMAC','Cybernet MAC']))
-        ident=identity.get((host or target).upper(), identity.get(target.upper(), {}))
+        ident=identity.get((probe or '').upper(), identity.get((host or '').upper(), identity.get((target or '').upper(), {})))
         ping_status=first(ident, ['PingStatus'])
         identity_status=first(ident, ['IdentityStatus'])
         observed_serial=first(ident, ['ObservedSerial'])

--- a/survey/sas-live-serial-probe.sh
+++ b/survey/sas-live-serial-probe.sh
@@ -192,13 +192,20 @@ def load_index(path, source):
 def lookup(index, value):
     return (index.get(key(value)) or [None])[0]
 
+def serial_from_manifest(row):
+    return first(row, [
+        "expected_cybernet_serial","ExpectedCybernetSerial","ExpectedSerial","Expected Serial",
+        "Serial","SerialNumber","ServiceTag","AssetSerial","Cybernet Serial","Cybernet S/N",
+    ])
+
 def manifest_record(row):
     cyber_host = first(row, ["Cybernet Hostname","CybernetHostName","Cybernet Host","HostName","Hostname"])
     neuron_host = first(row, ["Neuron Hostname","NeuronHostName","Neuron Host"])
-    cyber_serial = first(row, ["expected_cybernet_serial","ExpectedCybernetSerial","Cybernet Serial","Cybernet S/N"])
+    cyber_serial = serial_from_manifest(row)
     neuron_serial = first(row, ["expected_neuron_serial","ExpectedNeuronSerial","Neuron S/N","Neuron Serial"])
-    mac = norm_mac(first(row, ["expected_mac","ExpectedMAC","MACAddress","MAC"]))
-    target = first(row, ["target","Target","SurveyTargetHint","Identifier","HostName","Hostname","Cybernet Serial","Neuron S/N","MACAddress"]) or cyber_host or neuron_host or cyber_serial or neuron_serial or mac
+    mac = norm_mac(first(row, ["expected_mac","ExpectedMAC","MACAddress","MAC"] ))
+    stable_serial = cyber_serial or neuron_serial
+    target = stable_serial or first(row, ["target","Target","SurveyTargetHint","Identifier","HostName","Hostname","MACAddress"]) or cyber_host or neuron_host or mac
     typ = ident_type(target)
     expected_host = cyber_host or neuron_host or (target if typ == "hostname" else "")
     return {
@@ -212,6 +219,21 @@ def manifest_record(row):
         "expected_neuron_serial": neuron_serial,
         "expected_mac": mac,
     }
+
+def lookup_candidates(rec):
+    # Serial is the primary identity. Hostname is only a fallback because it can drift.
+    values = [
+        rec["expected_cybernet_serial"],
+        rec["expected_neuron_serial"],
+        rec["input_identifier"],
+        rec["expected_mac"],
+        rec["expected_hostname"],
+    ]
+    out = []
+    for value in values:
+        if value and value not in out:
+            out.append(value)
+    return out
 
 def drift(expected, resolved, typ):
     expected, resolved = norm_id(expected), norm_id(resolved)
@@ -285,12 +307,19 @@ with open(manifest, newline="", encoding="utf-8-sig") as handle:
         rec = manifest_record(raw)
         attempted = ["manifest_match"]
         ev = None
+        candidates = lookup_candidates(rec)
         if identity_csv:
             attempted.append("identity_csv_lookup")
-            ev = lookup(identity, rec["input_identifier"])
+            for candidate in candidates:
+                ev = lookup(identity, candidate)
+                if ev is not None:
+                    break
         if ev is None and ad_csv:
             attempted.append("ad_csv_lookup")
-            ev = lookup(ad, rec["input_identifier"])
+            for candidate in candidates:
+                ev = lookup(ad, candidate)
+                if ev is not None:
+                    break
         if ev is None:
             ev = empty("Identifier is not resolved by supplied evidence sources")
 

--- a/tests/survey/test_serial_first_identity.py
+++ b/tests/survey/test_serial_first_identity.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Offline regression tests for serial-first Cybernet identity handling.
+
+These tests intentionally avoid network access. They use synthetic manifests and
+synthetic identity evidence to prove that serial is treated as the stable
+identity while hostname remains only a mutable transport hint.
+"""
+from __future__ import annotations
+
+import csv
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def write_csv(path: Path, rows: list[dict[str, str]], fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, quoting=csv.QUOTE_ALL, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def read_first_row(path: Path) -> dict[str, str]:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        return next(csv.DictReader(handle))
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, cwd=REPO_ROOT, check=True)
+
+
+def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() -> None:
+    with tempfile.TemporaryDirectory() as tmp_raw:
+        tmp = Path(tmp_raw)
+        manifest = tmp / "manifest.csv"
+        output = tmp / "cybernet_evidence.csv"
+        fake_adapter = tmp / "fake_identity_adapter.sh"
+        captured_targets = tmp / "captured_targets.txt"
+
+        write_csv(
+            manifest,
+            [
+                {
+                    "Identifier": "CYB-SERIAL-001",
+                    "Target": "CYB-SERIAL-001",
+                    "HostName": "OLD-CYBERNET-HOST",
+                    "Serial": "CYB-SERIAL-001",
+                    "MACAddress": "",
+                    "DeviceType": "Cybernet",
+                    "Source": "offline-test",
+                    "ExcelRow": "42",
+                    "ConflictField": "Cybernet Serial",
+                    "ConflictValue": "CYB-SERIAL-001",
+                }
+            ],
+            [
+                "Identifier",
+                "Target",
+                "HostName",
+                "Serial",
+                "MACAddress",
+                "DeviceType",
+                "Source",
+                "ExcelRow",
+                "ConflictField",
+                "ConflictValue",
+            ],
+        )
+
+        fake_adapter.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "targets_file=''\n"
+            "output=''\n"
+            "while [[ $# -gt 0 ]]; do\n"
+            "  case \"$1\" in\n"
+            "    --targets-file) targets_file=\"$2\"; shift 2 ;;\n"
+            "    --output) output=\"$2\"; shift 2 ;;\n"
+            "    --timeout) shift 2 ;;\n"
+            "    *) shift ;;\n"
+            "  esac\n"
+            "done\n"
+            f"cp \"$targets_file\" {captured_targets!s}\n"
+            "printf '%s\\n' 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes' > \"$output\"\n"
+            "printf '%s\\n' '\"2026-06-25 00:00:00\",\"OLD-CYBERNET-HOST\",\"10.10.10.10\",\"Reachable\",\"OLD-CYBERNET-HOST\",\"RENAMED-CYBERNET-HOST\",\"CYB-SERIAL-001\",\"AA:BB:CC:DD:EE:FF\",\"WMI\",\"IdentityCollected\",\"offline fixture\"' >> \"$output\"\n",
+            encoding="utf-8",
+        )
+        fake_adapter.chmod(fake_adapter.stat().st_mode | stat.S_IXUSR)
+
+        run(
+            [
+                "bash",
+                "survey/sas-collect-cybernet-evidence.sh",
+                "--manifest",
+                str(manifest),
+                "--identity-adapter",
+                str(fake_adapter),
+                "--output",
+                str(output),
+            ]
+        )
+
+        # The adapter should be asked to probe by hostname, not by serial, because
+        # serial is not directly reachable on the network.
+        assert captured_targets.read_text(encoding="utf-8").strip() == "OLD-CYBERNET-HOST"
+
+        row = read_first_row(output)
+        assert row["Target"] == "CYB-SERIAL-001"
+        assert row["HostName"] == "OLD-CYBERNET-HOST"
+        assert row["ExpectedSerial"] == "CYB-SERIAL-001"
+        assert row["ObservedHostName"] == "RENAMED-CYBERNET-HOST"
+        assert row["ObservedSerial"] == "CYB-SERIAL-001"
+        assert row["EvidenceStatus"] == "Confirmed"
+
+
+def test_live_serial_probe_resolves_by_serial_before_hostname() -> None:
+    with tempfile.TemporaryDirectory() as tmp_raw:
+        tmp = Path(tmp_raw)
+        manifest = tmp / "manifest.csv"
+        identity = tmp / "identity.csv"
+        output = tmp / "live_serial_probe_results.csv"
+
+        write_csv(
+            manifest,
+            [
+                {
+                    "Identifier": "CYB-SERIAL-002",
+                    "Target": "CYB-SERIAL-002",
+                    "HostName": "OLD-CYBERNET-HOST",
+                    "Serial": "CYB-SERIAL-002",
+                    "MACAddress": "",
+                    "DeviceType": "Cybernet",
+                    "ExcelRow": "43",
+                }
+            ],
+            ["Identifier", "Target", "HostName", "Serial", "MACAddress", "DeviceType", "ExcelRow"],
+        )
+        write_csv(
+            identity,
+            [
+                {
+                    "Timestamp": "2026-06-25 00:00:00",
+                    "Target": "SOME-OTHER-HOSTNAME",
+                    "ResolvedAddress": "10.10.10.20",
+                    "PingStatus": "Reachable",
+                    "DnsName": "SOME-OTHER-HOSTNAME",
+                    "ObservedHostName": "RENAMED-CYBERNET-HOST",
+                    "ObservedSerial": "CYB-SERIAL-002",
+                    "ObservedMACs": "AA:BB:CC:DD:EE:11",
+                    "TransportUsed": "WMI",
+                    "IdentityStatus": "IdentityCollected",
+                    "Notes": "offline fixture",
+                }
+            ],
+            [
+                "Timestamp",
+                "Target",
+                "ResolvedAddress",
+                "PingStatus",
+                "DnsName",
+                "ObservedHostName",
+                "ObservedSerial",
+                "ObservedMACs",
+                "TransportUsed",
+                "IdentityStatus",
+                "Notes",
+            ],
+        )
+
+        run(
+            [
+                "bash",
+                "survey/sas-live-serial-probe.sh",
+                "--manifest",
+                str(manifest),
+                "--identity-csv",
+                str(identity),
+                "--output",
+                str(output),
+                "--no-dashboard",
+            ]
+        )
+
+        row = read_first_row(output)
+        assert row["target"] == "CYB-SERIAL-002"
+        assert row["expected_hostname"] == "OLD-CYBERNET-HOST"
+        assert row["resolved_hostname"] == "RENAMED-CYBERNET-HOST"
+        assert row["resolved_serial"] == "CYB-SERIAL-002"
+        assert row["classification"] == "identity_resolved"
+        assert row["identity_drift_status"] == "hostname_drift"
+        assert row["log_status"] == "hostname_drift"
+
+
+if __name__ == "__main__":
+    test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint()
+    test_live_serial_probe_resolves_by_serial_before_hostname()
+    print("offline serial-first identity tests passed")

--- a/tests/survey/test_serial_first_identity.py
+++ b/tests/survey/test_serial_first_identity.py
@@ -8,7 +8,6 @@ identity while hostname remains only a mutable transport hint.
 from __future__ import annotations
 
 import csv
-import os
 import stat
 import subprocess
 import tempfile
@@ -40,7 +39,6 @@ def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() 
         manifest = tmp / "manifest.csv"
         output = tmp / "cybernet_evidence.csv"
         fake_adapter = tmp / "fake_identity_adapter.sh"
-        captured_targets = tmp / "captured_targets.txt"
 
         write_csv(
             manifest,
@@ -85,9 +83,13 @@ def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() 
             "    *) shift ;;\n"
             "  esac\n"
             "done\n"
-            f"cp \"$targets_file\" {captured_targets!s}\n"
+            "probe=$(head -n 1 \"$targets_file\")\n"
             "printf '%s\\n' 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes' > \"$output\"\n"
-            "printf '%s\\n' '\"2026-06-25 00:00:00\",\"OLD-CYBERNET-HOST\",\"10.10.10.10\",\"Reachable\",\"OLD-CYBERNET-HOST\",\"RENAMED-CYBERNET-HOST\",\"CYB-SERIAL-001\",\"AA:BB:CC:DD:EE:FF\",\"WMI\",\"IdentityCollected\",\"offline fixture\"' >> \"$output\"\n",
+            "if [[ \"$probe\" == 'OLD-CYBERNET-HOST' ]]; then\n"
+            "  printf '\"2026-06-25 00:00:00\",\"%s\",\"10.10.10.10\",\"Reachable\",\"%s\",\"RENAMED-CYBERNET-HOST\",\"CYB-SERIAL-001\",\"AA:BB:CC:DD:EE:FF\",\"WMI\",\"IdentityCollected\",\"probe=%s\"\\n' \"$probe\" \"$probe\" \"$probe\" >> \"$output\"\n"
+            "else\n"
+            "  printf '\"2026-06-25 00:00:00\",\"%s\",\"\",\"NoPing\",\"\",\"\",\"\",\"\",\"\",\"UnreachableOrBlocked\",\"probe=%s\"\\n' \"$probe\" \"$probe\" >> \"$output\"\n"
+            "fi\n",
             encoding="utf-8",
         )
         fake_adapter.chmod(fake_adapter.stat().st_mode | stat.S_IXUSR)
@@ -105,10 +107,6 @@ def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() 
             ]
         )
 
-        # The adapter should be asked to probe by hostname, not by serial, because
-        # serial is not directly reachable on the network.
-        assert captured_targets.read_text(encoding="utf-8").strip() == "OLD-CYBERNET-HOST"
-
         row = read_first_row(output)
         assert row["Target"] == "CYB-SERIAL-001"
         assert row["HostName"] == "OLD-CYBERNET-HOST"
@@ -116,6 +114,7 @@ def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() 
         assert row["ObservedHostName"] == "RENAMED-CYBERNET-HOST"
         assert row["ObservedSerial"] == "CYB-SERIAL-001"
         assert row["EvidenceStatus"] == "Confirmed"
+        assert row["Notes"] == "probe=OLD-CYBERNET-HOST"
 
 
 def test_live_serial_probe_resolves_by_serial_before_hostname() -> None:

--- a/tests/survey/test_serial_first_identity.py
+++ b/tests/survey/test_serial_first_identity.py
@@ -33,12 +33,89 @@ def run(cmd: list[str]) -> None:
     subprocess.run(cmd, cwd=REPO_ROOT, check=True)
 
 
+def fake_identity_adapter(path: Path) -> None:
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "targets_file=''\n"
+        "output=''\n"
+        "while [[ $# -gt 0 ]]; do\n"
+        "  case \"$1\" in\n"
+        "    --targets-file) targets_file=\"$2\"; shift 2 ;;\n"
+        "    --output) output=\"$2\"; shift 2 ;;\n"
+        "    --timeout) shift 2 ;;\n"
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n"
+        "probe=$(head -n 1 \"$targets_file\" || true)\n"
+        "printf '%s\\n' 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes' > \"$output\"\n"
+        "if [[ \"$probe\" == 'OLD-CYBERNET-HOST' ]]; then\n"
+        "  printf '\"2026-06-25 00:00:00\",\"%s\",\"10.10.10.10\",\"Reachable\",\"%s\",\"RENAMED-CYBERNET-HOST\",\"CYB-SERIAL-001\",\"AA:BB:CC:DD:EE:FF\",\"WMI\",\"IdentityCollected\",\"probe=%s\"\\n' \"$probe\" \"$probe\" \"$probe\" >> \"$output\"\n"
+        "elif [[ \"$probe\" == 'CYB-SERIAL-003' ]]; then\n"
+        "  printf '\"2026-06-25 00:00:00\",\"%s\",\"\",\"NoPing\",\"\",\"\",\"\",\"\",\"\",\"UnreachableOrBlocked\",\"probe=%s\"\\n' \"$probe\" \"$probe\" >> \"$output\"\n"
+        "else\n"
+        "  printf '\"2026-06-25 00:00:00\",\"%s\",\"\",\"NoPing\",\"\",\"\",\"\",\"\",\"\",\"UnreachableOrBlocked\",\"probe=%s\"\\n' \"$probe\" \"$probe\" >> \"$output\"\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_manifest_builder_prefers_serial_over_hostname() -> None:
+    with tempfile.TemporaryDirectory() as tmp_raw:
+        tmp = Path(tmp_raw)
+        requests = tmp / "survey_requests_duplicate_resolution.csv"
+        output = tmp / "remote_survey_manifest.csv"
+
+        write_csv(
+            requests,
+            [
+                {
+                    "KnownResolutionIdentifiers": "cybernet hostname=OLD-CYBERNET-HOST; cybernet serial=CYB-SERIAL-000; cybernet mac=AA-BB-CC-DD-EE-00",
+                    "SurveyTargetHint": "OLD-CYBERNET-HOST",
+                    "ConflictValue": "OLD-CYBERNET-HOST",
+                    "MissingResolutionIdentifiers": "Neuron Serial",
+                    "ExcelRow": "41",
+                    "ConflictField": "Cybernet Hostname",
+                    "LocationKey": "NSUH-TEST",
+                }
+            ],
+            [
+                "KnownResolutionIdentifiers",
+                "SurveyTargetHint",
+                "ConflictValue",
+                "MissingResolutionIdentifiers",
+                "ExcelRow",
+                "ConflictField",
+                "LocationKey",
+            ],
+        )
+
+        run(
+            [
+                "bash",
+                "deployment-audit/sas-build-survey-manifest.sh",
+                "--requests",
+                str(requests),
+                "--output",
+                str(output),
+            ]
+        )
+
+        row = read_first_row(output)
+        assert row["Identifier"] == "CYB-SERIAL-000"
+        assert row["Target"] == "CYB-SERIAL-000"
+        assert row["HostName"] == "OLD-CYBERNET-HOST"
+        assert row["Serial"] == "CYB-SERIAL-000"
+        assert row["MACAddress"] == "AA:BB:CC:DD:EE:00"
+
+
 def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() -> None:
     with tempfile.TemporaryDirectory() as tmp_raw:
         tmp = Path(tmp_raw)
         manifest = tmp / "manifest.csv"
         output = tmp / "cybernet_evidence.csv"
-        fake_adapter = tmp / "fake_identity_adapter.sh"
+        adapter = tmp / "fake_identity_adapter.sh"
 
         write_csv(
             manifest,
@@ -69,30 +146,7 @@ def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() 
                 "ConflictValue",
             ],
         )
-
-        fake_adapter.write_text(
-            "#!/usr/bin/env bash\n"
-            "set -euo pipefail\n"
-            "targets_file=''\n"
-            "output=''\n"
-            "while [[ $# -gt 0 ]]; do\n"
-            "  case \"$1\" in\n"
-            "    --targets-file) targets_file=\"$2\"; shift 2 ;;\n"
-            "    --output) output=\"$2\"; shift 2 ;;\n"
-            "    --timeout) shift 2 ;;\n"
-            "    *) shift ;;\n"
-            "  esac\n"
-            "done\n"
-            "probe=$(head -n 1 \"$targets_file\")\n"
-            "printf '%s\\n' 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes' > \"$output\"\n"
-            "if [[ \"$probe\" == 'OLD-CYBERNET-HOST' ]]; then\n"
-            "  printf '\"2026-06-25 00:00:00\",\"%s\",\"10.10.10.10\",\"Reachable\",\"%s\",\"RENAMED-CYBERNET-HOST\",\"CYB-SERIAL-001\",\"AA:BB:CC:DD:EE:FF\",\"WMI\",\"IdentityCollected\",\"probe=%s\"\\n' \"$probe\" \"$probe\" \"$probe\" >> \"$output\"\n"
-            "else\n"
-            "  printf '\"2026-06-25 00:00:00\",\"%s\",\"\",\"NoPing\",\"\",\"\",\"\",\"\",\"\",\"UnreachableOrBlocked\",\"probe=%s\"\\n' \"$probe\" \"$probe\" >> \"$output\"\n"
-            "fi\n",
-            encoding="utf-8",
-        )
-        fake_adapter.chmod(fake_adapter.stat().st_mode | stat.S_IXUSR)
+        fake_identity_adapter(adapter)
 
         run(
             [
@@ -101,7 +155,7 @@ def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() 
                 "--manifest",
                 str(manifest),
                 "--identity-adapter",
-                str(fake_adapter),
+                str(adapter),
                 "--output",
                 str(output),
             ]
@@ -115,6 +169,65 @@ def test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint() 
         assert row["ObservedSerial"] == "CYB-SERIAL-001"
         assert row["EvidenceStatus"] == "Confirmed"
         assert row["Notes"] == "probe=OLD-CYBERNET-HOST"
+
+
+def test_cybernet_collector_reports_serial_only_rows_without_crashing() -> None:
+    with tempfile.TemporaryDirectory() as tmp_raw:
+        tmp = Path(tmp_raw)
+        manifest = tmp / "serial_only_manifest.csv"
+        output = tmp / "cybernet_evidence.csv"
+        adapter = tmp / "fake_identity_adapter.sh"
+
+        write_csv(
+            manifest,
+            [
+                {
+                    "Identifier": "",
+                    "Target": "",
+                    "HostName": "",
+                    "Serial": "CYB-SERIAL-003",
+                    "MACAddress": "",
+                    "DeviceType": "Cybernet",
+                    "Source": "offline-test",
+                    "ExcelRow": "44",
+                    "ConflictField": "Cybernet Serial",
+                    "ConflictValue": "CYB-SERIAL-003",
+                }
+            ],
+            [
+                "Identifier",
+                "Target",
+                "HostName",
+                "Serial",
+                "MACAddress",
+                "DeviceType",
+                "Source",
+                "ExcelRow",
+                "ConflictField",
+                "ConflictValue",
+            ],
+        )
+        fake_identity_adapter(adapter)
+
+        run(
+            [
+                "bash",
+                "survey/sas-collect-cybernet-evidence.sh",
+                "--manifest",
+                str(manifest),
+                "--identity-adapter",
+                str(adapter),
+                "--output",
+                str(output),
+            ]
+        )
+
+        row = read_first_row(output)
+        assert row["Target"] == "CYB-SERIAL-003"
+        assert row["ExpectedSerial"] == "CYB-SERIAL-003"
+        assert row["PingStatus"] == "NoPing"
+        assert row["EvidenceStatus"] == "Unreachable"
+        assert row["Notes"] == "probe=CYB-SERIAL-003"
 
 
 def test_live_serial_probe_resolves_by_serial_before_hostname() -> None:
@@ -196,6 +309,8 @@ def test_live_serial_probe_resolves_by_serial_before_hostname() -> None:
 
 
 if __name__ == "__main__":
+    test_manifest_builder_prefers_serial_over_hostname()
     test_cybernet_collector_keeps_serial_as_target_and_hostname_as_probe_hint()
+    test_cybernet_collector_reports_serial_only_rows_without_crashing()
     test_live_serial_probe_resolves_by_serial_before_hostname()
     print("offline serial-first identity tests passed")


### PR DESCRIPTION
## What changed

- Makes the deployment survey manifest prefer Cybernet serial before hostname when choosing the stable target identifier.
- Keeps hostname available as the transport/probe hint because live WMI/SSH/DNS collection still needs a reachable name or IP.
- Updates Cybernet evidence collection to output serial-first targets while matching collected identity evidence back through the hostname probe hint.
- Adds WMI pass-through flags to the Cybernet evidence collector so observed Windows serial/MAC evidence can actually be collected through the existing workstation identity adapter.
- Updates the live serial resolver to look up evidence by expected Cybernet serial first, then Neuron serial, identifier, MAC, and hostname fallback.
- Handles serial-only manifest rows by emitting an unreachable/blocked row instead of failing before report generation.

## Known gaps

- Offline tests prove CSV logic only; they do not prove real NSUH DNS, WMI, firewall, AD, or credential behavior.
- Serial-only rows cannot be actively reached unless another source maps that serial to a hostname, IP, AD object, DHCP lease, or tracker record.
- WMI success still depends on approved network path, permissions, firewall, endpoint state, and local PowerShell/WMI client behavior.
- Hostname drift is intentionally not treated as failure when serial matches, but drift still needs tracker cleanup.
- Debug logs and WMI outputs may contain sensitive operational details and should remain local.

## Risks

- If the source tracker has a wrong serial, serial-first logic will correctly flag conflicts, but the row will need manual review instead of automatic confirmation.
- If only hostname evidence exists and no observed serial/MAC is collected, confidence remains limited because hostname can drift.
- If users run WMI batches off-network, unreachable results may reflect network position rather than device absence.
- If generated evidence CSVs are committed by accident, they may expose hostnames, IPs, serials, or operational notes.

## Validation

- Offline serial-first regression test passes on Git Bash/Windows with no network required.
- Tests cover manifest generation, hostname-as-probe behavior, serial-only rows, and serial-first resolver lookup.