### PR TITLE
feat(ui): add approved SysAdminSuite update flow

### DIFF
--- a/Config/update-manifest.sample.json
+++ b/Config/update-manifest.sample.json
@@ -1,7 +1,13 @@
 {
+  "manifestVersion": 1,
+  "channel": "stable",
   "version": "0.1.0",
   "package": "SysAdminSuite-Portable-v0.1.0.zip",
+  "packageUrl": "https://example.invalid/SysAdminSuite-Portable-v0.1.0.zip",
   "checksumSha256": "REPLACE_WITH_REAL_SHA256",
   "publishedUtc": "2026-04-16T00:00:00Z",
+  "gitCommit": "REPLACE_WITH_SOURCE_COMMIT",
+  "minimumRuntime": "Windows 10; .NET 8 runtime for dashboard host",
+  "releaseNotesUrl": "https://example.invalid/SysAdminSuite/releases/v0.1.0",
   "notes": "Initial portable artifact manifest sample."
 }

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ On first run, the launcher may **automatically prepare (build) the dashboard app
 
 **No .NET SDK on the machine?** Use the pre-built field release ZIP ([`docs/DASHBOARD_FIELD_RELEASE.md`](docs/DASHBOARD_FIELD_RELEASE.md)), not a raw git clone.
 
+Updates are opt-in. If a newer `main` or field package is available, the
+launcher prompts before applying it. See [`docs/APPROVED_UPDATE_FLOW.md`](docs/APPROVED_UPDATE_FLOW.md).
+
 (`START-HERE-SysAdminSuite-Dashboard.cmd` and `SysAdminSuite Dashboard.cmd` are compatibility aliases for sites that prefer a `.cmd` shortcut.)
 
 Read [`START-HERE-SysAdminSuite.md`](START-HERE-SysAdminSuite.md) for plain-language steps. Agents and IT staff: [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).

--- a/START-HERE-SysAdminSuite-Dashboard.bat
+++ b/START-HERE-SysAdminSuite-Dashboard.bat
@@ -16,6 +16,38 @@ echo.
 set "ROOT=%~dp0"
 cd /d "%ROOT%"
 set "HEALTH_URL=http://127.0.0.1:5000/dashboard/"
+set "UPDATE_HELPER=%ROOT%tools\update\Invoke-SysAdminSuiteUpdate.ps1"
+
+if exist "%UPDATE_HELPER%" (
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%UPDATE_HELPER%" -CheckOnly -Quiet
+    set "UPDATE_RC=!errorlevel!"
+    if "!UPDATE_RC!"=="10" (
+        echo.
+        echo A SysAdminSuite update is available.
+        choice /C YN /N /M "Apply the update before opening the dashboard? [Y/N] "
+        if "!errorlevel!"=="1" (
+            powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%UPDATE_HELPER%" -Apply -Approved
+            if errorlevel 1 (
+                echo.
+                echo The update could not be applied automatically.
+                echo Continuing with the current local copy.
+                echo.
+            ) else (
+                echo.
+                echo Update applied. Continuing with the dashboard.
+                echo.
+            )
+        ) else (
+            echo.
+            echo Update skipped. Continuing with the current local copy.
+            echo.
+        )
+    ) else if "!UPDATE_RC!"=="20" (
+        echo.
+        echo Update check needs manual review, so the dashboard will continue with the current local copy.
+        echo.
+    )
+)
 
 if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
     echo Packaged field release detected - dashboard app is already included.

--- a/START-HERE-SysAdminSuite.md
+++ b/START-HERE-SysAdminSuite.md
@@ -74,6 +74,13 @@ On first run, the launcher may **automatically prepare (build) the dashboard app
 
 No internet is required after the repo or package is on your machine.
 
+## How do updates work?
+
+Updates are opt-in. If this is a git clone, the launcher can offer to fast-forward
+clean `main` from `origin/main`. If this is a ZIP or field package, updates come
+from a checksum-verified package manifest. In both cases, you approve before
+anything changes. See [`docs/APPROVED_UPDATE_FLOW.md`](docs/APPROVED_UPDATE_FLOW.md).
+
 ## What if the dashboard does not open?
 
 1. Run `START-HERE-SysAdminSuite-Dashboard.bat` from the **repo root**, not from inside a subfolder.

