### PR TITLE
fix(ui): prove dashboard field launcher path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@
 
 For most users, do not start with command-line tools.
 
+First, get the repo. Choose the parent folder where you want SysAdminSuite to live, then run:
+
+```bash
+git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git
+```
+
+This creates the `SysAdminSuite` folder. Then open that folder and double-click `START-HERE-SysAdminSuite-Dashboard.bat`.
+
+Do not create a `SysAdminSuite` folder first and then clone inside it. That can create `SysAdminSuite\SysAdminSuite` and the launcher will not be at the top level.
+
 Double-click:
 
 `START-HERE-SysAdminSuite-Dashboard.bat`

--- a/START-HERE-SysAdminSuite.md
+++ b/START-HERE-SysAdminSuite.md
@@ -14,6 +14,26 @@ This opens the local dashboard and tutorial page.
 
 Use CLI tools only when the dashboard or a runbook gives you a specific command.
 
+## How do I download SysAdminSuite?
+
+Choose the parent folder where you want SysAdminSuite to live (for example, your Desktop or a `dev` folder).
+
+Run:
+
+```bash
+git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git
+```
+
+This creates the `SysAdminSuite` folder.
+
+Then open the `SysAdminSuite` folder and double-click:
+
+`START-HERE-SysAdminSuite-Dashboard.bat`
+
+**Do not** create a `SysAdminSuite` folder first and then clone inside it. That can create `SysAdminSuite\SysAdminSuite` and the launcher will not be at the top level where you expect it.
+
+No Git? Use the green **Code** button on the GitHub page, choose **Download ZIP**, then extract it. The extracted folder contains `START-HERE-SysAdminSuite-Dashboard.bat`.
+
 ## I just downloaded or cloned the repo. What do I click?
 
 Double-click **`START-HERE-SysAdminSuite-Dashboard.bat`** at the repo root.

--- a/Tests/bash/test_dashboard_entrypoint_contracts.sh
+++ b/Tests/bash/test_dashboard_entrypoint_contracts.sh
@@ -64,6 +64,16 @@ grep -Fq 'http://127.0.0.1:5000/dashboard/' "$start_md" \
 grep -Fq 'flowchart TD' "$start_md" \
   || fail "START-HERE-SysAdminSuite.md is missing the Mermaid workflow diagram"
 
+# Clone/download wording: field users must be told where to clone from and warned
+# against the nested SysAdminSuite\SysAdminSuite mistake. Assert in the lay-user
+# front doors (README + START-HERE) and the agent canonical reference.
+for clone_doc in "$readme" "$start_md" "$entry_doc"; do
+  grep -Fq 'git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git' "$clone_doc" \
+    || fail "$(basename "$clone_doc") is missing the git clone instruction"
+  grep -Fq 'SysAdminSuite\SysAdminSuite' "$clone_doc" \
+    || fail "$(basename "$clone_doc") is missing the nested-folder (SysAdminSuite\\SysAdminSuite) warning"
+done
+
 # Canonical docs must not present a .cmd as the primary field instruction.
 # grep is line-based, so .* matches "same line"; alternation covers both .cmd
 # aliases. A nearby alias mention on its own line (e.g. "...are compatibility

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -10,6 +10,18 @@
 
 Compatibility aliases (same behavior, not the documented primary): **`START-HERE-SysAdminSuite-Dashboard.cmd`** and **`SysAdminSuite Dashboard.cmd`**.
 
+## Get the repo first (clone / download)
+
+Field users must clone or download before they can double-click. Tell them to pick a parent folder, then:
+
+```bash
+git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git
+```
+
+This creates the `SysAdminSuite` folder; they then open it and double-click `START-HERE-SysAdminSuite-Dashboard.bat`.
+
+Warn against the common mistake: do **not** create a `SysAdminSuite` folder first and clone inside it, which produces `SysAdminSuite\SysAdminSuite` and hides the launcher one level deep. ZIP download via the GitHub **Code** button is an equivalent no-Git path.
+
 ## Launcher matrix
 
 | File | Audience | What it does |


### PR DESCRIPTION
## What failed or was unclear

Post-merge field proof of PR #91. The Windows double-click smoke test passed end to end, but the **clone/download wording audit failed**: none of the field docs told a user where to clone from, and none warned against the common `SysAdminSuite\SysAdminSuite` nested-folder mistake.

## What changed

- Added the clone/download instruction (with parent-folder guidance) and the nested-folder warning to:
  - `README.md` (Start here)
  - `START-HERE-SysAdminSuite.md` (new "How do I download SysAdminSuite?" section)
  - `docs/DASHBOARD_ENTRYPOINT.md` (agent canonical reference)
- Added a guard in `Tests/bash/test_dashboard_entrypoint_contracts.sh` asserting the `git clone` instruction and the `SysAdminSuite\SysAdminSuite` warning are present in those docs, so the wording cannot regress.
- Docs-only + test guard. No launcher logic, dashboard, or PowerShell survey scripts were changed.

## Exact smoke-test result

Run on Windows from the repo root:

- `Launch-SysAdminSuiteDashboard.Host.bat --no-browser` resolved the locally built host exe and exited `0`.
- Host process `SysAdminSuite Dashboard` started.
- `GET http://127.0.0.1:5000/dashboard/` -> `200`.
- `GET http://127.0.0.1:5000/dashboard/?tutorial=cybernet` -> `200`.
- Host process stopped cleanly after the test.

The host exe exists only as a local, gitignored build (`dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe`), exactly as documented. No `dist/` output was committed.

## Exact clone/download instruction now presented

```
Choose the parent folder where you want SysAdminSuite to live.

git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git

This creates the SysAdminSuite folder.
Then open the SysAdminSuite folder and double-click:
START-HERE-SysAdminSuite-Dashboard.bat

Do not create a SysAdminSuite folder first and then clone inside it.
That can create SysAdminSuite\SysAdminSuite.
```

## Confirmations

- `.bat` remains canonical: `START-HERE-SysAdminSuite-Dashboard.bat` is the documented front door.
- `.cmd` remains compatibility only: `START-HERE-SysAdminSuite-Dashboard.cmd` and `SysAdminSuite Dashboard.cmd` still delegate to the `.bat`.
- No generated `dist/` output was committed.

## Validation

- `bash Tests/bash/test_dashboard_entrypoint_contracts.sh` -> `PASS: dashboard entrypoint contracts`
- `git diff --check` -> clean
