### PR TITLE
fix(ui): auto-publish dashboard host on first run

### DIFF
--- a/Launch-SysAdminSuiteDashboard.Host.bat
+++ b/Launch-SysAdminSuiteDashboard.Host.bat
@@ -1,46 +1,44 @@
 @echo off
 :: Launch-SysAdminSuiteDashboard.Host.bat
-:: PS-independent launcher for the SysAdminSuite web dashboard.
-:: Spawns SysAdminSuite.DashboardHost.exe which serves dashboard/ over
-:: http://127.0.0.1:5000 and shows a tray icon (Open, Copy URL, Stop).
-:: No powershell.exe and no Python required.
+:: Field-safe dashboard host launcher.
+::
+:: Discovers the SysAdminSuite dashboard host executable. On first run, if the
+:: host is missing, this AUTOMATICALLY builds it via
+:: tools\publish-dashboard-entrypoint.ps1 so the field user never has to run a
+:: publish command by hand. It then starts the tray host which serves
+:: http://127.0.0.1:5000 (Open Dashboard, Copy URL, Stop).
+::
+:: Exit codes (consumed by START-HERE-SysAdminSuite-Dashboard.bat):
+::   0  host found or built, and started
+::   2  .NET SDK (dotnet) missing - cannot build on this machine
+::   3  auto-publish ran but the host could not be built or located
 
-setlocal
+setlocal enabledelayedexpansion
 set "ROOT=%~dp0"
 
-:: 1) Portable layout (zip): app\bin\SysAdminSuite.DashboardHost.exe
-if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
-    start "" /B "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" %*
-    exit /b 0
-)
+call :find_host
+if defined HOST_EXE goto :start_host
 
-:: 2) Friendly field publish output (tools\publish-dashboard-entrypoint.ps1)
-if exist "%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe" (
-    start "" /B "%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe" %*
-    exit /b 0
-)
+:: Host missing: prepare it automatically. No manual command for the user.
+echo Preparing the dashboard app for first use. This can take a minute...
+where dotnet >nul 2>nul
+if errorlevel 1 exit /b 2
 
-:: 3) Documented publish output (run dotnet publish to populate)
-if exist "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" (
-    start "" /B "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" %*
-    exit /b 0
-)
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%ROOT%tools\publish-dashboard-entrypoint.ps1"
+if errorlevel 1 exit /b 3
 
-:: 4) Dev tree fallback (Release build)
-if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" (
-    start "" /B "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" %*
-    exit /b 0
-)
+call :find_host
+if not defined HOST_EXE exit /b 3
 
-:: 5) Dev tree fallback (Debug build)
-if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" (
-    start "" /B "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" %*
-    exit /b 0
-)
+:start_host
+start "" /B "%HOST_EXE%" %*
+exit /b 0
 