--- a/Tests/bash/test_update_flow_contracts.sh
+++ b/Tests/bash/test_update_flow_contracts.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+helper="$repo_root/tools/update/Invoke-SysAdminSuiteUpdate.ps1"
+policy="$repo_root/docs/APPROVED_UPDATE_FLOW.md"
+manifest="$repo_root/Config/update-manifest.sample.json"
+launcher="$repo_root/START-HERE-SysAdminSuite-Dashboard.bat"
+deployment_doc="$repo_root/docs/DEPLOYMENT_ARTIFACTS.md"
+field_doc="$repo_root/docs/DASHBOARD_FIELD_RELEASE.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$helper" ]] || fail "update helper is missing"
+[[ -f "$policy" ]] || fail "approved update policy doc is missing"
+[[ -f "$manifest" ]] || fail "update manifest sample is missing"
+
+# Updates must require explicit approval before mutation.
+grep -Fq -- '-CheckOnly' "$helper" \
+  || fail "helper is missing CheckOnly mode"
+grep -Fq -- '-Apply' "$helper" \
+  || fail "helper is missing Apply mode"
+grep -Fq -- '-Approved' "$helper" \
+  || fail "helper is missing Approved guard"
+grep -Fq 'Refusing to apply update without -Approved' "$helper" \
+  || fail "helper does not refuse apply without approval"
+
+# Source clone path must be fast-forward only and must never hard reset.
+grep -Fq "'pull', '--ff-only', 'origin', 'main'" "$helper" \
+  || fail "git clone update path does not use git pull --ff-only origin main"
+grep -Fq "'fetch', 'origin'" "$helper" \
+  || fail "git clone update path does not fetch origin"
+grep -Fq "'status', '--short'" "$helper" \
+  || fail "git clone update path does not check for a clean working tree"
+grep -Fq "'branch', '--show-current'" "$helper" \
+  || fail "git clone update path does not verify current branch"
+grep -Fq "'log', '--branches', '--not', '--remotes', '--oneline'" "$helper" \
+  || fail "git clone update path does not check for local-only commits"
+grep -Fq 'reset --hard' "$helper" \
+  && fail "helper must not use git reset --hard"
+
+# Package path must be manifest and checksum based.
+grep -Fq 'checksumSha256' "$helper" \
+  || fail "package update path does not verify checksumSha256"
+grep -Fq 'Expand-Archive' "$helper" \
+  || fail "package update path does not extract package"
+grep -Fq 'app.previous' "$helper" \
+  || fail "package update path does not create an app backup"
+grep -Fq '"packageUrl"' "$manifest" \
+  || fail "manifest sample must include packageUrl"
+grep -Fq '"checksumSha256"' "$manifest" \
+  || fail "manifest sample must include checksumSha256"
+
+# Launcher must check and prompt; it must not apply silently.
+grep -Fq 'Invoke-SysAdminSuiteUpdate.ps1' "$launcher" \
+  || fail "launcher does not call update helper"
+grep -Fq -- '-CheckOnly -Quiet' "$launcher" \
+  || fail "launcher does not check quietly before prompting"
+grep -Fq 'Apply the update before opening the dashboard' "$launcher" \
+  || fail "launcher does not prompt for update approval"
+grep -Fq -- '-Apply -Approved' "$launcher" \
+  || fail "launcher does not pass Approved when applying update"
+
+# Docs must distinguish git clone vs package updates and forbid silent updates.
+grep -Fq 'must never update silently' "$policy" \
+  || fail "policy doc does not forbid silent updates"
+grep -Fq 'git pull --ff-only' "$policy" \
+  || fail "policy doc does not document git fast-forward path"
+grep -Fq 'checksum-verified' "$field_doc" \
+  || fail "field release doc does not mention checksum-verified package updates"
+grep -Fq 'Invoke-SysAdminSuiteUpdate.ps1' "$deployment_doc" \
+  || fail "deployment artifacts doc does not reference update helper"
+
+echo "PASS: approved update flow contracts"

