### PR TITLE
fix(ui): make dashboard start action recoverable

### DIFF
--- a/.github/workflows/dashboard-smoke.yml
+++ b/.github/workflows/dashboard-smoke.yml
@@ -25,5 +25,11 @@ jobs:
           node --check dashboard/js/parsers.js
           node --check dashboard/js/app.js
           node --check dashboard/js/bundle.js
+          node --check dashboard/js/cybernet-os-preflight.js
+          node --check dashboard/js/launch-cybernet-tutorial.js
       - name: Dashboard parser smoke test
         run: node dashboard/smoke-test.js
+      - name: Dashboard Start-button runtime smoke test
+        run: node dashboard/start-button-smoke.js
+      - name: Dashboard tutorial launcher contracts
+        run: bash Tests/bash/test_dashboard_tutorial_launcher_contracts.sh

--- a/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
+++ b/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
@@ -5,6 +5,9 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 cmd="$repo_root/Start-CybernetSurveyTutorial.cmd"
 index="$repo_root/dashboard/index.html"
 helper="$repo_root/dashboard/js/launch-cybernet-tutorial.js"
+app="$repo_root/dashboard/js/app.js"
+bundle="$repo_root/dashboard/js/bundle.js"
+preflight="$repo_root/dashboard/js/cybernet-os-preflight.js"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -14,6 +17,9 @@ fail() {
 [[ -f "$cmd" ]] || fail "Start-CybernetSurveyTutorial.cmd is missing"
 [[ -f "$index" ]] || fail "dashboard/index.html is missing"
 [[ -f "$helper" ]] || fail "dashboard/js/launch-cybernet-tutorial.js is missing"
+[[ -f "$app" ]] || fail "dashboard/js/app.js is missing"
+[[ -f "$bundle" ]] || fail "dashboard/js/bundle.js is missing"
+[[ -f "$preflight" ]] || fail "dashboard/js/cybernet-os-preflight.js is missing"
 
 grep -Fq 'dashboard\index.html' "$cmd" || fail "launcher does not point at dashboard\index.html"
 grep -q "tutorial=cybernet" "$cmd" || fail "launcher does not request the Cybernet tutorial"
@@ -25,5 +31,48 @@ grep -q "URLSearchParams" "$helper" || fail "helper does not inspect query param
 if grep -viE '^[[:space:]]*rem[[:space:]]' "$cmd" | grep -qiE 'naabu|nmap|credential|password|psexec|invoke-command'; then
   fail "double-click launcher must not run survey, credential, or remote command tooling"
 fi
+
+# ── Start-button visible-failure contracts ──────────────────────────────────
+# A press of Start must never strand the user: the wizard must open and be
+# verified visible, or a visible recovery state must be shown. The Start button
+# must not simply be hidden with no visible continuation.
+
+# 1. The hero must carry a visible status line for Opening / open / error states.
+grep -q 'id="cybernet-hero-status"' "$index" \
+  || fail "dashboard index is missing the hero status line (cybernet-hero-status)"
+
+# 2. app.js must use an explicit, verified state transition (not a bare unhide).
+grep -q 'startCybernetTutorial' "$app" \
+  || fail "app.js does not define an explicit startCybernetTutorial transition"
+grep -q 'window.startCybernetTutorial' "$app" \
+  || fail "app.js does not expose startCybernetTutorial for the auto-launch path"
+grep -q 'getComputedStyle' "$app" \
+  || fail "app.js does not verify the tutorial is actually visible before transforming the hero"
+grep -q 'cybernet-hero-status' "$app" \
+  || fail "app.js does not drive a visible hero status"
+
+# 3. Recovery: the Start action must transform into a recovery control rather
+#    than vanish. Guard against the old strand pattern that only hid the hero.
+grep -q 'Restart Cybernet Survey' "$app" \
+  || fail "app.js does not provide a recovery control (Restart Cybernet Survey)"
+if grep -Eq "cybernet-hero-actions'\)\?\.classList\.add\('hidden'\)" "$app"; then
+  fail "app.js still hides cybernet-hero-actions on Start (strands the user)"
+fi
+
+# 4. The OS-preflight helper must not force the wizard hidden on load.
+if grep -q 'syncTutorialVisibility' "$preflight"; then
+  fail "cybernet-os-preflight.js still gates wizard visibility (forces display:none)"
+fi
+if grep -Eq "root\.style\.display *= *liveActive" "$preflight"; then
+  fail "cybernet-os-preflight.js still forces the tutorial root display off"
+fi
+
+# 5. The auto-launch helper must route through the verified transition.
+grep -q 'window.startCybernetTutorial' "$helper" \
+  || fail "launch-cybernet-tutorial.js does not use the verified startCybernetTutorial transition"
+
+# 6. The served bundle must be rebuilt from source (not stale).
+grep -q 'startCybernetTutorial' "$bundle" \
+  || fail "dashboard/js/bundle.js is stale — rebuild with: node dashboard/build-bundle.js"
 
 echo "PASS: dashboard tutorial launcher contracts"

--- a/dashboard/css/style.css
+++ b/dashboard/css/style.css
@@ -1183,6 +1183,17 @@ textarea.paste-area:focus { border-color: var(--accent); }
   align-items: center;
 }
 