-echo Unable to locate SysAdminSuite.DashboardHost.exe.
-echo Build with:
-echo     powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
-echo Or:
-echo     dotnet publish src\SysAdminSuite.DashboardHost -c Release -r win-x64 --self-contained false -o tools\publish\SysAdminSuite.DashboardHost
-exit /b 1
+:find_host
+set "HOST_EXE="
+if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%app\bin\SysAdminSuite.DashboardHost.exe"
+if not defined HOST_EXE if exist "%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe" set "HOST_EXE=%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe"
+if not defined HOST_EXE if exist "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe"
+if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe"
+if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe"
+exit /b 0

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Double-click:
 
 This opens the local dashboard and tutorial at `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
 
+On first run, the launcher may **automatically prepare (build) the dashboard app** before opening the browser. Field users do not run any command by hand. If the workstation cannot build it (for example, no .NET SDK), the launcher asks for the packaged SysAdminSuite Dashboard release or IT/admin preparation.
+
 (`START-HERE-SysAdminSuite-Dashboard.cmd` and `SysAdminSuite Dashboard.cmd` are compatibility aliases for sites that prefer a `.cmd` shortcut.)
 
 Read [`START-HERE-SysAdminSuite.md`](START-HERE-SysAdminSuite.md) for plain-language steps. Agents and IT staff: [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).

--- a/START-HERE-SysAdminSuite-Dashboard.bat
+++ b/START-HERE-SysAdminSuite-Dashboard.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 title SysAdminSuite Dashboard
 
 echo.
@@ -9,13 +9,13 @@ echo ==========================================
 echo.
 echo Double-click launcher - no commands to memorize.
 echo This opens the local dashboard and tutorial.
-echo No internet is required after the repo is downloaded.
-echo.
-echo Starting the local dashboard at http://127.0.0.1:5000/dashboard/
+echo The first run may take a minute while the dashboard app is prepared.
+echo No internet is required to use the dashboard after that.
 echo.
 
 set "ROOT=%~dp0"
 cd /d "%ROOT%"
+set "HEALTH_URL=http://127.0.0.1:5000/dashboard/"
 
 if not exist "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" (
     echo Could not find Launch-SysAdminSuiteDashboard.Host.bat.
@@ -26,29 +26,64 @@ if not exist "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" (
     exit /b 1
 )
 
-echo Starting dashboard host...
+echo Starting the dashboard host^.^.^.
+echo If this is the first run, the dashboard app will be prepared automatically now.
 call "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" --no-browser
-if errorlevel 1 (
+set "RC=%errorlevel%"
+
+if "%RC%"=="2" (
     echo.
-    echo The dashboard host could not start.
+    echo The .NET SDK ^(dotnet^) was not found on this machine.
     echo.
-    echo A developer can build the host once on this machine:
-    echo   powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
+    echo The dashboard app could not be built on this machine.
     echo.
-    echo That creates a local SysAdminSuite Dashboard.exe under dist\SysAdminSuiteDashboard\
-    echo ^(not committed to git - built on your machine only^).
+    echo This usually means the .NET SDK is missing or blocked.
     echo.
-    echo Then double-click this file again.
+    echo Ask for the packaged SysAdminSuite Dashboard release, or have IT/admin prepare this workstation.
     echo.
-    echo Shortcut tip: right-click this .bat file ^> Send to ^> Desktop ^(create shortcut^).
+    echo Do not use CLI survey commands unless the dashboard or runbook gives you one.
     echo.
     echo Press any key to close...
     pause >nul
     exit /b 1
 )
 
-echo Waiting for the dashboard host to start...
-timeout /t 3 /nobreak >nul
+if not "%RC%"=="0" (
+    echo.
+    echo The dashboard app could not be built on this machine.
+    echo.
+    echo This usually means the .NET SDK is missing or blocked.
+    echo.
+    echo Ask for the packaged SysAdminSuite Dashboard release, or have IT/admin prepare this workstation.
+    echo.
+    echo Do not use CLI survey commands unless the dashboard or runbook gives you one.
+    echo.
+    echo Press any key to close...
+    pause >nul
+    exit /b 1
+)
+
+echo Waiting for the dashboard to be ready^.^.^.
+set "HOST_UP=0"
+for /L %%i in (1,1,20) do (
+    if "!HOST_UP!"=="0" (
+        curl.exe -s -o nul --max-time 2 "%HEALTH_URL%" >nul 2>nul && set "HOST_UP=1"
+        if "!HOST_UP!"=="0" timeout /t 1 /nobreak >nul
+    )
+)
+
+if not "!HOST_UP!"=="1" (
+    echo.
+    echo The dashboard host did not respond on http://127.0.0.1:5000 .
+    echo.
+    echo Ask for the packaged SysAdminSuite Dashboard release, or have IT/admin prepare this workstation.
+    echo.
+    echo Do not use CLI survey commands unless the dashboard or runbook gives you one.
+    echo.
+    echo Press any key to close...
+    pause >nul
+    exit /b 1
+)
 
 echo Opening dashboard and Cybernet tutorial in your browser...
 start "" "http://127.0.0.1:5000/dashboard/?tutorial=cybernet"

--- a/START-HERE-SysAdminSuite.md
+++ b/START-HERE-SysAdminSuite.md
@@ -63,6 +63,8 @@ flowchart TD
 
 3. The browser tab shows the Harold icon. Click **Start Cybernet Survey** to follow the guided tutorial.
 
+On first run, the launcher may **automatically prepare (build) the dashboard app** for a minute before the browser opens. You do not need to run any command yourself. If this machine cannot build it (for example, no .NET SDK), the launcher will tell you to ask for the packaged SysAdminSuite Dashboard release or have IT/admin prepare the workstation.
+
 No internet is required after the repo is on your machine.
 
 ## What if the dashboard does not open?
@@ -70,7 +72,7 @@ No internet is required after the repo is on your machine.
 1. Run `START-HERE-SysAdminSuite-Dashboard.bat` from the **repo root**, not from inside a subfolder.
 2. The window will not close on its own — read any message it prints, then press a key to close it.
 3. Paste into your browser: `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`
-4. If the host is missing, a developer/IT can build it once (see below), then double-click the `.bat` again.
+4. The launcher tries to prepare the dashboard app automatically. If it reports that the app could not be built on this machine, ask for the packaged SysAdminSuite Dashboard release or have IT/admin prepare the workstation. You should not run the build command yourself.
 5. Read [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md) for IT troubleshooting.
 
 ## What about an EXE?

--- a/Tests/bash/test_dashboard_entrypoint_contracts.sh
+++ b/Tests/bash/test_dashboard_entrypoint_contracts.sh
@@ -10,6 +10,7 @@ start_md="$repo_root/START-HERE-SysAdminSuite.md"
 entry_doc="$repo_root/docs/DASHBOARD_ENTRYPOINT.md"
 exe_sprint="$repo_root/docs/DASHBOARD_EXE_FUTURE_SPRINT.md"
 readme="$repo_root/README.md"
+survey_readme="$repo_root/survey/README.md"
 agents="$repo_root/AGENTS.md"
 index="$repo_root/dashboard/index.html"
 
@@ -81,6 +82,46 @@ done
 # primary instruction is forbidden.
 grep -Eq 'Double-click.*(START-HERE-SysAdminSuite-Dashboard|SysAdminSuite Dashboard)\.cmd' "$start_md" \
   && fail "START-HERE-SysAdminSuite.md must not present a .cmd as the primary double-click"
+# Auto-publish on first run: the host launcher must build the dashboard host
+# automatically (via the publish script) when it is missing, and must check for
+# the .NET SDK first so a clean failure path exists.
+[[ -f "$host_bat" ]] || fail "Launch-SysAdminSuiteDashboard.Host.bat is missing"
+grep -Fq 'publish-dashboard-entrypoint.ps1' "$host_bat" \
+  || fail "host launcher does not auto-invoke publish-dashboard-entrypoint.ps1"
+grep -Fq 'powershell.exe' "$host_bat" \
+  || fail "host launcher does not run the publish script via powershell.exe"
+grep -Fq 'dotnet' "$host_bat" \
+  || fail "host launcher does not check for dotnet before building"
+
+# The root .bat must NOT instruct field users to run the publish command by hand
+# as the normal path, and must not tell them to double-click again as a routine.
+grep -Fq -- '-File tools\publish-dashboard-entrypoint.ps1' "$bat" \
+  && fail "root .bat must not instruct field users to run publish manually"
+grep -Fiq 'double-click this file again' "$bat" \
+  && fail "root .bat must not tell users to double-click again as the normal path"
+
+# The root .bat must health-check before opening the browser (no dead tab).
+grep -Fq 'curl' "$bat" \
+  || fail "root .bat has no health check (curl) before opening the browser"
+health_line=$(grep -n 'HOST_UP=1' "$bat" | head -1 | cut -d: -f1)
+browser_line=$(grep -n 'start "" "http' "$bat" | head -1 | cut -d: -f1)
+[[ -n "$health_line" && -n "$browser_line" && "$health_line" -lt "$browser_line" ]] \
+  || fail "root .bat opens the browser before the host health check"
+
+# Field-safe build-failure messaging in the root .bat.
+grep -Fq 'The dashboard app could not be built on this machine' "$bat" \
+  || fail "root .bat missing field-safe build-failure message"
+grep -Fq 'Ask for the packaged SysAdminSuite Dashboard release' "$bat" \
+  || fail "root .bat missing packaged-release / IT-admin guidance"
+
+# Docs must mention automatic first-run preparation and keep CLI non-default.
+for prep_doc in "$readme" "$start_md" "$entry_doc" "$survey_readme"; do
+  grep -Fq 'automatically prepare' "$prep_doc" \
+    || fail "$(basename "$prep_doc") does not mention automatic first-run preparation"
+done
+grep -Fq 'Use CLI tools only' "$start_md" \
+  || fail "START-HERE-SysAdminSuite.md must keep CLI as non-default"
+
 grep -Fq 'rel="icon"' "$index" \
   || fail "dashboard/index.html missing favicon link"
 grep -Fq 'assets/harold.jpg' "$index" \

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -8,6 +8,8 @@
 > Your browser opens `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
 > CLI tools are optional — use them only when the dashboard or a runbook says so.
 
