### PR TITLE
feat(ui): dashboard field release package for no-SDK machines

### DIFF
--- a/.github/workflows/dashboard-field-release.yml
+++ b/.github/workflows/dashboard-field-release.yml
@@ -1,0 +1,74 @@
+# Build the dashboard field-release ZIP on demand or when release tooling changes.
+# Uploads dist/*.zip as a CI artifact — does NOT commit binaries to git.
+name: Dashboard field release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version label for the package (e.g. 0.1.0)'
+        required: true
+        default: '0.1.0'
+  push:
+    branches: [main]
+    paths:
+      - 'src/SysAdminSuite.DashboardHost/**'
+      - 'dashboard/**'
+      - 'START-HERE-SysAdminSuite-Dashboard.bat'
+      - 'Launch-SysAdminSuiteDashboard.Host.bat'
+      - 'tools/publish-dashboard-entrypoint.ps1'
+      - 'tools/build/New-DashboardFieldRelease.ps1'
+      - '.github/workflows/dashboard-field-release.yml'
+
+jobs:
+  build-field-release:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build dashboard field-release ZIP
+        shell: pwsh
+        run: |
+          $version = '${{ github.event.inputs.version }}'
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            $version = 'ci-' + (Get-Date -Format 'yyyyMMdd-HHmm')
+          }
+          pwsh -NoProfile -ExecutionPolicy Bypass -File tools/build/New-DashboardFieldRelease.ps1 -Version $version
+
+      - name: Verify package layout
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem -Path dist -Filter 'SysAdminSuite-Dashboard-Field-*.zip' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $zip) { throw 'No field-release zip produced under dist/' }
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $archive = [System.IO.Compression.ZipFile]::OpenRead($zip.FullName)
+          try {
+            $required = @(
+              'START-HERE-SysAdminSuite-Dashboard.bat',
+              'Launch-SysAdminSuiteDashboard.Host.bat',
+              'dashboard/index.html',
+              'app/bin/SysAdminSuite.DashboardHost.exe',
+              'app/bin/SysAdminSuite.DashboardHost.dll'
+            )
+            foreach ($entry in $required) {
+              $found = $archive.Entries | Where-Object { $_.FullName -replace '\\','/' -eq $entry }
+              if (-not $found) { throw "Missing zip entry: $entry" }
+            }
+          } finally {
+            $archive.Dispose()
+          }
+          Write-Host "Package layout OK: $($zip.Name)"
+
+      - name: Upload field-release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sysadminsuite-dashboard-field-release
+          path: |
+            dist/SysAdminSuite-Dashboard-Field-*.zip
+            dist/SysAdminSuite-Dashboard-Field-*.manifest.json
+          if-no-files-found: error

--- a/Launch-SysAdminSuiteDashboard.Host.bat
+++ b/Launch-SysAdminSuiteDashboard.Host.bat
@@ -19,8 +19,9 @@ set "ROOT=%~dp0"
 call :find_host
 if defined HOST_EXE goto :start_host
 
-:: Host missing: prepare it automatically. No manual command for the user.
-echo Preparing the dashboard app for first use. This can take a minute...
+:: Host missing on a source checkout: prepare automatically. Packaged field
+:: releases ship app\bin\SysAdminSuite.DashboardHost.exe and skip this path.
+echo Source checkout: preparing the dashboard app for first use. This can take a minute...
 where dotnet >nul 2>nul
 if errorlevel 1 exit /b 2
 
@@ -31,6 +32,13 @@ call :find_host
 if not defined HOST_EXE exit /b 3
 
 :start_host