+.cybernet-hero-status {
+  margin: 10px 0 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-dim);
+}
+
+.cybernet-hero-status.is-busy { color: var(--info); }
+.cybernet-hero-status.is-open { color: var(--success); }
+.cybernet-hero-status.is-error { color: var(--error); }
+
 .btn-compact { padding: 6px 12px; font-size: 12px; }
 .btn-link {
   background: transparent;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -126,6 +126,7 @@
         <button class="btn-primary" id="hero-start-survey" type="button">Start Cybernet Survey</button>
         <button class="btn-secondary" id="hero-load-evidence" type="button">Load Evidence</button>
       </div>
+      <p id="cybernet-hero-status" class="cybernet-hero-status hidden" role="status" aria-live="polite"></p>
     </div>
   </section>
 

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -132,11 +132,75 @@ function switchTab(tab) {
 
 // ── Cybernet-first shell ─────────────────────────────────────────────────────
 function initCybernetShell() {
-  document.getElementById('hero-start-survey')?.addEventListener('click', () => {
-    document.getElementById('cybernet-tutorial')?.classList.remove('hidden');
-    document.getElementById('cybernet-hero-actions')?.classList.add('hidden');
-    document.getElementById('cybernet-tutorial')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
+  const startBtn = document.getElementById('hero-start-survey');
+  const tutorial = document.getElementById('cybernet-tutorial');
+  const statusEl = document.getElementById('cybernet-hero-status');
+
+  const setHeroStatus = (msg, kind) => {
+    if (!statusEl) return;
+    statusEl.textContent = msg || '';
+    statusEl.classList.remove('is-busy', 'is-open', 'is-error');
+    if (kind) statusEl.classList.add(kind);
+    statusEl.classList.toggle('hidden', !msg);
+  };
+
+  // Effective visibility check: catches a none from the class, an inline style,
+  // or a rule set by another script (e.g. the OS-preflight helper).
+  const tutorialIsVisible = () => {
+    if (!tutorial) return false;
+    if (tutorial.classList.contains('hidden')) return false;
+    const cs = window.getComputedStyle(tutorial);
+    return cs.display !== 'none' && cs.visibility !== 'hidden';
+  };
+
+  // Explicit, verified state transition. A press of Start must always leave the
+  // user in a visible state: tutorial open, or a clear recovery message — never a
+  // vanished button with nothing showing.
+  const startCybernetTutorial = (opts) => {
+    const source = (opts && opts.source) || 'manual';
+    if (!tutorial || !startBtn) {
+      setHeroStatus('Could not open the tutorial. Reload the dashboard or use Load Evidence.', 'is-error');
+      toast('Survey tutorial is unavailable. Reload the dashboard.', 'error');
+      return false;
+    }
+
+    setHeroStatus('Opening tutorial…', 'is-busy');
+
+    // Show the wizard. Clear any inline display another script may have set so a
+    // stale inline none cannot silently keep the wizard hidden.
+    tutorial.style.display = '';
+    tutorial.classList.remove('hidden');
+    if (typeof window.__sasResetCybernetWizard === 'function') {
+      try { window.__sasResetCybernetWizard(); } catch (_) { /* non-fatal */ }
+    }
+
+    // Verify the wizard is actually visible before transforming the hero. If it
+    // is not, restore the obvious action instead of stranding the user.
+    if (!tutorialIsVisible()) {
+      tutorial.classList.add('hidden');
+      setHeroStatus('Could not open the tutorial. Try again or use Load Evidence.', 'is-error');
+      toast('Could not open the survey tutorial. Try again or load evidence.', 'error');
+      return false;
+    }
+
+    // Keep the hero action visible and turn it into a recovery control rather
+    // than hiding the only obvious button.
+    startBtn.textContent = 'Restart Cybernet Survey';
+    startBtn.setAttribute('aria-label', 'Restart the Cybernet survey from step 1');
+    setHeroStatus('Tutorial open below.', 'is-open');
+    if (source !== 'silent') {
+      window.setTimeout(() => {
+        tutorial.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 30);
+    }
+    return true;
+  };
+
+  startBtn?.addEventListener('click', () => startCybernetTutorial({ source: 'manual' }));
+
+  // Expose the same verified transition for the ?tutorial=cybernet auto-launch
+  // path so it cannot diverge from the manual click behavior.
+  window.startCybernetTutorial = startCybernetTutorial;
 
   const openEvidence = () => {
     document.getElementById('evidence-loader')?.classList.remove('hidden');
@@ -690,6 +754,9 @@ function initCybernetTutorial() {
     }
   });
   copy?.addEventListener('click', copyCommand);
+
+  // Allow the hero "Restart Cybernet Survey" control to reset to step 1.
+  window.__sasResetCybernetWizard = () => { idx = 0; copiedThisStep = false; render(); };
 
   render();
 }

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -3910,11 +3910,75 @@ function switchTab(tab) {
 
 // ── Cybernet-first shell ─────────────────────────────────────────────────────
 function initCybernetShell() {
-  document.getElementById('hero-start-survey')?.addEventListener('click', () => {
-    document.getElementById('cybernet-tutorial')?.classList.remove('hidden');
-    document.getElementById('cybernet-hero-actions')?.classList.add('hidden');
-    document.getElementById('cybernet-tutorial')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  });
+  const startBtn = document.getElementById('hero-start-survey');
+  const tutorial = document.getElementById('cybernet-tutorial');
+  const statusEl = document.getElementById('cybernet-hero-status');
+
+  const setHeroStatus = (msg, kind) => {
+    if (!statusEl) return;
+    statusEl.textContent = msg || '';
+    statusEl.classList.remove('is-busy', 'is-open', 'is-error');
+    if (kind) statusEl.classList.add(kind);
+    statusEl.classList.toggle('hidden', !msg);
+  };
+
+  // Effective visibility check: catches a none from the class, an inline style,
+  // or a rule set by another script (e.g. the OS-preflight helper).
+  const tutorialIsVisible = () => {
+    if (!tutorial) return false;
+    if (tutorial.classList.contains('hidden')) return false;
+    const cs = window.getComputedStyle(tutorial);
+    return cs.display !== 'none' && cs.visibility !== 'hidden';
+  };
+
+  // Explicit, verified state transition. A press of Start must always leave the
+  // user in a visible state: tutorial open, or a clear recovery message — never a
+  // vanished button with nothing showing.
+  const startCybernetTutorial = (opts) => {
+    const source = (opts && opts.source) || 'manual';
+    if (!tutorial || !startBtn) {
+      setHeroStatus('Could not open the tutorial. Reload the dashboard or use Load Evidence.', 'is-error');
+      toast('Survey tutorial is unavailable. Reload the dashboard.', 'error');
+      return false;
+    }
+
+    setHeroStatus('Opening tutorial…', 'is-busy');
+
+    // Show the wizard. Clear any inline display another script may have set so a
+    // stale inline none cannot silently keep the wizard hidden.
+    tutorial.style.display = '';
+    tutorial.classList.remove('hidden');
+    if (typeof window.__sasResetCybernetWizard === 'function') {
+      try { window.__sasResetCybernetWizard(); } catch (_) { /* non-fatal */ }
+    }
+
+    // Verify the wizard is actually visible before transforming the hero. If it
+    // is not, restore the obvious action instead of stranding the user.
+    if (!tutorialIsVisible()) {
+      tutorial.classList.add('hidden');
+      setHeroStatus('Could not open the tutorial. Try again or use Load Evidence.', 'is-error');
+      toast('Could not open the survey tutorial. Try again or load evidence.', 'error');
+      return false;
+    }
+
+    // Keep the hero action visible and turn it into a recovery control rather
+    // than hiding the only obvious button.
+    startBtn.textContent = 'Restart Cybernet Survey';
+    startBtn.setAttribute('aria-label', 'Restart the Cybernet survey from step 1');
+    setHeroStatus('Tutorial open below.', 'is-open');
+    if (source !== 'silent') {
+      window.setTimeout(() => {
+        tutorial.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 30);
+    }
+    return true;
+  };
+
+  startBtn?.addEventListener('click', () => startCybernetTutorial({ source: 'manual' }));
+
+  // Expose the same verified transition for the ?tutorial=cybernet auto-launch
+  // path so it cannot diverge from the manual click behavior.
+  window.startCybernetTutorial = startCybernetTutorial;
 
   const openEvidence = () => {
     document.getElementById('evidence-loader')?.classList.remove('hidden');
@@ -4468,6 +4532,9 @@ function initCybernetTutorial() {
     }
   });
   copy?.addEventListener('click', copyCommand);
+
+  // Allow the hero "Restart Cybernet Survey" control to reset to step 1.
+  window.__sasResetCybernetWizard = () => { idx = 0; copiedThisStep = false; render(); };
 
   render();
 }

--- a/dashboard/js/cybernet-os-preflight.js
+++ b/dashboard/js/cybernet-os-preflight.js
@@ -98,12 +98,6 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
     }
   }
 
-  function syncTutorialVisibility(root) {
-    const liveControls = document.getElementById('live-controls');
-    const liveActive = liveControls && liveControls.classList.contains('active');
-    root.style.display = liveActive ? '' : 'none';
-  }
-
   function ensureOsCard(root) {
     if (!root || document.getElementById('cybernet-os-preflight')) return;
     const card = document.createElement('div');
@@ -179,10 +173,6 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
     if (!root) return;
     ensureOsCard(root);
     patchCurrentStep();
-    syncTutorialVisibility(root);
-    document.querySelectorAll('.mode-btn').forEach(btn => {
-      btn.addEventListener('click', () => setTimeout(() => syncTutorialVisibility(root), 0));
-    });
     root.addEventListener('click', () => setTimeout(patchCurrentStep, 0));
     const observer = new MutationObserver(() => patchCurrentStep());
     const titleEl = document.getElementById('cybernet-step-title');

--- a/dashboard/js/launch-cybernet-tutorial.js
+++ b/dashboard/js/launch-cybernet-tutorial.js
@@ -18,6 +18,14 @@
     const startButton = document.getElementById('hero-start-survey');
     const tutorial = document.getElementById('cybernet-tutorial');
 
+    // Prefer the dashboard's verified state transition so the auto-launch path
+    // cannot diverge from the manual click (visible tutorial or visible recovery).
+    if (typeof window.startCybernetTutorial === 'function' && tutorial) {
+      window.startCybernetTutorial({ source: 'query' });
+      return;
+    }
+
+    // Fallback for older shells: click the button directly.
     if (startButton && tutorial) {
       startButton.click();
       window.setTimeout(function () {

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -340,3 +340,38 @@ tourAssert(indexHtml.includes('class="advanced-section-head"'), 'advanced-sectio
 
 console.log(`\nTour: ${tourPassed} passed, ${tourFailed} failed`);
 if (tourFailed > 0) process.exit(1);
+
+// ── Start-button visible-failure contracts ───────────────────────────────────
+// Source-level guards that a press of Start can never strand the user. The full
+// runtime behavior is exercised by dashboard/start-button-smoke.js.
+
+const bundleJs = readFileSync(join(__dir, 'js', 'bundle.js'), 'utf8');
+const preflightJs = readFileSync(join(__dir, 'js', 'cybernet-os-preflight.js'), 'utf8');
+const launchJs = readFileSync(join(__dir, 'js', 'launch-cybernet-tutorial.js'), 'utf8');
+
+let startPassed = 0;
+let startFailed = 0;
+function startAssert(ok, label, detail) {
+  if (ok) { console.log(`PASS [start-button:${label}]`); startPassed++; }
+  else { console.error(`FAIL [start-button:${label}]${detail ? ': ' + detail : ''}`); startFailed++; }
+}
+
+startAssert(indexHtml.includes('id="cybernet-hero-status"'), 'hero-status-in-html', 'missing cybernet-hero-status');
+startAssert(appJs.includes('startCybernetTutorial'), 'explicit-transition', 'app.js missing startCybernetTutorial');
+startAssert(appJs.includes('window.startCybernetTutorial'), 'transition-exposed', 'app.js does not expose startCybernetTutorial');
+startAssert(appJs.includes('getComputedStyle'), 'verifies-visibility', 'app.js does not verify tutorial visibility');
+startAssert(appJs.includes("tutorial.style.display = ''"), 'clears-inline-none', 'app.js does not clear a stale inline display:none');
+startAssert(/Restart Cybernet Survey/.test(appJs), 'recovery-control', 'app.js missing Restart recovery control');
+startAssert(appJs.includes('cybernet-hero-status'), 'drives-status', 'app.js does not drive the hero status');
+// Guard the old strand pattern: Start must not simply hide the hero actions.
+startAssert(!/cybernet-hero-actions'\)\?\.classList\.add\('hidden'\)/.test(appJs), 'no-strand-pattern',
+  'app.js still hides cybernet-hero-actions on Start');
+startAssert(!preflightJs.includes('syncTutorialVisibility'), 'preflight-not-gating-wizard',
+  'cybernet-os-preflight.js still forces the wizard hidden');
+startAssert(launchJs.includes('window.startCybernetTutorial'), 'auto-start-uses-transition',
+  'launch-cybernet-tutorial.js does not use the verified transition');
+startAssert(bundleJs.includes('startCybernetTutorial'), 'bundle-not-stale',
+  'bundle.js is stale — rebuild with: node dashboard/build-bundle.js');
+
+console.log(`\nStart button: ${startPassed} passed, ${startFailed} failed`);
+if (startFailed > 0) process.exit(1);

--- a/dashboard/start-button-smoke.js
+++ b/dashboard/start-button-smoke.js
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+// dashboard/start-button-smoke.js — runtime exercise for the Cybernet Start button.
+// Run: node dashboard/start-button-smoke.js
+//
+// Loads the real production bundle under a minimal DOM mock and proves that a
+// press of Start never strands the user. Specifically it guards the exact field
+// failure: "I clicked Start, the button disappeared, and nothing showed."
+//
+// Covered states:
+//   1. Initial load  — wizard hidden, Start button labelled normally.
+//   2. Manual click  — wizard becomes visibly open, Start transforms into a
+//                      recovery control, hero status announces the open state.
+//   3. Rogue inline display:none on the wizard (the original bug) — opening must
+//      clear it so the wizard still shows.
+//   4. ?tutorial=cybernet auto-start — routes through the same verified path.
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+let passed = 0;
+let failed = 0;
+function assert(ok, label, detail) {
+  if (ok) { console.log(`PASS [start-button:${label}]`); passed++; }
+  else { console.error(`FAIL [start-button:${label}]${detail ? ': ' + detail : ''}`); failed++; }
+}
+
+// ── Minimal DOM mock ────────────────────────────────────────────────────────
+function makeClassList(el) {
+  const set = new Set();
+  return {
+    add: (...c) => c.forEach(x => set.add(x)),
+    remove: (...c) => c.forEach(x => set.delete(x)),
+    contains: c => set.has(c),
+    toggle: (c, force) => {
+      const want = force === undefined ? !set.has(c) : !!force;
+      if (want) set.add(c); else set.delete(c);
+      return want;
+    },
+    _set: set,
+  };
+}
+
+function makeEl(id) {
+  const el = {
+    _id: id || '',
+    style: {},
+    attributes: {},
+    dataset: {},
+    children: [],
+    _listeners: {},
+    textContent: '',
+    value: '',
+    disabled: false,
+    innerHTML: '',
+  };
+  el.classList = makeClassList(el);
+  el.setAttribute = (k, v) => { el.attributes[k] = String(v); };
+  el.getAttribute = k => (k in el.attributes ? el.attributes[k] : null);
+  el.removeAttribute = k => { delete el.attributes[k]; };
+  el.addEventListener = (type, fn) => { (el._listeners[type] = el._listeners[type] || []).push(fn); };
+  el.removeEventListener = () => {};
+  el.dispatch = type => { (el._listeners[type] || []).forEach(fn => { try { fn({ target: el, preventDefault() {} }); } catch (_) {} }); };
+  el.click = () => el.dispatch('click');
+  el.scrollIntoView = () => {};
+  el.focus = () => {};
+  el.select = () => {};
+  el.appendChild = c => { el.children.push(c); return c; };
+  el.insertBefore = c => { el.children.unshift(c); return c; };
+  el.removeChild = c => { el.children = el.children.filter(x => x !== c); };
+  el.remove = () => {};
+  el.querySelector = () => null;
+  el.querySelectorAll = () => [];
+  el.getClientRects = () => (isVisible(el) ? [{ width: 100, height: 50 }] : []);
+  Object.defineProperty(el, 'offsetParent', { get: () => (isVisible(el) ? document.body : null) });
+  Object.defineProperty(el, 'firstChild', { get: () => el.children[0] || null });
+  return el;
+}
+
+function isVisible(el) {
+  if (!el) return false;
+  if (el.classList.contains('hidden')) return false;       // .hidden { display:none !important }
+  if (el.style.display === 'none') return false;
+  if (el.style.visibility === 'hidden') return false;
+  return true;
+}
+
+const elements = new Map();
+// Seed the ids that mirror index.html's initial state.
+function seed(id, classes = []) {
+  const el = makeEl(id);
+  classes.forEach(c => el.classList.add(c));
+  elements.set(id, el);
+  return el;
+}
+const tutorial = seed('cybernet-tutorial', ['hidden']);
+const startBtn = seed('hero-start-survey');
+startBtn.textContent = 'Start Cybernet Survey';
+seed('cybernet-hero-actions');
+seed('cybernet-hero-status', ['hidden']);
+seed('toast-container');
+
+const document = {
+  readyState: 'loading',
+  _listeners: {},
+  getElementById: id => {
+    if (!elements.has(id)) elements.set(id, makeEl(id));
+    return elements.get(id);
+  },
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  createElement: tag => makeEl(`__created_${tag}`),
+  addEventListener: (type, fn) => { (document._listeners[type] = document._listeners[type] || []).push(fn); },
+  removeEventListener: () => {},
+};
+document.head = makeEl('__head');
+document.body = makeEl('__body');
+document.documentElement = makeEl('__html');
+
+class MutationObserverMock { observe() {} disconnect() {} takeRecords() { return []; } }
+
+const storage = new Map();
+const localStorage = {
+  getItem: k => (storage.has(k) ? storage.get(k) : null),
+  setItem: (k, v) => storage.set(k, String(v)),
+  removeItem: k => storage.delete(k),
+};
+
+const navigator = { clipboard: { writeText: () => Promise.resolve() }, userAgent: 'node-smoke' };
+
+const window = {
+  location: { search: '', hash: '', href: 'http://127.0.0.1:5000/dashboard/' },
+  setTimeout: (fn) => { try { fn(); } catch (_) {} return 0; }, // run synchronously for the test
+  clearTimeout: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  matchMedia: () => ({ matches: false, addEventListener() {}, addListener() {} }),
+  getComputedStyle: el => ({
+    display: isVisible(el) ? 'block' : 'none',
+    visibility: el && el.style && el.style.visibility === 'hidden' ? 'hidden' : 'visible',
+  }),
+  MutationObserver: MutationObserverMock,
+  WebSocket: function () { return { addEventListener() {}, close() {}, send() {} }; },
+  EventSource: function () { return { addEventListener() {}, close() {} }; },
+  fetch: () => Promise.reject(new Error('no network in smoke test')),
+  navigator,
+  localStorage,
+};
+window.window = window;
+
+function runScript(relPath) {
+  const src = readFileSync(join(__dir, relPath), 'utf8');
+  const fn = new Function(
+    'window', 'document', 'navigator', 'localStorage', 'getComputedStyle',
+    'MutationObserver', 'location', 'setTimeout', 'clearTimeout', 'URLSearchParams',
+    'WebSocket', 'EventSource', 'fetch',
+    src
+  );
+  fn(
+    window, document, navigator, localStorage, window.getComputedStyle,
+    MutationObserverMock, window.location, window.setTimeout, window.clearTimeout, URLSearchParams,
+    window.WebSocket, window.EventSource, window.fetch
+  );
+}
+
+function fireDomReady() {
+  document.readyState = 'complete';
+  // Later init functions (panels, relay) may touch APIs we do not mock and log
+  // tolerated errors; the start-button wiring (initCybernetShell) runs first and
+  // is what we test. Silence that expected noise so CI logs stay clean.
+  const realError = console.error;
+  const realWarn = console.warn;
+  console.error = () => {};
+  console.warn = () => {};
+  try {
+    (document._listeners.DOMContentLoaded || []).forEach(fn => {
+      try { fn(); } catch (_) { /* tolerated */ }
+    });
+  } finally {
+    console.error = realError;
+    console.warn = realWarn;
+  }
+}
+
+// ── Run the real bundle ─────────────────────────────────────────────────────
+runScript('js/bundle.js');
+fireDomReady();
+
+// State 1: initial load — wizard hidden, Start labelled normally.
+assert(!isVisible(tutorial), 'initial-wizard-hidden', 'wizard should start hidden');
+assert(startBtn.textContent === 'Start Cybernet Survey', 'initial-start-label', `was "${startBtn.textContent}"`);
+assert(typeof window.startCybernetTutorial === 'function', 'transition-exposed', 'window.startCybernetTutorial missing');
+
+// State 3 (the original bug): a rogue inline display:none must not survive open.
+tutorial.style.display = 'none';
+startBtn.click();
+
+// State 2: after click — wizard visibly open, Start transformed, status announced.
+assert(isVisible(tutorial), 'click-opens-wizard', 'wizard still hidden after Start click');
+assert(!tutorial.classList.contains('hidden'), 'click-removes-hidden-class', 'hidden class still present');
+assert(startBtn.textContent !== 'Start Cybernet Survey' && /restart/i.test(startBtn.textContent),
+  'click-transforms-start', `Start did not become a recovery control (was "${startBtn.textContent}")`);
+const statusEl = document.getElementById('cybernet-hero-status');
+assert(isVisible(statusEl) && /open/i.test(statusEl.textContent), 'click-shows-status',
+  `hero status not shown (was "${statusEl.textContent}")`);
+assert(document.getElementById('cybernet-hero-actions') && isVisible(document.getElementById('cybernet-hero-actions')),
+  'hero-actions-not-stranded', 'hero actions were hidden, stranding the user');
+
+// State 4: ?tutorial=cybernet auto-start uses the same verified path.
+// Reset the wizard to the closed state, then drive the auto-launch helper.
+tutorial.classList.add('hidden');
+tutorial.style.display = 'none';
+startBtn.textContent = 'Start Cybernet Survey';
+window.location.search = '?tutorial=cybernet';
+document.readyState = 'complete';
+runScript('js/launch-cybernet-tutorial.js');
+assert(isVisible(tutorial), 'auto-start-opens-wizard', 'auto-start left the wizard hidden');
+assert(/restart/i.test(startBtn.textContent), 'auto-start-transforms-start',
+  `auto-start did not transform Start (was "${startBtn.textContent}")`);
+
+console.log(`\nStart button: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Failure addressed

A field user pressed **Start Cybernet Survey**, the button disappeared, and the tutorial never showed — the user was stranded with no idea whether the dashboard was working, loading, or broken. Treated as a blocker-level UX failure.

## Root cause (two combined faults)

1. `dashboard/js/cybernet-os-preflight.js` set an **inline `display:none`** on `#cybernet-tutorial` on load (its `syncTutorialVisibility` gate keyed off `live-controls`). That inline style survived the class-based unhide in `app.js`, so the wizard physically could not show.
2. The Start handler unconditionally added `hidden` to `#cybernet-hero-actions`, so the only obvious action vanished with no visible continuation or recovery.

## Fix

- Replace the bare unhide with an explicit, verified state transition `startCybernetTutorial({ source })` that:
  - clears any stale inline `display`, removes `hidden`, resets the wizard to step 1,
  - verifies the wizard is actually visible (`getComputedStyle`) before transforming the hero,
  - on failure restores the action and shows a clear error (toast + status).
- Keep `#cybernet-hero-actions` visible and turn the primary button into a recovery control: **Restart Cybernet Survey**.
- Add a live hero status line (`Opening tutorial…` / `Tutorial open below.` / `Could not open the tutorial…`).
- Remove the `syncTutorialVisibility` gate (the OS selector card is preserved).
- Route the `?tutorial=cybernet` auto-launch through the same verified transition so it cannot diverge from the manual click.

## Tests

- `dashboard/start-button-smoke.js` — new runtime DOM-mock exercise of the **real production bundle**: initial state, manual click, stale inline `display:none`, and the `?tutorial=cybernet` auto-start path (10 assertions).
- `dashboard/smoke-test.js` — added source contracts incl. a no-strand guard and a bundle-staleness check (11 assertions).
- `Tests/bash/test_dashboard_tutorial_launcher_contracts.sh` — extended with Start-button visible-failure contracts.
- `.github/workflows/dashboard-smoke.yml` — now runs the runtime smoke and the launcher contracts in CI.

## Validation (local)

- `node dashboard/smoke-test.js` -> pass (Start button: 11 passed, 0 failed)
- `node dashboard/start-button-smoke.js` -> pass (10 passed, 0 failed)
- `bash Tests/bash/test_dashboard_tutorial_launcher_contracts.sh` -> PASS
- `bash Tests/bash/test_dashboard_entrypoint_contracts.sh` -> PASS
- `node --check` on app.js / bundle.js / cybernet-os-preflight.js / launch-cybernet-tutorial.js -> ok

## Scope notes

- PowerShell files untouched.
- No `dist/` or `tools/publish/` output committed.
- `.cmd` not made primary; launcher contracts unchanged.
- PR #95 untouched.

## Cold-judge check

"I clicked Start, the button disappeared, and nothing obvious happened" is no longer possible: Start always yields a visibly open wizard, or a visible recovery control + error message.