--- a/docs/APPROVED_UPDATE_FLOW.md
+++ b/docs/APPROVED_UPDATE_FLOW.md
@@ -1,0 +1,80 @@
+# Approved Update Flow
+
+SysAdminSuite can check for newer files, but it must never update silently. The
+user approves the update first, similar to an app update prompt.
+
+## Delivery Modes
+
+| Local copy | How updates work | Safety rule |
+|------------|------------------|-------------|
+| Source clone (`.git` present) | Compare local `main` with `origin/main`; update with `git pull --ff-only` after approval | Only clean local `main` can auto-update |
+| ZIP / field package (`.git` absent) | Read a trusted update manifest, verify the package SHA256, then replace package content after approval | Only checksum-verified packages can apply |
+
+The launcher may check for updates before opening the dashboard. If an update is
+available, it asks the user before applying it. If the check fails, the dashboard
+continues with the current local copy.
+
+## Source Clone Rules
+
+For developer and IT git clones:
+
+1. Run `git fetch origin`.
+2. Confirm the current branch is `main`.
+3. Confirm `git status --short` is clean.
+4. Confirm there are no local-only commits.
+5. Confirm the update can be applied with `git pull --ff-only origin main`.
+6. Ask the user for approval.
+7. Apply the fast-forward update only after approval.
+
+The updater must not run `git reset --hard`, delete branches, or update feature
+branches automatically.
+
+## ZIP / Field Package Rules
+
+For users who downloaded a ZIP or received a field release package:
+
+1. Read `manifest/update-manifest.json` or a configured manifest path/URL.
+2. Compare the manifest with the current package.
+3. Ask the user for approval.
+4. Download or copy the package to a temporary folder.
+5. Verify `checksumSha256`.
+6. Back up the current app/root content.
+7. Apply the package.
+
+The updater must not use credentials, broaden scans, mutate endpoints, or commit
+runtime evidence.
+
+## Helper
+
+The shared helper is:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\update\Invoke-SysAdminSuiteUpdate.ps1 -CheckOnly
+```
+
+Apply only after user approval:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\update\Invoke-SysAdminSuiteUpdate.ps1 -Apply -Approved
+```
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| `0` | No update available, or update applied successfully |
+| `1` | Error |
+| `10` | Update available; approval required |
+| `20` | Manual review required |
+
+## Launcher Behavior
+
+`START-HERE-SysAdminSuite-Dashboard.bat` checks with the helper. It only prompts
+when the helper reports an available update. If the user says no, or if the
+check needs manual review, the dashboard opens from the current local copy.
+
+## Related Docs
+
+- [`REMOTE_WORKFLOW.md`](REMOTE_WORKFLOW.md) — source-clone mainline rules
+- [`DEPLOYMENT_ARTIFACTS.md`](DEPLOYMENT_ARTIFACTS.md) — package manifest/update rules
+- [`DASHBOARD_FIELD_RELEASE.md`](DASHBOARD_FIELD_RELEASE.md) — no-SDK field package path

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -12,6 +12,8 @@ On first run the launcher will **automatically prepare (build) the dashboard hos
 
 **Field release package (no SDK):** [`DASHBOARD_FIELD_RELEASE.md`](DASHBOARD_FIELD_RELEASE.md) — pre-built zip with `app/bin/SysAdminSuite.DashboardHost.exe`.
 
+**Updates:** launcher checks are opt-in and must prompt before applying changes. Source clones use a clean `main` fast-forward; ZIP/field packages use checksum-verified manifests. See [`APPROVED_UPDATE_FLOW.md`](APPROVED_UPDATE_FLOW.md).
+
 Compatibility aliases (same behavior, not the documented primary): **`START-HERE-SysAdminSuite-Dashboard.cmd`** and **`SysAdminSuite Dashboard.cmd`**.
 
 ## Get the repo first (clone / download)

--- a/docs/DASHBOARD_FIELD_RELEASE.md
+++ b/docs/DASHBOARD_FIELD_RELEASE.md
@@ -11,6 +11,10 @@
 
 Field users on locked-down PCs should receive the **field release package**, not a raw git clone.
 
+Updates are also package-based for this path. The launcher may prompt when a
+trusted manifest says a newer field package is available; it uses a
+checksum-verified package before applying anything. See [`APPROVED_UPDATE_FLOW.md`](APPROVED_UPDATE_FLOW.md).
+
 ## Build the field release (trusted machine with .NET 8 SDK)
 
 From repo root:

--- a/docs/DEPLOYMENT_ARTIFACTS.md
+++ b/docs/DEPLOYMENT_ARTIFACTS.md
@@ -52,6 +52,12 @@ Use a JSON manifest (`Config/update-manifest.sample.json`) with:
 7. Validate startup and primary QR task dispatch.
 8. If validation fails, restore `app.previous`.
 