+if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
+    if /i not "%HOST_EXE%"=="%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
+        rem other host path won; packaged layout not primary
+    ) else (
+        echo Using packaged dashboard host from app\bin.
+    )
+)
 start "" /B "%HOST_EXE%" %*
 exit /b 0
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Double-click:
 
 This opens the local dashboard and tutorial at `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
 
-On first run, the launcher may **automatically prepare (build) the dashboard app** before opening the browser. Field users do not run any command by hand. If the workstation cannot build it (for example, no .NET SDK), the launcher asks for the packaged SysAdminSuite Dashboard release or IT/admin preparation.
+On first run, the launcher may **automatically prepare (build) the dashboard app** before opening the browser. Field users do not run any command by hand. If the workstation cannot build it (for example, no .NET SDK), the launcher asks for the packaged SysAdminSuite Dashboard **field release** or IT/admin preparation.
+
+**No .NET SDK on the machine?** Use the pre-built field release ZIP ([`docs/DASHBOARD_FIELD_RELEASE.md`](docs/DASHBOARD_FIELD_RELEASE.md)), not a raw git clone.
 
 (`START-HERE-SysAdminSuite-Dashboard.cmd` and `SysAdminSuite Dashboard.cmd` are compatibility aliases for sites that prefer a `.cmd` shortcut.)
 

--- a/START-HERE-SysAdminSuite-Dashboard.bat
+++ b/START-HERE-SysAdminSuite-Dashboard.bat
@@ -17,6 +17,17 @@ set "ROOT=%~dp0"
 cd /d "%ROOT%"
 set "HEALTH_URL=http://127.0.0.1:5000/dashboard/"
 
+if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
+    echo Packaged field release detected - dashboard app is already included.
+    echo No build step is required on this machine.
+    echo.
+) else (
+    echo Source checkout detected - the dashboard app may be prepared on first run.
+    echo If this machine has the .NET SDK, the launcher will build it automatically.
+    echo If not, ask for the packaged SysAdminSuite Dashboard field release instead.
+    echo.
+)
+
 if not exist "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" (
     echo Could not find Launch-SysAdminSuiteDashboard.Host.bat.
     echo Make sure you are running this from the SysAdminSuite repo root.
@@ -33,13 +44,14 @@ set "RC=%errorlevel%"
 
 if "%RC%"=="2" (
     echo.
-    echo The .NET SDK ^(dotnet^) was not found on this machine.
+    echo Source checkout without the .NET SDK ^(dotnet^).
     echo.
     echo The dashboard app could not be built on this machine.
     echo.
     echo This usually means the .NET SDK is missing or blocked.
     echo.
-    echo Ask for the packaged SysAdminSuite Dashboard release, or have IT/admin prepare this workstation.
+    echo Ask for the packaged SysAdminSuite Dashboard field release ^(pre-built host under app\bin^),
+    echo or have IT/admin prepare this workstation.
     echo.
     echo Do not use CLI survey commands unless the dashboard or runbook gives you one.
     echo.
@@ -52,9 +64,10 @@ if not "%RC%"=="0" (
     echo.
     echo The dashboard app could not be built on this machine.
     echo.
-    echo This usually means the .NET SDK is missing or blocked.
+    echo This usually means the .NET SDK is missing or blocked on a source checkout.
     echo.
-    echo Ask for the packaged SysAdminSuite Dashboard release, or have IT/admin prepare this workstation.
+    echo Ask for the packaged SysAdminSuite Dashboard field release ^(pre-built host under app\bin^),
+    echo or have IT/admin prepare this workstation.
     echo.
     echo Do not use CLI survey commands unless the dashboard or runbook gives you one.
     echo.

--- a/START-HERE-SysAdminSuite.md
+++ b/START-HERE-SysAdminSuite.md
@@ -63,9 +63,16 @@ flowchart TD
 
 3. The browser tab shows the Harold icon. Click **Start Cybernet Survey** to follow the guided tutorial.
 
-On first run, the launcher may **automatically prepare (build) the dashboard app** for a minute before the browser opens. You do not need to run any command yourself. If this machine cannot build it (for example, no .NET SDK), the launcher will tell you to ask for the packaged SysAdminSuite Dashboard release or have IT/admin prepare the workstation.
+On first run, the launcher may **automatically prepare (build) the dashboard app** for a minute before the browser opens. You do not need to run any command yourself. If this machine cannot build it (for example, no .NET SDK), the launcher will tell you to ask for the packaged SysAdminSuite Dashboard **field release** or have IT/admin prepare the workstation.
 
-No internet is required after the repo is on your machine.
+### Source clone vs field release package
+
+| You have | Do this |
+|----------|---------|
+| Git + optional .NET SDK (developer/IT) | Clone the repo, double-click `START-HERE-SysAdminSuite-Dashboard.bat` |
+| No .NET SDK (typical field PC) | Get the **field release ZIP** — see [`docs/DASHBOARD_FIELD_RELEASE.md`](docs/DASHBOARD_FIELD_RELEASE.md) — extract it, then double-click the `.bat` |
+
+No internet is required after the repo or package is on your machine.
 
 ## What if the dashboard does not open?
 

--- a/Tests/bash/test_dashboard_entrypoint_contracts.sh
+++ b/Tests/bash/test_dashboard_entrypoint_contracts.sh
@@ -8,6 +8,9 @@ friendly="$repo_root/SysAdminSuite Dashboard.cmd"
 host_bat="$repo_root/Launch-SysAdminSuiteDashboard.Host.bat"
 start_md="$repo_root/START-HERE-SysAdminSuite.md"
 entry_doc="$repo_root/docs/DASHBOARD_ENTRYPOINT.md"
+field_release_doc="$repo_root/docs/DASHBOARD_FIELD_RELEASE.md"
+field_release_script="$repo_root/tools/build/New-DashboardFieldRelease.ps1"
+field_release_workflow="$repo_root/.github/workflows/dashboard-field-release.yml"
 exe_sprint="$repo_root/docs/DASHBOARD_EXE_FUTURE_SPRINT.md"
 readme="$repo_root/README.md"
 survey_readme="$repo_root/survey/README.md"
@@ -111,8 +114,25 @@ browser_line=$(grep -n 'start "" "http' "$bat" | head -1 | cut -d: -f1)
 # Field-safe build-failure messaging in the root .bat.
 grep -Fq 'The dashboard app could not be built on this machine' "$bat" \
   || fail "root .bat missing field-safe build-failure message"
-grep -Fq 'Ask for the packaged SysAdminSuite Dashboard release' "$bat" \
-  || fail "root .bat missing packaged-release / IT-admin guidance"
+grep -Fq 'packaged SysAdminSuite Dashboard field release' "$bat" \
+  || fail "root .bat missing field-release / IT-admin guidance"
+
+# Launcher must distinguish packaged field release vs source checkout paths.
+grep -Fq 'Packaged field release detected' "$bat" \
+  || fail "root .bat does not detect packaged field release layout"
+grep -Fq 'Source checkout detected' "$bat" \
+  || fail "root .bat does not label source-checkout path"
+
+# Field release package tooling and docs (no SDK on target).
+[[ -f "$field_release_doc" ]] || fail "docs/DASHBOARD_FIELD_RELEASE.md is missing"
+[[ -f "$field_release_script" ]] || fail "tools/build/New-DashboardFieldRelease.ps1 is missing"
+[[ -f "$field_release_workflow" ]] || fail ".github/workflows/dashboard-field-release.yml is missing"
+grep -Fq 'DASHBOARD_FIELD_RELEASE.md' "$entry_doc" \
+  || fail "DASHBOARD_ENTRYPOINT.md does not reference field release doc"
+grep -Fq 'field release package' "$start_md" \
+  || fail "START-HERE-SysAdminSuite.md does not explain field release package"
+grep -Fq 'app/bin/SysAdminSuite.DashboardHost.exe' "$field_release_doc" \
+  || fail "DASHBOARD_FIELD_RELEASE.md does not document app/bin host layout"
 
 # Docs must mention automatic first-run preparation and keep CLI non-default.
 for prep_doc in "$readme" "$start_md" "$entry_doc" "$survey_readme"; do

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -8,7 +8,9 @@
 > Your browser opens `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
 > CLI tools are optional — use them only when the dashboard or a runbook says so.
 