+On first run the launcher will **automatically prepare (build) the dashboard host** if it is missing — it runs `tools/publish-dashboard-entrypoint.ps1` for the user, waits for the host to respond on port 5000, and only then opens the browser. Field users are never told to run the publish command by hand. If the build cannot run (no .NET SDK), the launcher shows a field-safe message directing the user to the packaged release or IT/admin preparation.
+
 Compatibility aliases (same behavior, not the documented primary): **`START-HERE-SysAdminSuite-Dashboard.cmd`** and **`SysAdminSuite Dashboard.cmd`**.
 
 ## Get the repo first (clone / download)
@@ -76,7 +78,7 @@ See [`dashboard/README.md`](../dashboard/README.md) — **Loading experience (Hi
 | Symptom | Action |
 |---------|--------|
 | Browser did not open | Paste `http://127.0.0.1:5000/dashboard/?tutorial=cybernet` |
-| Host exe not found | Run `tools/publish-dashboard-entrypoint.ps1`, retry `.bat` |
+| Host exe not found | The `.bat` builds it automatically on first run. If the build fails, get the packaged release or have IT/admin prepare the machine (do not tell field users to run publish by hand) |
 | Port 5000 in use | Stop prior instance from tray icon |
 | User asks "do I run code?" | Point to `START-HERE-SysAdminSuite-Dashboard.bat` double-click; read [`START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) |
 

--- a/survey/README.md
+++ b/survey/README.md
@@ -4,7 +4,7 @@ This directory contains Bash-first survey tooling for SysAdminSuite.
 
 ## Primary Field Tutorial: Cybernet / Neuron Network Survey
 
-**Default front door:** double-click [`../START-HERE-SysAdminSuite-Dashboard.bat`](../START-HERE-SysAdminSuite-Dashboard.bat) and use **Start Cybernet Survey** in the dashboard. CLI is available for specific advanced survey use cases only.
+**Default front door:** double-click [`../START-HERE-SysAdminSuite-Dashboard.bat`](../START-HERE-SysAdminSuite-Dashboard.bat) and use **Start Cybernet Survey** in the dashboard. On first run the launcher may **automatically prepare (build) the dashboard app** before opening the browser; field users do not run any command by hand. CLI is available for specific advanced survey use cases only.
 
 The current priority tutorial for field technicians is:
 


### PR DESCRIPTION
## Exact failure addressed

A field user double-clicked `START-HERE-SysAdminSuite-Dashboard.bat`. The dashboard host exe was missing, so the launcher printed this and told the user to run it manually:

```
powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
```

That pushed developer work onto a field user. The double-click path must prepare itself.

## What changed

- **`Launch-SysAdminSuiteDashboard.Host.bat`**: now discovers the host exe and, when missing, **automatically** runs `tools\publish-dashboard-entrypoint.ps1` (powershell -> dotnet), then retries starting the host. Exit codes: `0` started, `2` .NET SDK (dotnet) missing, `3` publish failed.
- **`START-HERE-SysAdminSuite-Dashboard.bat`**: calls the host launcher, then **health-checks `http://127.0.0.1:5000` with curl before opening the browser** (no dead tab). On `2`/`3`/non-zero it shows a field-safe message pointing to the packaged release or IT/admin preparation and keeps the window open. It no longer instructs users to run publish manually or to "double-click this file again".
- **Docs** (`README.md`, `START-HERE-SysAdminSuite.md`, `docs/DASHBOARD_ENTRYPOINT.md`, `survey/README.md`): explain automatic first-run preparation and keep CLI non-default.
- **`Tests/bash/test_dashboard_entrypoint_contracts.sh`**: new guards for auto-publish, dotnet check, no manual-publish instruction in the root `.bat`, health-check-before-browser ordering, field-safe build-failure messaging, and docs mention of automatic first-run prep.

## Does auto-publish work?

Yes. Windows smoke (with .NET 8 SDK present):

- Renamed all existing host outputs (`dist/SysAdminSuiteDashboard`, `tools/publish/SysAdminSuite.DashboardHost`, `src/.../bin/Release/net8.0-windows`) to force the missing-host path.
- `Launch-SysAdminSuiteDashboard.Host.bat --no-browser` printed `Preparing the dashboard app for first use...`, ran `dotnet publish`, rebuilt the host, started it, and exited `0`.
- Health check: `GET http://127.0.0.1:5000/dashboard/` came up; `GET .../dashboard/?tutorial=cybernet` -> `200`.
- Host process stopped cleanly afterward.

## Is missing dotnet handled cleanly?

Yes. Simulated host-missing with a PATH that excludes `dotnet`:

- `Launch-SysAdminSuiteDashboard.Host.bat` exited `2` (no publish attempted).
- The root `.bat` maps exit `2` to a field-safe message: ".NET SDK (dotnet) was not found" + "Ask for the packaged SysAdminSuite Dashboard release, or have IT/admin prepare this workstation", **no browser opened**, window stays open.

## Windows smoke result

PASS: auto-publish builds and starts the host, dashboard + Cybernet tutorial serve HTTP 200; dotnet-missing path returns a clean field-safe error with no dead browser tab.

## Validation

- `bash Tests/bash/test_dashboard_entrypoint_contracts.sh` -> `PASS: dashboard entrypoint contracts`
- `git diff --check` -> clean
- `git status --short` -> only the 7 intended tracked files

## Confirmations

- `.bat` remains canonical; `.cmd` files remain compatibility-only aliases.
- No generated `dist/` (or `tools/publish/`) output was committed; both remain gitignored.

Do not merge — PR only.