+## Approved Prompted Update Procedure
+`tools/update/Invoke-SysAdminSuiteUpdate.ps1` can perform the same package update
+after the user approves it. The helper reads a manifest, verifies
+`checksumSha256`, backs up the current app/root content, and applies only a
+recognized package layout. See [`APPROVED_UPDATE_FLOW.md`](APPROVED_UPDATE_FLOW.md).
+
 ## Approved Transport Methods
 - Internal SMB file share
 - Browser download from approved release location

--- a/tools/update/Invoke-SysAdminSuiteUpdate.ps1
+++ b/tools/update/Invoke-SysAdminSuiteUpdate.ps1
@@ -1,0 +1,329 @@
+<#
+.SYNOPSIS
+    Check for, and optionally apply, approved SysAdminSuite updates.
+
+.DESCRIPTION
+    Supports two local install modes:
+
+    - Git source clone: fetches origin/main and updates only clean local main
+      via git pull --ff-only after approval.
+    - ZIP / field package: reads a trusted update manifest, verifies package
+      SHA256, backs up the current app/root content, then applies the package
+      after approval.
+
+    This helper never updates silently. Use -CheckOnly to report availability.
+    Use -Apply -Approved only after a user explicitly approved the update.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Check')]
+param(
+    [ValidateSet('Auto', 'Git', 'Package')]
+    [string]$Source = 'Auto',
+
+    [Parameter(ParameterSetName = 'Check')]
+    [switch]$CheckOnly,
+
+    [Parameter(ParameterSetName = 'Apply')]
+    [switch]$Apply,
+
+    [Parameter(ParameterSetName = 'Apply')]
+    [switch]$Approved,
+
+    [string]$InstallRoot,
+    [string]$ManifestPath,
+    [switch]$Quiet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:ExitNoUpdate = 0
+$script:ExitError = 1
+$script:ExitUpdateAvailable = 10
+$script:ExitManualReview = 20
+
+function Write-UpdateMessage {
+    param([string]$Message)
+    if (-not $Quiet) {
+        Write-Host $Message
+    }
+}
+
+function Resolve-InstallRoot {
+    if ($InstallRoot) {
+        return (Resolve-Path -LiteralPath $InstallRoot).Path
+    }
+    return (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+}
+
+function Test-IsGitClone {
+    param([string]$Root)
+    return (Test-Path -LiteralPath (Join-Path $Root '.git'))
+}
+
+function Invoke-Git {
+    param(
+        [string]$Root,
+        [string[]]$Arguments
+    )
+    $output = & git -C $Root @Arguments 2>&1
+    $code = $LASTEXITCODE
+    return [pscustomobject]@{
+        ExitCode = $code
+        Output   = (($output | ForEach-Object { "$_" }) -join [Environment]::NewLine)
+    }
+}
+
+function Get-GitUpdateState {
+    param([string]$Root)
+
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        return [pscustomobject]@{
+            Safe            = $false
+            UpdateAvailable = $false
+            Reason          = 'git is not available on PATH.'
+        }
+    }
+
+    $fetch = Invoke-Git -Root $Root -Arguments @('fetch', 'origin')
+    if ($fetch.ExitCode -ne 0) {
+        return [pscustomobject]@{
+            Safe            = $false
+            UpdateAvailable = $false
+            Reason          = "git fetch origin failed. $($fetch.Output)"
+        }
+    }
+
+    $branch = (Invoke-Git -Root $Root -Arguments @('branch', '--show-current')).Output.Trim()
+    if ($branch -ne 'main') {
+        return [pscustomobject]@{
+            Safe            = $false
+            UpdateAvailable = $false
+            Reason          = "Current branch is '$branch'. Switch to main before updating."
+        }
+    }
+
+    $status = (Invoke-Git -Root $Root -Arguments @('status', '--short')).Output.Trim()
+    if ($status) {
+        return [pscustomobject]@{
+            Safe            = $false
+            UpdateAvailable = $false
+            Reason          = 'Working tree has local changes. Commit, stash, or discard them before updating.'
+        }
+    }
+
+    $localOnly = (Invoke-Git -Root $Root -Arguments @('log', '--branches', '--not', '--remotes', '--oneline')).Output.Trim()
+    if ($localOnly) {
+        return [pscustomobject]@{
+            Safe            = $false
+            UpdateAvailable = $false
+            Reason          = 'Local-only commits exist. Push or preserve them before updating.'
+        }
+    }
+
+    $counts = (Invoke-Git -Root $Root -Arguments @('rev-list', '--left-right', '--count', 'main...origin/main')).Output.Trim()
+    $parts = $counts -split '\s+'
+    $ahead = [int]$parts[0]
+    $behind = [int]$parts[1]
+
+    if ($ahead -gt 0) {
+        return [pscustomobject]@{
+            Safe            = $false
+            UpdateAvailable = $false
+            Reason          = 'Local main is ahead of origin/main. Manual review required.'
+        }
+    }
+
+    return [pscustomobject]@{
+        Safe            = $true
+        UpdateAvailable = ($behind -gt 0)
+        Reason          = if ($behind -gt 0) { "origin/main is $behind commit(s) ahead." } else { 'Already up to date.' }
+    }
+}
+
+function Invoke-GitUpdate {
+    param([string]$Root)
+    $pull = Invoke-Git -Root $Root -Arguments @('pull', '--ff-only', 'origin', 'main')
+    if ($pull.ExitCode -ne 0) {
+        throw "git pull --ff-only failed. $($pull.Output)"
+    }
+    Write-UpdateMessage 'SysAdminSuite source clone updated from origin/main.'
+}
+
+function Resolve-DefaultManifest {
+    param([string]$Root)
+    foreach ($candidate in @(
+            (Join-Path $Root 'manifest\update-manifest.json'),
+            (Join-Path $Root 'Config\update-manifest.json'))) {
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function Read-Manifest {
+    param([string]$Manifest)
+    if (-not $Manifest) {
+        return $null
+    }
+
+    if ($Manifest -match '^https?://') {
+        $content = (Invoke-WebRequest -UseBasicParsing -Uri $Manifest).Content
+    } else {
+        if (-not (Test-Path -LiteralPath $Manifest)) {
+            throw "Manifest not found: $Manifest"
+        }
+        $content = Get-Content -LiteralPath $Manifest -Raw
+    }
+    return $content | ConvertFrom-Json
+}
+
+function Get-PackagePath {
+    param(
+        [object]$Manifest,
+        [string]$ManifestSource,
+        [string]$DownloadDir
+    )
+
+    $packageUrl = $null
+    if ($Manifest.PSObject.Properties.Name -contains 'packageUrl') {
+        $packageUrl = $Manifest.packageUrl
+    }
+    if (-not $packageUrl -and ($Manifest.PSObject.Properties.Name -contains 'package')) {
+        $packageUrl = $Manifest.package
+    }
+    if (-not $packageUrl) {
+        throw 'Manifest must include packageUrl or package.'
+    }
+
+    $target = Join-Path $DownloadDir ([IO.Path]::GetFileName($packageUrl))
+    if ($packageUrl -match '^https?://') {
+        Invoke-WebRequest -UseBasicParsing -Uri $packageUrl -OutFile $target
+        return $target
+    }
+
+    if ([IO.Path]::IsPathRooted($packageUrl)) {
+        Copy-Item -LiteralPath $packageUrl -Destination $target -Force
+        return $target
+    }
+
+    if ($ManifestSource -and -not ($ManifestSource -match '^https?://')) {
+        $manifestDir = Split-Path -Parent (Resolve-Path -LiteralPath $ManifestSource).Path
+        $sourcePath = Join-Path $manifestDir $packageUrl
+        Copy-Item -LiteralPath $sourcePath -Destination $target -Force
+        return $target
+    }
+
+    throw 'Relative package path cannot be resolved for remote manifest. Use packageUrl.'
+}
+
+function Test-PackageUpdateAvailable {
+    param([object]$Manifest)
+    if (-not $Manifest) {
+        return [pscustomobject]@{
+            Safe            = $true
+            UpdateAvailable = $false
+            Reason          = 'No update manifest configured.'
+        }
+    }
+    return [pscustomobject]@{
+        Safe            = $true
+        UpdateAvailable = $true
+        Reason          = "Package update available: $($Manifest.version)"
+    }
+}
+
+function Invoke-PackageUpdate {
+    param(
+        [string]$Root,
+        [object]$Manifest,
+        [string]$ManifestSource
+    )
+
+    $temp = Join-Path ([IO.Path]::GetTempPath()) ("SysAdminSuiteUpdate_" + [guid]::NewGuid().ToString('N'))
+    $extract = Join-Path $temp 'extract'
+    New-Item -ItemType Directory -Path $extract -Force | Out-Null
+
+    try {
+        $packagePath = Get-PackagePath -Manifest $Manifest -ManifestSource $ManifestSource -DownloadDir $temp
+        $hash = (Get-FileHash -Path $packagePath -Algorithm SHA256).Hash
+        if ($Manifest.checksumSha256 -and ($hash -ne $Manifest.checksumSha256)) {
+            throw "Package checksum mismatch. Expected $($Manifest.checksumSha256), got $hash."
+        }
+
+        Expand-Archive -Path $packagePath -DestinationPath $extract -Force
+        $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+
+        if (Test-Path -LiteralPath (Join-Path $extract 'app')) {
+            $app = Join-Path $Root 'app'
+            $backup = Join-Path $Root "app.previous.$timestamp"
+            if (Test-Path -LiteralPath $app) {
+                Move-Item -LiteralPath $app -Destination $backup -Force
+            }
+            Copy-Item -Path (Join-Path $extract 'app') -Destination $app -Recurse -Force
+            Write-UpdateMessage "Package app folder updated. Backup: $backup"
+            return
+        }
+
+        if ((Test-Path -LiteralPath (Join-Path $extract 'START-HERE-SysAdminSuite-Dashboard.bat')) -and
+            (Test-Path -LiteralPath (Join-Path $extract 'app\bin\SysAdminSuite.DashboardHost.exe'))) {
+            $parent = Split-Path -Parent $Root
+            $leaf = Split-Path -Leaf $Root
+            $backup = Join-Path $parent "$leaf.previous.$timestamp"
+            Copy-Item -Path $Root -Destination $backup -Recurse -Force
+            Copy-Item -Path (Join-Path $extract '*') -Destination $Root -Recurse -Force
+            Write-UpdateMessage "Field package updated. Backup: $backup"
+            return
+        }
+
+        throw 'Package layout is not recognized. Expected app/ or dashboard field-release root.'
+    } finally {
+        Remove-Item -LiteralPath $temp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+try {
+    $root = Resolve-InstallRoot
+    $isGit = Test-IsGitClone -Root $root
+    $mode = $Source
+    if ($mode -eq 'Auto') {
+        $mode = if ($isGit) { 'Git' } else { 'Package' }
+    }
+
+    if ($Apply -and -not $Approved) {
+        Write-Error 'Refusing to apply update without -Approved.'
+        exit $script:ExitError
+    }
+
+    if ($mode -eq 'Git') {
+        $state = Get-GitUpdateState -Root $root
+        Write-UpdateMessage $state.Reason
+        if (-not $state.Safe) {
+            exit $script:ExitManualReview
+        }
+        if (-not $state.UpdateAvailable) {
+            exit $script:ExitNoUpdate
+        }
+        if ($Apply) {
+            Invoke-GitUpdate -Root $root
+            exit $script:ExitNoUpdate
+        }
+        exit $script:ExitUpdateAvailable
+    }
+
+    $manifestSource = if ($ManifestPath) { $ManifestPath } else { Resolve-DefaultManifest -Root $root }
+    $manifest = Read-Manifest -Manifest $manifestSource
+    $state = Test-PackageUpdateAvailable -Manifest $manifest
+    Write-UpdateMessage $state.Reason
+    if (-not $state.UpdateAvailable) {
+        exit $script:ExitNoUpdate
+    }
+    if ($Apply) {
+        Invoke-PackageUpdate -Root $root -Manifest $manifest -ManifestSource $manifestSource
+        exit $script:ExitNoUpdate
+    }
+    exit $script:ExitUpdateAvailable
+} catch {
+    Write-Error $_.Exception.Message
+    exit $script:ExitError
+}


### PR DESCRIPTION
## Summary

Adds an approved update flow for SysAdminSuite installs:

- Source clones (`.git` present) can check `origin/main` and update only clean local `main` with `git pull --ff-only` after user approval.
- ZIP / field package installs use a trusted update manifest and `checksumSha256` verification before applying a package after user approval.
- `START-HERE-SysAdminSuite-Dashboard.bat` checks quietly and prompts only when an update is available; it never updates silently.

## Safety model

- No `git reset --hard` updater path.
- No automatic feature-branch updates.
- No branch deletion.
- No generated `dist/` or package binaries committed.
- Package updates are manifest + checksum based.

## Validation

- PowerShell parse: `tools/update/Invoke-SysAdminSuiteUpdate.ps1` parses cleanly.
- `bash Tests/bash/test_update_flow_contracts.sh` — PASS.
- `bash Tests/bash/test_dashboard_entrypoint_contracts.sh` — PASS.
- `git diff --check` — clean.

## Merge policy

`merge_when_green` for this PR. Preserve the branch; branch deletion is not authorized.