-On first run the launcher will **automatically prepare (build) the dashboard host** if it is missing — it runs `tools/publish-dashboard-entrypoint.ps1` for the user, waits for the host to respond on port 5000, and only then opens the browser. Field users are never told to run the publish command by hand. If the build cannot run (no .NET SDK), the launcher shows a field-safe message directing the user to the packaged release or IT/admin preparation.
+On first run the launcher will **automatically prepare (build) the dashboard host** if it is missing — it runs `tools/publish-dashboard-entrypoint.ps1` for the user, waits for the host to respond on port 5000, and only then opens the browser. Field users are never told to run the publish command by hand. If the build cannot run (no .NET SDK), the launcher shows a field-safe message directing the user to the **field release package** or IT/admin preparation.
+
+**Field release package (no SDK):** [`DASHBOARD_FIELD_RELEASE.md`](DASHBOARD_FIELD_RELEASE.md) — pre-built zip with `app/bin/SysAdminSuite.DashboardHost.exe`.
 
 Compatibility aliases (same behavior, not the documented primary): **`START-HERE-SysAdminSuite-Dashboard.cmd`** and **`SysAdminSuite Dashboard.cmd`**.
 
@@ -22,7 +24,7 @@ git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git
 
 This creates the `SysAdminSuite` folder; they then open it and double-click `START-HERE-SysAdminSuite-Dashboard.bat`.
 
