### PR TITLE
feat(ui): clarify Cybernet tutorial for field techs

### DIFF
--- a/dashboard/css/style.css
+++ b/dashboard/css/style.css
@@ -1078,6 +1078,17 @@ textarea.paste-area:focus { border-color: var(--accent); }
 .cybernet-step-content ul { margin: 8px 0 0 18px; color: var(--text-dim); font-size: 12px; }
 .cybernet-command-panel { flex: 1 1 56%; min-width: 0; box-sizing: border-box; }
 .command-panel-title { font-size: 11px; font-weight: 700; color: var(--text-dim); margin-bottom: 6px; }
+.command-panel-runner {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(245, 158, 11, 0.45);
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--warning);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+}
 #cybernet-step-command {
   width: 100%; height: 112px; resize: vertical;
   padding: 10px; border: 1px solid var(--border); border-radius: 8px;
@@ -1087,6 +1098,50 @@ textarea.paste-area:focus { border-color: var(--accent); }
 }
 .command-panel-note { margin-top: 6px; color: var(--warning); font-size: 11px; }
 .cybernet-tutorial-nav { margin-top: 10px; justify-content: flex-end; }
+.sas-guide-panel {
+  border-radius: 12px;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.38), 0 0 24px rgba(245, 158, 11, 0.38);
+  animation: sasGuidePanelGlow 1.05s ease-in-out infinite;
+}
+.sas-guide-glow {
+  position: relative;
+  border-color: rgba(56, 189, 248, 0.95) !important;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.35), 0 0 30px rgba(56, 189, 248, 0.75) !important;
+  animation: sasGuideButtonGlow 0.95s ease-in-out infinite;
+}
+.sas-guide-glow::after {
+  content: "LOOK HERE";
+  position: absolute;
+  right: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.96);
+  color: #06111f;
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: .05em;
+  white-space: nowrap;
+  animation: sasGuideArrowBounce 0.7s ease-in-out infinite;
+}
+.sas-guide-drop {
+  border-color: rgba(56, 189, 248, 0.95) !important;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.35), 0 0 32px rgba(56, 189, 248, 0.65) !important;
+  animation: sasGuideButtonGlow 0.95s ease-in-out infinite;
+}
+@keyframes sasGuideButtonGlow {
+  0%, 100% { filter: brightness(1); transform: translateY(0); }
+  50% { filter: brightness(1.24); transform: translateY(-1px); }
+}
+@keyframes sasGuidePanelGlow {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.28), 0 0 18px rgba(245, 158, 11, 0.28); }
+  50% { box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.62), 0 0 34px rgba(245, 158, 11, 0.55); }
+}
+@keyframes sasGuideArrowBounce {
+  0%, 100% { transform: translate(-2px, -50%); }
+  50% { transform: translate(-10px, -50%); }
+}
 .cybernet-manifest-summary {
   margin-top: 12px;
   padding: 10px 12px;
@@ -1114,6 +1169,21 @@ textarea.paste-area:focus { border-color: var(--accent); }
 @media (max-width: 900px) {
   .cybernet-tutorial-head, .cybernet-step-card { flex-direction: column; }
   .cybernet-tutorial-actions { flex-wrap: wrap; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sas-guide-panel,
+  .sas-guide-glow,
+  .sas-guide-glow::after,
+  .sas-guide-drop,
+  .cybernet-progress-rail li.active {
+    animation: none !important;
+  }
+
+  .sas-guide-glow {
+    outline: 3px solid rgba(56, 189, 248, 0.9);
+    outline-offset: 2px;
+  }
 }
 
 @media (max-width: 480px) {
@@ -1169,11 +1239,19 @@ textarea.paste-area:focus { border-color: var(--accent); }
   border-color: var(--accent);
   color: #fff;
   background: rgba(79,142,247,0.35);
+  box-shadow: 0 0 18px rgba(79,142,247,0.45);
+  animation: sasGuideButtonGlow 1.4s ease-in-out infinite;
 }
 
 .cybernet-progress-rail li.done {
   border-color: rgba(34, 197, 94, 0.35);
   color: var(--success);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cybernet-progress-rail li.active {
+    animation: none !important;
+  }
 }
 
 .cybernet-hero-actions {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -143,7 +143,10 @@
         </details>
       </div>
       <div class="cybernet-command-panel" id="cybernet-command-panel">
-        <div class="command-panel-title">Command</div>
+        <div class="command-panel-title">Command to run outside the dashboard</div>
+        <div class="command-panel-runner" id="cybernet-command-runner">
+          You run this on an admin machine. The dashboard does not run commands; it only reads the files you drop back in.
+        </div>
         <textarea id="cybernet-step-command" readonly spellcheck="false"></textarea>
         <div class="command-panel-note" id="cybernet-step-note"></div>
       </div>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -608,57 +608,70 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Prepare your target list',
     railLabel: 'Targets',
-    body: 'Start with one hostname or IP per line. Keep this file boring and repeatable so a new technician can rerun the same workflow without hand-editing commands.',
+    body: 'First, make a simple list of the computers you want to check. Put one computer name or IP address on each line. This only prepares a local file for the next steps.',
     command: "mkdir -p /tmp/sas-cybernet\nprintf '%s\\n' 'WMH300OPR001' 'WMH300OPR002' > /tmp/sas-cybernet/targets.txt",
     checks: [
-      'Use hostnames, IPv4 addresses, or IPv6 addresses only.',
-      'Do not paste passwords, usernames, or ticket notes into the target file.',
-      'Optional: normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
+      'Use only computer names, IPv4 addresses, or IPv6 addresses.',
+      'Do not paste passwords, usernames, tickets, or notes into this file.',
+      'If the list came from another source, you can normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
     ],
-    note: 'This step is local-only; it does not touch target devices.',
+    nextAction: 'Copy this local setup command, run it on your admin machine, then come back and click Next.',
+    note: 'This step only creates a local targets file. It does not touch target devices.',
     optional: false
   },
   {
     title: 'Prove network posture first',
     railLabel: 'Network posture',
-    body: 'Before blaming the product, prove the machine is on the right network path. This catches guest-network and segmented-network failures early.',
+    body: 'Now check whether your admin machine can see the targets at all. This catches guest Wi-Fi, wrong VLAN, DNS, SMB, and RPC problems before anyone blames the tool.',
     command: 'bash bash/transport/sas-network-preflight.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --ports 135,445,3389,9100 \\\n  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru',
-    checks: ['DNS should resolve internal hostnames when you expect internal reachability.', 'SMB/445 and RPC/135 failures on every target often mean network posture, not code failure.', 'Classify guest-network blocking separately from product defects.'],
+    checks: [
+      'If internal names do not resolve, the machine is probably not on the right network path.',
+      'If SMB/445 and RPC/135 fail for every target, treat that as a network posture problem first.',
+      'Classify guest-network blocking separately from product defects.'
+    ],
+    nextAction: 'Run the matching command outside the dashboard. When it finishes, drop network_preflight.csv into Load Evidence.',
     note: 'Load network_preflight.csv via Load Evidence after the command finishes.',
     optional: false
   },
   {
     title: 'Acquire Cybernet identity evidence',
     railLabel: 'Identity evidence',
-    body: 'Collect read-only workstation identity evidence. The adapter records what it can safely observe, such as DNS, ping, ARP/MAC hints, and optional transport notes.',
+    body: 'Collect read-only identity clues from each target. The command records what it can safely observe, such as DNS, ping status, MAC hints, and transport notes.',
     command: 'bash bash/transport/sas-workstation-identity.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru',
-    checks: ['Treat hostname, MAC, serial, and IP as separate evidence fields.', 'Do not use reachability alone as Cybernet identity proof.', 'Preserve unknown or partial rows; they are useful triage evidence.'],
+    checks: [
+      'Hostname, MAC, serial, and IP are separate clues; do not mix them together.',
+      'Do not use reachability alone as Cybernet identity proof.',
+      'Keep unknown or partial rows; they are useful triage evidence.'
+    ],
+    nextAction: 'Run the matching command outside the dashboard. When it finishes, drop workstation_identity.csv into Load Evidence.',
     note: 'Load workstation_identity.csv back via Load Evidence for searchable protocol evidence.',
     optional: false
   },
   {
     title: 'Optional reachability check',
     railLabel: 'Reachability',
-    body: 'Low-noise port confirmation on an approved target list. Skip this step if posture and identity evidence are already sufficient.',
+    body: 'This is an extra confirmation pass for approved targets. Use it only when you need low-noise port evidence after the posture and identity checks.',
     command: 'mkdir -p logs/targets logs/nmap\ncp /tmp/sas-cybernet/targets.txt logs/targets/cybernet_confirm_hosts.txt\nbash survey/sas-run-naabu-pipeline.sh --site cybernet \\\n  --profile keyports_cybernet_json \\\n  --list logs/targets/cybernet_confirm_hosts.txt \\\n  --out logs/nmap/cybernet_naabu.json',
     checks: [
       'Profile: keyports_cybernet_json (-ec -silent -json).',
       'Doctrine: docs/LOW_NOISE_SURVEY_DOCTRINE.md — local evidence only, no target-side writes.',
-      'This step is optional; do not treat it as mandatory for every survey.'
+      'This step is optional. Skip it when the earlier evidence is enough.'
     ],
+    nextAction: 'Run this only if the target list is approved for reachability confirmation, then load cybernet_naabu.json as optional evidence.',
     note: 'Advanced: keyports_cybernet_json · output logs/nmap/cybernet_naabu.json',
     optional: true
   },
   {
     title: 'Load evidence and review',
     railLabel: 'Review package',
-    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Normalized target manifests (cybernet_targets.csv) are imported separately from network or identity evidence.',
+    body: 'Bring the files back to this dashboard. Drag the CSV or JSON outputs into Load Evidence, then review the summary before calling the result good or bad.',
     command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/cybernet_*_targets.csv (manifest, not evidence)',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
       'Treat manifest rows as target lists, not reachability or identity proof.'
     ],
+    nextAction: 'Click Load resulting evidence, then drop the files into the highlighted box.',
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
   }
@@ -675,12 +688,15 @@ function initCybernetTutorial() {
   const kicker = document.getElementById('cybernet-step-kicker');
   const checks = document.getElementById('cybernet-step-checks');
   const command = document.getElementById('cybernet-step-command');
+  const runner = document.getElementById('cybernet-command-runner');
   const note = document.getElementById('cybernet-step-note');
   const commandPanel = document.getElementById('cybernet-command-panel');
   const prev = document.getElementById('cybernet-prev');
   const next = document.getElementById('cybernet-next');
   const copy = document.getElementById('cybernet-copy');
   const wizardFooter = document.getElementById('cybernet-wizard-footer');
+  const loadEvidenceEnd = document.getElementById('cybernet-load-evidence-end');
+  const dropZone = document.getElementById('drop-zone');
   const progressRail = document.getElementById('cybernet-progress-rail');
 
   function updateProgressRail() {
@@ -688,6 +704,15 @@ function initCybernetTutorial() {
       li.classList.toggle('active', i === idx);
       li.classList.toggle('done', i < idx);
     });
+  }
+
+  function updateGuideState(hasCommand) {
+    const finalStep = idx === CYBERNET_TUTORIAL_STEPS.length - 1;
+    copy?.classList.toggle('sas-guide-glow', hasCommand && !copiedThisStep);
+    next?.classList.toggle('sas-guide-glow', (hasCommand && copiedThisStep) || (!hasCommand && !finalStep));
+    loadEvidenceEnd?.classList.toggle('sas-guide-glow', finalStep);
+    dropZone?.classList.toggle('sas-guide-drop', finalStep);
+    commandPanel?.classList.toggle('sas-guide-panel', hasCommand && !copiedThisStep);
   }
 
   function render() {
@@ -701,12 +726,14 @@ function initCybernetTutorial() {
     const hasCommand = !!(step.command && !step.command.startsWith('# Use Load Evidence'));
     if (commandPanel) commandPanel.classList.toggle('hidden', !hasCommand);
     if (command) command.value = hasCommand ? step.command : '';
+    if (runner) runner.textContent = step.nextAction || 'Copy the command, run it outside the dashboard, then load the output file here.';
     if (note) note.textContent = step.note;
     prev.disabled = idx === 0;
-    next.textContent = idx === CYBERNET_TUTORIAL_STEPS.length - 1 ? 'Finish ✓' : 'Next →';
+    next.textContent = idx === CYBERNET_TUTORIAL_STEPS.length - 1 ? 'Finish: Load Evidence' : hasCommand ? 'Next after running it →' : 'Next →';
     copy?.classList.toggle('hidden', !hasCommand);
     wizardFooter?.classList.toggle('hidden', idx !== CYBERNET_TUTORIAL_STEPS.length - 1);
     updateProgressRail();
+    updateGuideState(hasCommand);
   }
 
   function copyCommand() {
@@ -726,6 +753,7 @@ function initCybernetTutorial() {
         copiedThisStep = true;
         toast('Command copied.', 'success');
         if (note) note.textContent = 'Command copied.';
+        updateGuideState(true);
       })
       .catch(() => {
         toast('Select and copy the command manually.', 'warning');
@@ -741,7 +769,7 @@ function initCybernetTutorial() {
     const step = CYBERNET_TUTORIAL_STEPS[idx];
     const hasCommand = !!(step?.command && !step?.command.startsWith('# Use Load Evidence'));
     if (hasCommand && !copiedThisStep && !step.optional) {
-      toast('Copy the command first, or use Show details if you need to skip.', 'warning');
+      toast('Copy the command first, run it outside the dashboard, then come back for Next.', 'warning');
       return;
     }
     if (idx < CYBERNET_TUTORIAL_STEPS.length - 1) {

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -4386,57 +4386,70 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Prepare your target list',
     railLabel: 'Targets',
-    body: 'Start with one hostname or IP per line. Keep this file boring and repeatable so a new technician can rerun the same workflow without hand-editing commands.',
+    body: 'First, make a simple list of the computers you want to check. Put one computer name or IP address on each line. This only prepares a local file for the next steps.',
     command: "mkdir -p /tmp/sas-cybernet\nprintf '%s\\n' 'WMH300OPR001' 'WMH300OPR002' > /tmp/sas-cybernet/targets.txt",
     checks: [
-      'Use hostnames, IPv4 addresses, or IPv6 addresses only.',
-      'Do not paste passwords, usernames, or ticket notes into the target file.',
-      'Optional: normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
+      'Use only computer names, IPv4 addresses, or IPv6 addresses.',
+      'Do not paste passwords, usernames, tickets, or notes into this file.',
+      'If the list came from another source, you can normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
     ],
-    note: 'This step is local-only; it does not touch target devices.',
+    nextAction: 'Copy this local setup command, run it on your admin machine, then come back and click Next.',
+    note: 'This step only creates a local targets file. It does not touch target devices.',
     optional: false
   },
   {
     title: 'Prove network posture first',
     railLabel: 'Network posture',
-    body: 'Before blaming the product, prove the machine is on the right network path. This catches guest-network and segmented-network failures early.',
+    body: 'Now check whether your admin machine can see the targets at all. This catches guest Wi-Fi, wrong VLAN, DNS, SMB, and RPC problems before anyone blames the tool.',
     command: 'bash bash/transport/sas-network-preflight.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --ports 135,445,3389,9100 \\\n  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru',
-    checks: ['DNS should resolve internal hostnames when you expect internal reachability.', 'SMB/445 and RPC/135 failures on every target often mean network posture, not code failure.', 'Classify guest-network blocking separately from product defects.'],
+    checks: [
+      'If internal names do not resolve, the machine is probably not on the right network path.',
+      'If SMB/445 and RPC/135 fail for every target, treat that as a network posture problem first.',
+      'Classify guest-network blocking separately from product defects.'
+    ],
+    nextAction: 'Run the matching command outside the dashboard. When it finishes, drop network_preflight.csv into Load Evidence.',
     note: 'Load network_preflight.csv via Load Evidence after the command finishes.',
     optional: false
   },
   {
     title: 'Acquire Cybernet identity evidence',
     railLabel: 'Identity evidence',
-    body: 'Collect read-only workstation identity evidence. The adapter records what it can safely observe, such as DNS, ping, ARP/MAC hints, and optional transport notes.',
+    body: 'Collect read-only identity clues from each target. The command records what it can safely observe, such as DNS, ping status, MAC hints, and transport notes.',
     command: 'bash bash/transport/sas-workstation-identity.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru',
-    checks: ['Treat hostname, MAC, serial, and IP as separate evidence fields.', 'Do not use reachability alone as Cybernet identity proof.', 'Preserve unknown or partial rows; they are useful triage evidence.'],
+    checks: [
+      'Hostname, MAC, serial, and IP are separate clues; do not mix them together.',
+      'Do not use reachability alone as Cybernet identity proof.',
+      'Keep unknown or partial rows; they are useful triage evidence.'
+    ],
+    nextAction: 'Run the matching command outside the dashboard. When it finishes, drop workstation_identity.csv into Load Evidence.',
     note: 'Load workstation_identity.csv back via Load Evidence for searchable protocol evidence.',
     optional: false
   },
   {
     title: 'Optional reachability check',
     railLabel: 'Reachability',
-    body: 'Low-noise port confirmation on an approved target list. Skip this step if posture and identity evidence are already sufficient.',
+    body: 'This is an extra confirmation pass for approved targets. Use it only when you need low-noise port evidence after the posture and identity checks.',
     command: 'mkdir -p logs/targets logs/nmap\ncp /tmp/sas-cybernet/targets.txt logs/targets/cybernet_confirm_hosts.txt\nbash survey/sas-run-naabu-pipeline.sh --site cybernet \\\n  --profile keyports_cybernet_json \\\n  --list logs/targets/cybernet_confirm_hosts.txt \\\n  --out logs/nmap/cybernet_naabu.json',
     checks: [
       'Profile: keyports_cybernet_json (-ec -silent -json).',
       'Doctrine: docs/LOW_NOISE_SURVEY_DOCTRINE.md — local evidence only, no target-side writes.',
-      'This step is optional; do not treat it as mandatory for every survey.'
+      'This step is optional. Skip it when the earlier evidence is enough.'
     ],
+    nextAction: 'Run this only if the target list is approved for reachability confirmation, then load cybernet_naabu.json as optional evidence.',
     note: 'Advanced: keyports_cybernet_json · output logs/nmap/cybernet_naabu.json',
     optional: true
   },
   {
     title: 'Load evidence and review',
     railLabel: 'Review package',
-    body: 'Drag recognized evidence CSVs into Load Evidence, then review the summary. Normalized target manifests (cybernet_targets.csv) are imported separately from network or identity evidence.',
+    body: 'Bring the files back to this dashboard. Drag the CSV or JSON outputs into Load Evidence, then review the summary before calling the result good or bad.',
     command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/cybernet_*_targets.csv (manifest, not evidence)',
     checks: [
       'Classify environment blocks separately from product defects.',
       'Keep smoke-test evidence separate from feature validation.',
       'Treat manifest rows as target lists, not reachability or identity proof.'
     ],
+    nextAction: 'Click Load resulting evidence, then drop the files into the highlighted box.',
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
   }
@@ -4453,12 +4466,15 @@ function initCybernetTutorial() {
   const kicker = document.getElementById('cybernet-step-kicker');
   const checks = document.getElementById('cybernet-step-checks');
   const command = document.getElementById('cybernet-step-command');
+  const runner = document.getElementById('cybernet-command-runner');
   const note = document.getElementById('cybernet-step-note');
   const commandPanel = document.getElementById('cybernet-command-panel');
   const prev = document.getElementById('cybernet-prev');
   const next = document.getElementById('cybernet-next');
   const copy = document.getElementById('cybernet-copy');
   const wizardFooter = document.getElementById('cybernet-wizard-footer');
+  const loadEvidenceEnd = document.getElementById('cybernet-load-evidence-end');
+  const dropZone = document.getElementById('drop-zone');
   const progressRail = document.getElementById('cybernet-progress-rail');
 
   function updateProgressRail() {
@@ -4466,6 +4482,15 @@ function initCybernetTutorial() {
       li.classList.toggle('active', i === idx);
       li.classList.toggle('done', i < idx);
     });
+  }
+
+  function updateGuideState(hasCommand) {
+    const finalStep = idx === CYBERNET_TUTORIAL_STEPS.length - 1;
+    copy?.classList.toggle('sas-guide-glow', hasCommand && !copiedThisStep);
+    next?.classList.toggle('sas-guide-glow', (hasCommand && copiedThisStep) || (!hasCommand && !finalStep));
+    loadEvidenceEnd?.classList.toggle('sas-guide-glow', finalStep);
+    dropZone?.classList.toggle('sas-guide-drop', finalStep);
+    commandPanel?.classList.toggle('sas-guide-panel', hasCommand && !copiedThisStep);
   }
 
   function render() {
@@ -4479,12 +4504,14 @@ function initCybernetTutorial() {
     const hasCommand = !!(step.command && !step.command.startsWith('# Use Load Evidence'));
     if (commandPanel) commandPanel.classList.toggle('hidden', !hasCommand);
     if (command) command.value = hasCommand ? step.command : '';
+    if (runner) runner.textContent = step.nextAction || 'Copy the command, run it outside the dashboard, then load the output file here.';
     if (note) note.textContent = step.note;
     prev.disabled = idx === 0;
-    next.textContent = idx === CYBERNET_TUTORIAL_STEPS.length - 1 ? 'Finish ✓' : 'Next →';
+    next.textContent = idx === CYBERNET_TUTORIAL_STEPS.length - 1 ? 'Finish: Load Evidence' : hasCommand ? 'Next after running it →' : 'Next →';
     copy?.classList.toggle('hidden', !hasCommand);
     wizardFooter?.classList.toggle('hidden', idx !== CYBERNET_TUTORIAL_STEPS.length - 1);
     updateProgressRail();
+    updateGuideState(hasCommand);
   }
 
   function copyCommand() {
@@ -4504,6 +4531,7 @@ function initCybernetTutorial() {
         copiedThisStep = true;
         toast('Command copied.', 'success');
         if (note) note.textContent = 'Command copied.';
+        updateGuideState(true);
       })
       .catch(() => {
         toast('Select and copy the command manually.', 'warning');
@@ -4519,7 +4547,7 @@ function initCybernetTutorial() {
     const step = CYBERNET_TUTORIAL_STEPS[idx];
     const hasCommand = !!(step?.command && !step?.command.startsWith('# Use Load Evidence'));
     if (hasCommand && !copiedThisStep && !step.optional) {
-      toast('Copy the command first, or use Show details if you need to skip.', 'warning');
+      toast('Copy the command first, run it outside the dashboard, then come back for Next.', 'warning');
       return;
     }
     if (idx < CYBERNET_TUTORIAL_STEPS.length - 1) {

--- a/dashboard/js/cybernet-os-preflight.js
+++ b/dashboard/js/cybernet-os-preflight.js
@@ -4,6 +4,7 @@
   'use strict';
 
   const STORAGE_KEY = 'sasCybernetTutorialOs';
+  const AUTO = 'auto-mixed';
   const WINDOWS = 'windows-powershell';
   const GIT_BASH = 'windows-gitbash';
   const BASH = 'bash-posix';
@@ -73,20 +74,21 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
   --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru`;
 
   const notes = {
+    [AUTO]: 'Auto / mixed mode: do not choose target OS up front. Use the section for the admin shell you are standing at; the results will tell you what the target looks like.',
     [WINDOWS]: 'Windows PowerShell mode uses Resolve-DnsName, Test-Connection, and Test-NetConnection.',
     [GIT_BASH]: 'Windows Git Bash mode keeps Bash output paths but forces Windows ping.exe syntax to avoid false NoPing results.',
     [BASH]: 'Linux/macOS/WSL Bash mode uses POSIX ping flags. Do not use this for Git Bash on a Windows admin box.'
   };
 
   function normalizeOs(value) {
-    return value === WINDOWS || value === GIT_BASH || value === BASH ? value : WINDOWS;
+    return value === AUTO || value === WINDOWS || value === GIT_BASH || value === BASH ? value : AUTO;
   }
 
   function selectedOs() {
     try {
       return normalizeOs(localStorage.getItem(STORAGE_KEY));
     } catch (_) {
-      return WINDOWS;
+      return AUTO;
     }
   }
 
@@ -104,9 +106,10 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
     card.id = 'cybernet-os-preflight';
     card.className = 'cybernet-os-preflight';
     card.innerHTML = `
-      <div class="cybernet-os-title">Preflight environment</div>
-      <label for="cybernet-os-select">Choose the OS/shell that will run the commands:</label>
+      <div class="cybernet-os-title">Optional command filter</div>
+      <label for="cybernet-os-select">Leave this on Auto for mixed sites. Pick one only if you already know which admin shell will run the command:</label>
       <select id="cybernet-os-select">
+        <option value="auto-mixed">Auto / mixed environment — show Windows PowerShell + Bash</option>
         <option value="windows-powershell">Windows PowerShell / Windows admin box</option>
         <option value="windows-gitbash">Windows Git Bash / Windows ping.exe</option>
         <option value="bash-posix">Linux/macOS/WSL Bash</option>
@@ -137,9 +140,40 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
   }
 
   function preflightCommandFor(os) {
+    if (os === AUTO) {
+      return [
+        '# Auto / mixed site: do not choose target OS yet.',
+        '# Copy and run ONE section below from the admin shell you are using.',
+        '',
+        '# --- Windows PowerShell admin box ---',
+        WINDOWS_PREFLIGHT,
+        '',
+        '# --- Windows Git Bash admin box ---',
+        GIT_BASH_PREFLIGHT,
+        '',
+        '# --- Linux/macOS/WSL Bash admin box ---',
+        BASH_PREFLIGHT
+      ].join('\n');
+    }
     if (os === WINDOWS) return WINDOWS_PREFLIGHT;
     if (os === GIT_BASH) return GIT_BASH_PREFLIGHT;
     return BASH_PREFLIGHT;
+  }
+
+  function identityCommandFor(os) {
+    if (os === AUTO) {
+      return [
+        '# Auto / mixed site: do not choose target OS yet.',
+        '# Copy and run ONE section below from the admin shell you are using.',
+        '',
+        '# --- Windows PowerShell admin box ---',
+        WINDOWS_IDENTITY,
+        '',
+        '# --- Bash admin box ---',
+        BASH_IDENTITY
+      ].join('\n');
+    }
+    return os === WINDOWS ? WINDOWS_IDENTITY : BASH_IDENTITY;
   }
 
   function patchCurrentStep() {
@@ -151,18 +185,22 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
 
     const os = selectedOs();
     const title = titleEl.textContent.trim();
-    if (osNoteEl) osNoteEl.textContent = notes[os] || notes[WINDOWS];
+    if (osNoteEl) osNoteEl.textContent = notes[os] || notes[AUTO];
 
     if (title === 'Prove network posture first') {
       commandEl.value = preflightCommandFor(os);
-      if (noteEl) noteEl.textContent = os === WINDOWS
+      if (noteEl) noteEl.textContent = os === AUTO
+        ? 'Run one matching section outside the dashboard, then drag network_preflight.csv back into Load Evidence.'
+        : os === WINDOWS
         ? 'Run this in Windows PowerShell, then drag C:\\Temp\\sas-cybernet\\network_preflight.csv into the dashboard.'
         : 'Load network_preflight.csv into the Network tab after the command finishes.';
     }
 
     if (title === 'Acquire Cybernet identity evidence') {
-      commandEl.value = os === WINDOWS ? WINDOWS_IDENTITY : BASH_IDENTITY;
-      if (noteEl) noteEl.textContent = os === WINDOWS
+      commandEl.value = identityCommandFor(os);
+      if (noteEl) noteEl.textContent = os === AUTO
+        ? 'Run one matching section outside the dashboard, then drag workstation_identity.csv back into Load Evidence.'
+        : os === WINDOWS
         ? 'Run this in Windows PowerShell to avoid Git Bash ping/DNS mismatch, then drag C:\\Temp\\sas-cybernet\\workstation_identity.csv into the dashboard.'
         : 'Load workstation_identity.csv back into the dashboard for searchable protocol evidence.';
     }


### PR DESCRIPTION
## Summary

Field techs reported the Cybernet survey wizard was confusing: step 1 forced a Windows-vs-Linux choice, nothing said who runs the commands, the language was jargon-heavy, and there were no visual cues guiding the next action. This makes the wizard usable in the field.

- OS preflight now defaults to **Auto / mixed**, showing both Windows PowerShell and Bash command sections so mixed sites are not blocked by an early OS decision; explicit OS picks still filter to one shell.
- Adds a persistent "you run this outside the dashboard" runner banner plus per-step next-action guidance, so it is clear the dashboard does not execute commands.
- Rewrites the five wizard steps in plain field-tech language while preserving the doctrine commands and test-contract tokens (`--targets-file /tmp/sas-cybernet/targets.txt`, `keyports_cybernet_json`, low-noise survey language).
- Adds bold guided glow/arrow cues for Copy, Next, and Load Evidence, with a `prefers-reduced-motion` fallback.
- Rebuilds the dashboard bundle.

PowerShell remains first-class and always shown alongside Bash, per repo doctrine.

## Test plan

- [x] `node dashboard/build-bundle.js`
- [x] `node dashboard/smoke-test.js` (parser + shell + tour + start-button contracts)
- [x] `bash Tests/bash/test_dashboard_tutorial_launcher_contracts.sh`