-Warn against the common mistake: do **not** create a `SysAdminSuite` folder first and clone inside it, which produces `SysAdminSuite\SysAdminSuite` and hides the launcher one level deep. ZIP download via the GitHub **Code** button is an equivalent no-Git path.
+Warn against the common mistake: do **not** create a `SysAdminSuite` folder first and clone inside it, which produces `SysAdminSuite\SysAdminSuite` and hides the launcher one level deep. ZIP download via the GitHub **Code** button is an equivalent no-Git path for developers; **field users without the .NET SDK** should use the dashboard field release package instead ([`DASHBOARD_FIELD_RELEASE.md`](DASHBOARD_FIELD_RELEASE.md)).
 
 ## Launcher matrix
 

--- a/docs/DASHBOARD_FIELD_RELEASE.md
+++ b/docs/DASHBOARD_FIELD_RELEASE.md
@@ -1,0 +1,79 @@
+# Dashboard Field Release Package
+
+**Agent canonical reference** for how field users get the dashboard **without** the .NET SDK.
+
+## Two delivery paths
+
+| Path | Who | What you get | .NET SDK on target? | Launcher behavior |
+|------|-----|--------------|---------------------|-------------------|
+| **Source clone** | Developers, IT building from git | Full repository | Helpful on first run (auto-build) | Prepares `dist/` or `tools/publish/` on first double-click if SDK present |
+| **Field release package** | Technicians, lay users | Pre-built ZIP with host under `app/bin/` | **Not required** (runtime only) | Double-click starts immediately; no build step |
+
+Field users on locked-down PCs should receive the **field release package**, not a raw git clone.
+
+## Build the field release (trusted machine with .NET 8 SDK)
+
+From repo root:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\build\New-DashboardFieldRelease.ps1 -Version 0.1.0
+```
+
+Outputs (gitignored under `dist/`):
+
+- `SysAdminSuite-Dashboard-Field-v0.1.0.zip`
+- `SysAdminSuite-Dashboard-Field-v0.1.0.manifest.json` (SHA256 + UTC timestamp)
+
+Package layout at zip root:
+
+```text
+START-HERE-SysAdminSuite-Dashboard.bat   ← double-click this
+Launch-SysAdminSuiteDashboard.Host.bat
+dashboard/
+app/bin/SysAdminSuite.DashboardHost.exe  ← pre-built host + deps
+START-HERE-SysAdminSuite.md
+FIELD-RELEASE-README.txt
+```
+
+## Distribute to field users
+
+1. Copy the zip (and manifest) to an approved channel (internal share, GitHub Release asset, Software Center).
+2. Field user extracts the zip to a folder of their choice.
+3. Field user double-clicks `START-HERE-SysAdminSuite-Dashboard.bat`.
+4. Browser opens `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
+
+No git, no dotnet SDK, no manual publish command.
+
+## CI artifact (optional)
+
+Workflow [`.github/workflows/dashboard-field-release.yml`](../.github/workflows/dashboard-field-release.yml) builds the same zip on `workflow_dispatch` or when dashboard release paths change on `main`. Download the artifact from the Actions run — it is **not** committed to git.
+
+## Launcher scenario messages
+
+The root `.bat` tells the user which path applies:
+
+| Situation | User sees |
+|-----------|-----------|
+| Packaged release (`app/bin/` host present) | “Packaged field release detected — no build step required” |
+| Source clone, SDK available | “Source checkout — may be prepared on first run” then auto-build |
+| Source clone, no SDK | Field-safe error: ask for field release package or IT prep |
+
+## Requirements on target workstation
+
+- Windows 10 or later
+- .NET 8 **runtime** (framework-dependent publish; SDK not required for field package)
+- No internet required after the package is extracted
+
+## Related docs
+
+- [`DASHBOARD_ENTRYPOINT.md`](DASHBOARD_ENTRYPOINT.md) — launcher matrix and troubleshooting
+- [`START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) — lay-user guide (applies inside both clone and field package)
+- [`DEPLOYMENT_ARTIFACTS.md`](DEPLOYMENT_ARTIFACTS.md) — full portable runtime zip (broader than dashboard-only)
+- [`releases/PUBLISH.md`](releases/PUBLISH.md) — publishing checksums and channels
+
+## Agent guardrails
+
+- Do not commit `dist/` zip binaries to git.
+- Do not tell field users to `git clone` when they need the field release package.
+- Do not tell field users to run `publish-dashboard-entrypoint.ps1` by hand.
+- Keep `START-HERE-SysAdminSuite-Dashboard.bat` canonical; `.cmd` files remain compatibility aliases only.

--- a/survey/README.md
+++ b/survey/README.md
@@ -4,7 +4,7 @@ This directory contains Bash-first survey tooling for SysAdminSuite.
 
 ## Primary Field Tutorial: Cybernet / Neuron Network Survey
 
-**Default front door:** double-click [`../START-HERE-SysAdminSuite-Dashboard.bat`](../START-HERE-SysAdminSuite-Dashboard.bat) and use **Start Cybernet Survey** in the dashboard. On first run the launcher may **automatically prepare (build) the dashboard app** before opening the browser; field users do not run any command by hand. CLI is available for specific advanced survey use cases only.
+**Default front door:** double-click [`../START-HERE-SysAdminSuite-Dashboard.bat`](../START-HERE-SysAdminSuite-Dashboard.bat) and use **Start Cybernet Survey** in the dashboard. On first run the launcher may **automatically prepare (build) the dashboard app** before opening the browser; field users do not run any command by hand. Machines **without the .NET SDK** should use the dashboard field release package ([`../docs/DASHBOARD_FIELD_RELEASE.md`](../docs/DASHBOARD_FIELD_RELEASE.md)), not a source clone. CLI is available for specific advanced survey use cases only.
 
 The current priority tutorial for field technicians is:
 

--- a/tools/build/New-DashboardFieldRelease.ps1
+++ b/tools/build/New-DashboardFieldRelease.ps1
@@ -1,0 +1,147 @@
+<#
+.SYNOPSIS
+    Build a lean field-release ZIP for the SysAdminSuite dashboard (no .NET SDK on target).
+
+.DESCRIPTION
+    Produces dist/SysAdminSuite-Dashboard-Field-v{Version}.zip with:
+      - START-HERE-SysAdminSuite-Dashboard.bat (canonical launcher)
+      - Launch-SysAdminSuiteDashboard.Host.bat
+      - dashboard/ web assets
+      - app/bin/SysAdminSuite.DashboardHost.exe (+ runtime deps)
+      - START-HERE-SysAdminSuite.md (lay-user guide)
+
+    Intended for trusted build machines with the .NET 8 SDK. Output stays in
+    gitignored dist/ — upload to GitHub Releases or an approved share; do not
+    commit the zip to git.
+
+    See docs/DASHBOARD_FIELD_RELEASE.md for source-clone vs field-package guidance.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+    [string]$Configuration = 'Release',
+    [string]$RuntimeIdentifier = 'win-x64'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$distDir = Join-Path $repoRoot 'dist'
+$stagingRoot = Join-Path $distDir "SysAdminSuite-Dashboard-Field-v$Version"
+$artifactName = "SysAdminSuite-Dashboard-Field-v$Version.zip"
+$artifactPath = Join-Path $distDir $artifactName
+$publishScript = Join-Path $repoRoot 'tools\publish-dashboard-entrypoint.ps1'
+
+if (-not (Test-Path -LiteralPath $publishScript)) {
+    throw "Publish script not found: $publishScript"
+}
+
+if (-not (Test-Path -LiteralPath $distDir)) {
+    New-Item -ItemType Directory -Path $distDir -Force | Out-Null
+}
+
+if (Test-Path -LiteralPath $stagingRoot) {
+    Remove-Item -LiteralPath $stagingRoot -Recurse -Force
+}
+
+Write-Host "Publishing dashboard host (framework-dependent, $RuntimeIdentifier)..."
+& $publishScript -Configuration $Configuration -RuntimeIdentifier $RuntimeIdentifier
+
+$publishOutput = Join-Path $repoRoot 'dist\SysAdminSuiteDashboard'
+$hostExe = Join-Path $publishOutput 'SysAdminSuite.DashboardHost.exe'
+if (-not (Test-Path -LiteralPath $hostExe)) {
+    throw "Dashboard host publish failed; expected full publish output at: $publishOutput"
+}
+
+New-Item -ItemType Directory -Path (Join-Path $stagingRoot 'app\bin') -Force | Out-Null
+
+$rootFiles = @(
+    'START-HERE-SysAdminSuite-Dashboard.bat',
+    'START-HERE-SysAdminSuite-Dashboard.cmd',
+    'SysAdminSuite Dashboard.cmd',
+    'Launch-SysAdminSuiteDashboard.Host.bat',
+    'START-HERE-SysAdminSuite.md'
+)
+
+foreach ($file in $rootFiles) {
+    $source = Join-Path $repoRoot $file
+    if (-not (Test-Path -LiteralPath $source)) {
+        throw "Required field-release file missing: $source"
+    }
+    Copy-Item -LiteralPath $source -Destination (Join-Path $stagingRoot $file) -Force
+}
+
+$dashboardSource = Join-Path $repoRoot 'dashboard'
+if (-not (Test-Path -LiteralPath $dashboardSource)) {
+    throw "dashboard/ folder missing at repo root"
+}
+Copy-Item -Path $dashboardSource -Destination (Join-Path $stagingRoot 'dashboard') -Recurse -Force
+
+Copy-Item -Path (Join-Path $publishOutput '*') -Destination (Join-Path $stagingRoot 'app\bin') -Recurse -Force
+
+$fieldReadme = @"
+# SysAdminSuite Dashboard — Field Release
+
+This is a **field release package**. The dashboard host is already built under
+``app/bin/``. You do **not** need the .NET SDK on this machine.
+
+## Start
+
+Double-click:
+
+``START-HERE-SysAdminSuite-Dashboard.bat``
+
+Your browser opens the local dashboard and Cybernet tutorial.
+
+## Requirements
+
+- Windows 10 or later
+- .NET 8 **runtime** (not the SDK) — usually already present on managed PCs
+
+## Not a source checkout
+
+If you need to change survey scripts or develop against git, use a **source clone**
+instead. See docs/DASHBOARD_FIELD_RELEASE.md in the full repository.
+
+Version: $Version
+"@
+Set-Content -LiteralPath (Join-Path $stagingRoot 'FIELD-RELEASE-README.txt') -Value $fieldReadme -Encoding UTF8
+
+if (Test-Path -LiteralPath $artifactPath) {
+    Remove-Item -LiteralPath $artifactPath -Force
+}
+
+Compress-Archive -Path (Join-Path $stagingRoot '*') -DestinationPath $artifactPath -Force
+$hash = (Get-FileHash -Path $artifactPath -Algorithm SHA256).Hash
+
+$commit = $null
+try {
+    Push-Location $repoRoot
+    $commit = (& git rev-parse HEAD 2>$null)
+} finally {
+    Pop-Location
+}
+
+$manifestPath = Join-Path $distDir "SysAdminSuite-Dashboard-Field-v$Version.manifest.json"
+$manifest = [ordered]@{
+    version        = $Version
+    package        = $artifactName
+    checksumSha256 = $hash
+    publishedUtc   = (Get-Date).ToUniversalTime().ToString('o')
+    notes          = 'Dashboard field release; includes pre-built host under app/bin/. Requires .NET 8 runtime on target.'
+    artifactPath   = $artifactName
+    layout         = 'app/bin/SysAdminSuite.DashboardHost.exe at package root'
+}
+if ($commit) {
+    $manifest['gitCommit'] = $commit.Trim()
+}
+($manifest | ConvertTo-Json -Depth 4) | Set-Content -LiteralPath $manifestPath -Encoding UTF8
+
+Write-Host ""
+Write-Host "Dashboard field release created: $artifactPath" -ForegroundColor Green
+Write-Host "SHA256: $hash" -ForegroundColor Cyan
+Write-Host "Manifest: $manifestPath" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Field users: extract the zip, then double-click START-HERE-SysAdminSuite-Dashboard.bat"


### PR DESCRIPTION
## Summary

Field machines without the .NET SDK cannot rely on a source clone, even with auto-publish on first run. This PR adds a **dashboard field release package** workflow: a lean ZIP with the pre-built host under `app/bin/`, plus docs and launcher messages that distinguish source clone vs field package paths.

## What changed

- **`tools/build/New-DashboardFieldRelease.ps1`** — builds `dist/SysAdminSuite-Dashboard-Field-v{Version}.zip` + manifest (full publish output under `app/bin/`, not exe-only)
- **`.github/workflows/dashboard-field-release.yml`** — CI builds and uploads the zip as an artifact (`workflow_dispatch` or on relevant `main` pushes); does **not** commit binaries
- **`docs/DASHBOARD_FIELD_RELEASE.md`** — canonical guide: source clone vs field release package
- **Launcher scenario messages** in `START-HERE-SysAdminSuite-Dashboard.bat` and `Launch-SysAdminSuiteDashboard.Host.bat`
- **Docs** updates in README, START-HERE, DASHBOARD_ENTRYPOINT, survey/README
- **Contract tests** for field-release tooling and launcher wording

## Does NOT change

- PR #94 auto-publish behavior for source clones (unchanged)
- `.bat` canonical / `.cmd` alias policy (unchanged)
- No `dist/` binaries committed

## Local validation

- `bash Tests/bash/test_dashboard_entrypoint_contracts.sh` — PASS
- Built `SysAdminSuite-Dashboard-Field-v0.1.0-smoke.zip`, extracted, ran host from `app/bin/` — tutorial HTTP 200
- `git diff --check` — clean

## Field instruction (unchanged)

```
Double-click START-HERE-SysAdminSuite-Dashboard.bat.
The local dashboard opens.
Pick the tutorial.
Only use CLI commands when the dashboard or runbook gives you one.
```

## Test plan

- [ ] CI doctrine + test + contract checks pass
- [ ] Dashboard field-release workflow produces artifact with `app/bin/SysAdminSuite.DashboardHost.dll`
- [ ] Field user on no-SDK machine receives field release zip, not source clone
