### PR TITLE
feat(ui): split setup and Cybernet tutorials

### DIFF
--- a/.github/workflows/dashboard-smoke.yml
+++ b/.github/workflows/dashboard-smoke.yml
@@ -27,6 +27,8 @@ jobs:
           node --check dashboard/js/bundle.js
           node --check dashboard/js/cybernet-os-preflight.js
           node --check dashboard/js/launch-cybernet-tutorial.js
+          node --check dashboard/js/launch-repo-setup-tutorial.js
+          node --check dashboard/js/repo-setup-tutorial.js
       - name: Dashboard parser smoke test
         run: node dashboard/smoke-test.js
       - name: Dashboard Start-button runtime smoke test

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ bin/*
 **/obj/
 # Published host output staging (see docs/GUI_HOST_MIGRATION.md)
 tools/publish/
+# Downloaded Microsoft .NET bootstrap installers (system-wide install cache)
+tools/cache/
 
 # Local reference tree (install scripts, shortcuts, installers — not product code; never commit)
 tech emulation/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ For lay users opening the **web dashboard**, the front door is a double-click la
 
 Canonical agent reference: [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).
 
+First-run dependency bootstrap reference: [`docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md).
+
 Planned `.exe` shortcut sprint: [`docs/DASHBOARD_EXE_FUTURE_SPRINT.md`](docs/DASHBOARD_EXE_FUTURE_SPRINT.md).
 
 Do **not** direct field users to `python3 -m http.server`, raw `dotnet` commands, or Bash survey scripts as the default dashboard path.

--- a/Config/dotnet-bootstrap.json
+++ b/Config/dotnet-bootstrap.json
@@ -1,0 +1,37 @@
+{
+  "schema": 1,
+  "source": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json",
+  "channel": "8.0",
+  "release": "8.0.28",
+  "sdkVersion": "8.0.422",
+  "cacheDir": "tools/cache/dotnet",
+  "installMode": "system-wide",
+  "components": {
+    "aspnetcoreRuntime": {
+      "displayName": ".NET 8 ASP.NET Core Runtime",
+      "sharedFramework": "Microsoft.AspNetCore.App",
+      "versionPrefix": "8.",
+      "fileName": "aspnetcore-runtime-8.0.28-win-x64.exe",
+      "url": "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.28/aspnetcore-runtime-8.0.28-win-x64.exe",
+      "sha512": "b8bccd46b5b167c4250882105b8c01c46e5ea96dcb9c2de1d35add26afeab86fc499003822fc8341d5e8855283a5c615e81c6a851f7f721aed535eaeb2e19077",
+      "silentArgs": "/install /quiet /norestart"
+    },
+    "windowsDesktopRuntime": {
+      "displayName": ".NET 8 Windows Desktop Runtime",
+      "sharedFramework": "Microsoft.WindowsDesktop.App",
+      "versionPrefix": "8.",
+      "fileName": "windowsdesktop-runtime-8.0.28-win-x64.exe",
+      "url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/8.0.28/windowsdesktop-runtime-8.0.28-win-x64.exe",
+      "sha512": "931e5463994ae1d4984bcc05baf940979511185ec1a9bca0a5c0e5963d290fbfe3b348e5bd804fecbe698669374a34cee20e6d1e220e275e1536d55c848fc068",
+      "silentArgs": "/install /quiet /norestart"
+    },
+    "sdk": {
+      "displayName": ".NET 8 SDK",
+      "sdkVersionPrefix": "8.",
+      "fileName": "dotnet-sdk-8.0.422-win-x64.exe",
+      "url": "https://builds.dotnet.microsoft.com/dotnet/Sdk/8.0.422/dotnet-sdk-8.0.422-win-x64.exe",
+      "sha512": "13572cb985ca2feb08c093c4f0070ba6c5f75ff67013626e857926e4f870aed87f06db5738a377a3f2f5cdae8093a6b7046b2492a1f5e0bc51261e0cec4e9418",
+      "silentArgs": "/install /quiet /norestart"
+    }
+  }
+}

--- a/Launch-SysAdminSuiteDashboard.Host.bat
+++ b/Launch-SysAdminSuiteDashboard.Host.bat
@@ -2,31 +2,31 @@
 :: Launch-SysAdminSuiteDashboard.Host.bat
 :: Field-safe dashboard host launcher.
 ::
-:: Discovers the SysAdminSuite dashboard host executable. On first run, if the
-:: host is missing, this AUTOMATICALLY builds it via
-:: tools\publish-dashboard-entrypoint.ps1 so the field user never has to run a
-:: publish command by hand. It then starts the tray host which serves
-:: http://127.0.0.1:5000 (Open Dashboard, Copy URL, Stop).
+:: Discovers the SysAdminSuite dashboard host executable. On first run this
+:: calls the Bash bootstrap, which can install the official Microsoft .NET 8
+:: dependencies system-wide and build the host when it is missing. It then
+:: starts the tray host which serves http://127.0.0.1:5000 (Open Dashboard,
+:: Copy URL, Stop).
 ::
 :: Exit codes (consumed by START-HERE-SysAdminSuite-Dashboard.bat):
 ::   0  host found or built, and started
-::   2  .NET SDK (dotnet) missing - cannot build on this machine
-::   3  auto-publish ran but the host could not be built or located
+::   2  Git Bash, curl, download, or checksum verification failed
+::   3  Microsoft .NET install/build failed or needs IT/admin attention
 
 setlocal enabledelayedexpansion
 set "ROOT=%~dp0"
 
-call :find_host
-if defined HOST_EXE goto :start_host
+call :find_bash
+if not defined BASH_EXE (
+    echo Git Bash was not found. Install Git for Windows or use the packaged dashboard field release.
+    exit /b 2
+)
 
-:: Host missing on a source checkout: prepare automatically. Packaged field
-:: releases ship app\bin\SysAdminSuite.DashboardHost.exe and skip this path.
-echo Source checkout: preparing the dashboard app for first use. This can take a minute...
-where dotnet >nul 2>nul
-if errorlevel 1 exit /b 2
-
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%ROOT%tools\publish-dashboard-entrypoint.ps1"
-if errorlevel 1 exit /b 3
+echo Preparing dashboard dependencies and host for first use...
+"%BASH_EXE%" -lc "cd '%ROOT:\=/%' && bash scripts/ensure-dashboard-host.sh"
+set "ENSURE_RC=%errorlevel%"
+if "%ENSURE_RC%"=="2" exit /b 2
+if not "%ENSURE_RC%"=="0" exit /b 3
 
 call :find_host
 if not defined HOST_EXE exit /b 3
@@ -49,4 +49,13 @@ if not defined HOST_EXE if exist "%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuit
 if not defined HOST_EXE if exist "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe"
 if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe"
 if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe"
+exit /b 0
+
+:find_bash
+set "BASH_EXE="
+if exist "%ProgramFiles%\Git\bin\bash.exe" set "BASH_EXE=%ProgramFiles%\Git\bin\bash.exe"
+if defined BASH_EXE exit /b 0
+for /f "delims=" %%B in ('where bash 2^>nul') do (
+    if not defined BASH_EXE set "BASH_EXE=%%B"
+)
 exit /b 0

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Double-click:
 
 `START-HERE-SysAdminSuite-Dashboard.bat`
 
-This opens the local dashboard and tutorial at `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
+This opens the local dashboard and Repo Setup tutorial at `http://127.0.0.1:5000/dashboard/?tutorial=setup`.
 
-On first run, the launcher may **automatically prepare (build) the dashboard app** before opening the browser. Field users do not run any command by hand. If the workstation cannot build it (for example, no .NET SDK), the launcher asks for the packaged SysAdminSuite Dashboard **field release** or IT/admin preparation.
+On first run, the launcher may **automatically prepare the dashboard app** before opening the browser. If Microsoft .NET 8 dependencies are missing, it uses official Microsoft installers with checksum verification, then builds the local dashboard host when needed. Field users do not run any command by hand.
 
-**No .NET SDK on the machine?** Use the pre-built field release ZIP ([`docs/DASHBOARD_FIELD_RELEASE.md`](docs/DASHBOARD_FIELD_RELEASE.md)), not a raw git clone.
+If downloads or administrator approval are blocked, use the pre-built field release ZIP ([`docs/DASHBOARD_FIELD_RELEASE.md`](docs/DASHBOARD_FIELD_RELEASE.md)) or have IT/admin prepare the workstation. Bootstrap details: [`docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md).
 
 Updates are opt-in. If a newer `main` or field package is available, the
 launcher prompts before applying it. See [`docs/APPROVED_UPDATE_FLOW.md`](docs/APPROVED_UPDATE_FLOW.md).

--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -62,8 +62,8 @@ flowchart TD
 
 Use the Cybernet-first dashboard when you want a guided wizard instead of memorizing CLI steps. Live Mode is **not** the front door — it lives under **Advanced Tools → Generate Survey Commands**.
 
-1. **Open the dashboard** — double-click [`START-HERE-SysAdminSuite-Dashboard.bat`](START-HERE-SysAdminSuite-Dashboard.bat) at the repo root. This starts the local host and opens `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`. See [`START-HERE-SysAdminSuite.md`](START-HERE-SysAdminSuite.md) and [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).
-2. **Start Cybernet Survey** — opens the wizard (progress rail: Targets → Network posture → Identity evidence → Reachability → Review package).
+1. **Open the dashboard** — double-click [`START-HERE-SysAdminSuite-Dashboard.bat`](START-HERE-SysAdminSuite-Dashboard.bat) at the repo root. This starts the local host and opens `http://127.0.0.1:5000/dashboard/?tutorial=setup`; from there click **Start Cybernet Survey**. For a direct survey deep link, use [`Start-CybernetSurveyTutorial.cmd`](Start-CybernetSurveyTutorial.cmd). See [`START-HERE-SysAdminSuite.md`](START-HERE-SysAdminSuite.md) and [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).
+2. **Start Cybernet Survey** — opens the wizard (progress rail: Start → Load targets → Network posture → Identity evidence → Reachability → Review results).
 3. **Copy posture and identity commands** — run network preflight and workstation identity on the admin box; keep output local.
 4. **Optional reachability** — wizard step 4 is skippable; uses profile `keyports_cybernet_json` when you need low-noise port confirmation.
 5. **Load Evidence** — drop `network_preflight.csv`, `workstation_identity.csv`, optional reachability JSON, normalized target manifests, and AD population CSVs.

--- a/START-HERE-SysAdminSuite-Dashboard.bat
+++ b/START-HERE-SysAdminSuite-Dashboard.bat
@@ -9,8 +9,9 @@ echo ==========================================
 echo.
 echo Double-click launcher - no commands to memorize.
 echo This opens the local dashboard and tutorial.
-echo The first run may take a minute while the dashboard app is prepared.
-echo No internet is required to use the dashboard after that.
+echo The first run may take a minute while Microsoft .NET dependencies
+echo and the dashboard app are prepared.
+echo No internet is required after the dashboard dependencies are installed.
 echo.
 
 set "ROOT=%~dp0"
@@ -55,8 +56,10 @@ if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
     echo.
 ) else (
     echo Source checkout detected - the dashboard app may be prepared on first run.
-    echo If this machine has the .NET SDK, the launcher will build it automatically.
-    echo If not, ask for the packaged SysAdminSuite Dashboard field release instead.
+    echo If Microsoft .NET 8 is missing, the launcher can download the official Microsoft installers
+    echo and build the dashboard automatically.
+    echo If downloads or administrator approval are blocked, ask for the packaged
+    echo SysAdminSuite Dashboard field release instead.
     echo.
 )
 
@@ -70,17 +73,18 @@ if not exist "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" (
 )
 
 echo Starting the dashboard host^.^.^.
-echo If this is the first run, the dashboard app will be prepared automatically now.
+echo If this is the first run, dependencies and the dashboard app will be prepared automatically now.
 call "%ROOT%Launch-SysAdminSuiteDashboard.Host.bat" --no-browser
 set "RC=%errorlevel%"
 
 if "%RC%"=="2" (
     echo.
-    echo Source checkout without the .NET SDK ^(dotnet^).
+    echo The dashboard dependency download or verification could not complete.
     echo.
-    echo The dashboard app could not be built on this machine.
+    echo The dashboard app could not be prepared on this machine.
     echo.
-    echo This usually means the .NET SDK is missing or blocked.
+    echo This usually means Git Bash, curl, internet access, or Microsoft installer
+    echo checksum verification was blocked.
     echo.
     echo Ask for the packaged SysAdminSuite Dashboard field release ^(pre-built host under app\bin^),
     echo or have IT/admin prepare this workstation.
@@ -94,9 +98,10 @@ if "%RC%"=="2" (
 
 if not "%RC%"=="0" (
     echo.
-    echo The dashboard app could not be built on this machine.
+    echo The dashboard app could not be prepared on this machine.
     echo.
-    echo This usually means the .NET SDK is missing or blocked on a source checkout.
+    echo This usually means the Microsoft .NET install or dashboard build needs
+    echo IT/admin approval, or the workstation blocks the required Microsoft download.
     echo.
     echo Ask for the packaged SysAdminSuite Dashboard field release ^(pre-built host under app\bin^),
     echo or have IT/admin prepare this workstation.
@@ -130,12 +135,12 @@ if not "!HOST_UP!"=="1" (
     exit /b 1
 )
 
-echo Opening dashboard and Cybernet tutorial in your browser...
-start "" "http://127.0.0.1:5000/dashboard/?tutorial=cybernet"
+echo Opening dashboard and Repo Setup tutorial in your browser...
+start "" "http://127.0.0.1:5000/dashboard/?tutorial=setup"
 
 echo.
 echo If the page did not open, paste this into your browser:
-echo   http://127.0.0.1:5000/dashboard/?tutorial=cybernet
+echo   http://127.0.0.1:5000/dashboard/?tutorial=setup
 echo.
 echo A tray icon should appear. Right-click it for Open Dashboard, Copy URL, or Stop.
 echo.

--- a/START-HERE-SysAdminSuite.md
+++ b/START-HERE-SysAdminSuite.md
@@ -59,20 +59,20 @@ flowchart TD
 1. A small dashboard host starts on your computer (look for a tray icon near the clock).
 2. Your browser opens the local dashboard at:
 
-   `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`
+   `http://127.0.0.1:5000/dashboard/?tutorial=setup`
 
-3. The browser tab shows the Harold icon. Click **Start Cybernet Survey** to follow the guided tutorial.
+3. The browser tab shows the Harold icon. Follow **Repo Setup** first, then click **Start Cybernet Survey** for field survey work.
 
-On first run, the launcher may **automatically prepare (build) the dashboard app** for a minute before the browser opens. You do not need to run any command yourself. If this machine cannot build it (for example, no .NET SDK), the launcher will tell you to ask for the packaged SysAdminSuite Dashboard **field release** or have IT/admin prepare the workstation.
+On first run, the launcher may **automatically prepare the dashboard app** for a minute before the browser opens. If Microsoft .NET 8 dependencies are missing, it can download official Microsoft installers, verify them, and build the local dashboard host. You do not need to run any command yourself.
 
 ### Source clone vs field release package
 
 | You have | Do this |
 |----------|---------|
-| Git + optional .NET SDK (developer/IT) | Clone the repo, double-click `START-HERE-SysAdminSuite-Dashboard.bat` |
-| No .NET SDK (typical field PC) | Get the **field release ZIP** — see [`docs/DASHBOARD_FIELD_RELEASE.md`](docs/DASHBOARD_FIELD_RELEASE.md) — extract it, then double-click the `.bat` |
+| Git + internet/admin approval for Microsoft installers | Clone the repo, double-click `START-HERE-SysAdminSuite-Dashboard.bat` |
+| Locked-down PC where downloads or installs are blocked | Get the **field release ZIP** — see [`docs/DASHBOARD_FIELD_RELEASE.md`](docs/DASHBOARD_FIELD_RELEASE.md) — extract it, then double-click the `.bat` |
 
-No internet is required after the repo or package is on your machine.
+No internet is required after the dashboard dependencies are installed or the field release package is extracted. Bootstrap details: [`docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md).
 
 ## How do updates work?
 
@@ -85,8 +85,8 @@ anything changes. See [`docs/APPROVED_UPDATE_FLOW.md`](docs/APPROVED_UPDATE_FLOW
 
 1. Run `START-HERE-SysAdminSuite-Dashboard.bat` from the **repo root**, not from inside a subfolder.
 2. The window will not close on its own — read any message it prints, then press a key to close it.
-3. Paste into your browser: `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`
-4. The launcher tries to prepare the dashboard app automatically. If it reports that the app could not be built on this machine, ask for the packaged SysAdminSuite Dashboard release or have IT/admin prepare the workstation. You should not run the build command yourself.
+3. Paste into your browser: `http://127.0.0.1:5000/dashboard/?tutorial=setup`
+4. The launcher tries to prepare the dashboard app automatically. If it reports that dependency download, Microsoft .NET installation, or build preparation failed, ask for the packaged SysAdminSuite Dashboard release or have IT/admin prepare the workstation. You should not run the build command yourself.
 5. Read [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md) for IT troubleshooting.
 
 ## What about an EXE?

--- a/Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh
+++ b/Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+config="$repo_root/Config/dotnet-bootstrap.json"
+runtime_script="$repo_root/scripts/ensure-dotnet-runtime.sh"
+sdk_script="$repo_root/scripts/ensure-dotnet-sdk.sh"
+host_script="$repo_root/scripts/ensure-dashboard-host.sh"
+host_bat="$repo_root/Launch-SysAdminSuiteDashboard.Host.bat"
+start_bat="$repo_root/START-HERE-SysAdminSuite-Dashboard.bat"
+gitignore="$repo_root/.gitignore"
+
+[[ -f "$config" ]] || fail "missing Config/dotnet-bootstrap.json"
+[[ -f "$runtime_script" ]] || fail "missing ensure-dotnet-runtime.sh"
+[[ -f "$sdk_script" ]] || fail "missing ensure-dotnet-sdk.sh"
+[[ -f "$host_script" ]] || fail "missing ensure-dashboard-host.sh"
+
+grep -Fq 'dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json' "$config" \
+  || fail "bootstrap config does not cite official .NET release metadata"
+grep -Fq 'aspnetcore-runtime-8.0.28-win-x64.exe' "$config" \
+  || fail "bootstrap config missing ASP.NET Core runtime installer"
+grep -Fq 'windowsdesktop-runtime-8.0.28-win-x64.exe' "$config" \
+  || fail "bootstrap config missing Windows Desktop runtime installer"
+grep -Fq 'dotnet-sdk-8.0.422-win-x64.exe' "$config" \
+  || fail "bootstrap config missing .NET SDK installer"
+grep -Fq 'Microsoft.AspNetCore.App' "$config" \
+  || fail "bootstrap config missing ASP.NET Core shared framework check"
+grep -Fq 'Microsoft.WindowsDesktop.App' "$config" \
+  || fail "bootstrap config missing Windows Desktop shared framework check"
+grep -Eq '"sha512": "[0-9a-f]{128}"' "$config" \
+  || fail "bootstrap config must pin SHA512 hashes from Microsoft metadata"
+
+for script in "$runtime_script" "$sdk_script"; do
+  grep -Fq 'Config/dotnet-bootstrap.json' "$script" \
+    || fail "$(basename "$script") does not read bootstrap config"
+  grep -Fq 'curl.exe' "$script" \
+    || fail "$(basename "$script") does not prefer Windows curl.exe"
+  grep -Fq 'certutil.exe' "$script" \
+    || fail "$(basename "$script") does not provide Windows-native checksum verification"
+  grep -Fq 'cmd.exe /c' "$script" \
+    || fail "$(basename "$script") does not run the official installer through Windows"
+  grep -Fq -- '--dry-run' "$script" \
+    || fail "$(basename "$script") has no dry-run mode"
+done
+
+grep -Fq 'ensure-dotnet-runtime.sh' "$host_script" \
+  || fail "dashboard host ensure script does not call runtime ensure"
+grep -Fq 'ensure-dotnet-sdk.sh' "$host_script" \
+  || fail "dashboard host ensure script does not call SDK ensure"
+grep -Fq 'publish "$PROJECT"' "$host_script" \
+  || fail "dashboard host ensure script does not publish with dotnet"
+grep -Fq 'app/bin' "$host_script" \
+  || fail "dashboard host ensure script does not publish into ignored app/bin layout"
+grep -Fq -- '--self-contained false' "$host_script" \
+  || fail "dashboard host ensure script must preserve framework-dependent publish"
+
+grep -Fq 'ensure-dashboard-host.sh' "$host_bat" \
+  || fail "host launcher does not call dashboard bootstrap"
+grep -Fq 'Git\bin\bash.exe' "$host_bat" \
+  || fail "host launcher does not prefer Git Bash"
+grep -Fq 'Microsoft .NET dependencies' "$start_bat" \
+  || fail "root launcher does not tell users about Microsoft .NET bootstrap"
+grep -Fq 'administrator approval' "$start_bat" \
+  || fail "root launcher missing admin/IT bootstrap guidance"
+
+if grep -RIEq '\b(winget|choco|chocolatey)\b' "$runtime_script" "$sdk_script" "$host_script" "$config"; then
+  fail "dashboard bootstrap must not use winget/choco"
+fi
+
+grep -Fq 'tools/cache/' "$gitignore" \
+  || fail "downloaded Microsoft installer cache is not ignored"
+
+bash "$host_script" --dry-run >/dev/null
+
+echo "PASS: dashboard dependency bootstrap contracts"

--- a/Tests/bash/test_dashboard_entrypoint_contracts.sh
+++ b/Tests/bash/test_dashboard_entrypoint_contracts.sh
@@ -34,8 +34,8 @@ grep -Fq 'Launch-SysAdminSuiteDashboard.Host.bat' "$bat" \
   || fail ".bat launcher does not reference Launch-SysAdminSuiteDashboard.Host.bat"
 grep -Fq 'http://127.0.0.1:5000/dashboard/' "$bat" \
   || fail ".bat launcher does not mention dashboard URL"
-grep -Fq 'tutorial=cybernet' "$bat" \
-  || fail ".bat launcher does not open Cybernet tutorial entry"
+grep -Fq 'tutorial=setup' "$bat" \
+  || fail ".bat launcher does not open Repo Setup tutorial entry"
 # Pause-on-failure: the host-missing branch must both emit its error and pause.
 # "Press any key to close" also appears on the success path, so assert the
 # failure message exists alongside a pause rather than the pause text alone.
@@ -85,16 +85,16 @@ done
 # primary instruction is forbidden.
 grep -Eq 'Double-click.*(START-HERE-SysAdminSuite-Dashboard|SysAdminSuite Dashboard)\.cmd' "$start_md" \
   && fail "START-HERE-SysAdminSuite.md must not present a .cmd as the primary double-click"
-# Auto-publish on first run: the host launcher must build the dashboard host
-# automatically (via the publish script) when it is missing, and must check for
-# the .NET SDK first so a clean failure path exists.
+# Auto-prepare on first run: the host launcher must call the Bash bootstrap,
+# which ensures Microsoft .NET dependencies and builds the dashboard host when
+# it is missing.
 [[ -f "$host_bat" ]] || fail "Launch-SysAdminSuiteDashboard.Host.bat is missing"
-grep -Fq 'publish-dashboard-entrypoint.ps1' "$host_bat" \
-  || fail "host launcher does not auto-invoke publish-dashboard-entrypoint.ps1"
-grep -Fq 'powershell.exe' "$host_bat" \
-  || fail "host launcher does not run the publish script via powershell.exe"
-grep -Fq 'dotnet' "$host_bat" \
-  || fail "host launcher does not check for dotnet before building"
+grep -Fq 'ensure-dashboard-host.sh' "$host_bat" \
+  || fail "host launcher does not call scripts/ensure-dashboard-host.sh"
+grep -Fq 'Git\bin\bash.exe' "$host_bat" \
+  || fail "host launcher does not prefer Git Bash for bootstrap"
+grep -Fq 'Microsoft .NET 8' "$host_bat" \
+  || fail "host launcher does not describe Microsoft .NET bootstrap"
 
 # The root .bat must NOT instruct field users to run the publish command by hand
 # as the normal path, and must not tell them to double-click again as a routine.
@@ -112,10 +112,12 @@ browser_line=$(grep -n 'start "" "http' "$bat" | head -1 | cut -d: -f1)
   || fail "root .bat opens the browser before the host health check"
 
 # Field-safe build-failure messaging in the root .bat.
-grep -Fq 'The dashboard app could not be built on this machine' "$bat" \
-  || fail "root .bat missing field-safe build-failure message"
+grep -Fq 'The dashboard app could not be prepared on this machine' "$bat" \
+  || fail "root .bat missing field-safe prepare-failure message"
 grep -Fq 'packaged SysAdminSuite Dashboard field release' "$bat" \
   || fail "root .bat missing field-release / IT-admin guidance"
+grep -Fq 'official Microsoft installers' "$bat" \
+  || fail "root .bat missing official Microsoft installer guidance"
 
 # Launcher must distinguish packaged field release vs source checkout paths.
 grep -Fq 'Packaged field release detected' "$bat" \

--- a/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
+++ b/Tests/bash/test_dashboard_tutorial_launcher_contracts.sh
@@ -5,6 +5,7 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 cmd="$repo_root/Start-CybernetSurveyTutorial.cmd"
 index="$repo_root/dashboard/index.html"
 helper="$repo_root/dashboard/js/launch-cybernet-tutorial.js"
+setup_helper="$repo_root/dashboard/js/launch-repo-setup-tutorial.js"
 app="$repo_root/dashboard/js/app.js"
 bundle="$repo_root/dashboard/js/bundle.js"
 preflight="$repo_root/dashboard/js/cybernet-os-preflight.js"
@@ -17,6 +18,7 @@ fail() {
 [[ -f "$cmd" ]] || fail "Start-CybernetSurveyTutorial.cmd is missing"
 [[ -f "$index" ]] || fail "dashboard/index.html is missing"
 [[ -f "$helper" ]] || fail "dashboard/js/launch-cybernet-tutorial.js is missing"
+[[ -f "$setup_helper" ]] || fail "dashboard/js/launch-repo-setup-tutorial.js is missing"
 [[ -f "$app" ]] || fail "dashboard/js/app.js is missing"
 [[ -f "$bundle" ]] || fail "dashboard/js/bundle.js is missing"
 [[ -f "$preflight" ]] || fail "dashboard/js/cybernet-os-preflight.js is missing"
@@ -24,8 +26,11 @@ fail() {
 grep -Fq 'dashboard\index.html' "$cmd" || fail "launcher does not point at dashboard\index.html"
 grep -q "tutorial=cybernet" "$cmd" || fail "launcher does not request the Cybernet tutorial"
 grep -q "launch-cybernet-tutorial.js" "$index" || fail "dashboard index does not include tutorial launcher helper"
+grep -q "launch-repo-setup-tutorial.js" "$index" || fail "dashboard index does not include repo setup tutorial launcher helper"
 grep -q "hero-start-survey" "$helper" || fail "helper does not target the existing Start Cybernet Survey button"
 grep -q "URLSearchParams" "$helper" || fail "helper does not inspect query parameters"
+grep -q "hero-start-setup" "$setup_helper" || fail "setup helper does not target the Start Repo Setup button"
+grep -q "tutorial === 'setup'" "$setup_helper" || fail "setup helper does not inspect setup tutorial query parameter"
 
 # Ignore REM lines; the launcher documents that it does not run survey tooling.
 if grep -viE '^[[:space:]]*rem[[:space:]]' "$cmd" | grep -qiE 'naabu|nmap|credential|password|psexec|invoke-command'; then
@@ -46,6 +51,8 @@ grep -q 'startCybernetTutorial' "$app" \
   || fail "app.js does not define an explicit startCybernetTutorial transition"
 grep -q 'window.startCybernetTutorial' "$app" \
   || fail "app.js does not expose startCybernetTutorial for the auto-launch path"
+grep -q 'window.startRepoSetupTutorial' "$app" \
+  || fail "app.js does not expose startRepoSetupTutorial for the setup auto-launch path"
 grep -q 'getComputedStyle' "$app" \
   || fail "app.js does not verify the tutorial is actually visible before transforming the hero"
 grep -q 'cybernet-hero-status' "$app" \
@@ -70,9 +77,13 @@ fi
 # 5. The auto-launch helper must route through the verified transition.
 grep -q 'window.startCybernetTutorial' "$helper" \
   || fail "launch-cybernet-tutorial.js does not use the verified startCybernetTutorial transition"
+grep -q 'window.startRepoSetupTutorial' "$setup_helper" \
+  || fail "launch-repo-setup-tutorial.js does not use the verified startRepoSetupTutorial transition"
 
 # 6. The served bundle must be rebuilt from source (not stale).
 grep -q 'startCybernetTutorial' "$bundle" \
   || fail "dashboard/js/bundle.js is stale — rebuild with: node dashboard/build-bundle.js"
+grep -q 'initRepoSetupTutorial' "$bundle" \
+  || fail "dashboard/js/bundle.js is stale — missing Repo Setup tutorial; rebuild with: node dashboard/build-bundle.js"
 
 echo "PASS: dashboard tutorial launcher contracts"

--- a/dashboard/build-bundle.js
+++ b/dashboard/build-bundle.js
@@ -22,6 +22,7 @@ const files = [
   'dashboard/js/software-tracker-paths.js',
   'dashboard/js/software-tracker-state.js',
   'dashboard/js/software-tracker-tutorial.js',
+  'dashboard/js/repo-setup-tutorial.js',
   'dashboard/js/panel-software.js',
   'dashboard/js/tour.js',
   'dashboard/js/app.js',

--- a/dashboard/css/style.css
+++ b/dashboard/css/style.css
@@ -1098,6 +1098,7 @@ textarea.paste-area:focus { border-color: var(--accent); }
 .workflow-command-panel,
 .cybernet-command-panel { flex: 1 1 56%; min-width: 0; box-sizing: border-box; }
 
+#repo-setup-step-command,
 #cybernet-step-command,
 #sw-step-command {
   width: 100%; height: 112px; resize: vertical;
@@ -1111,6 +1112,7 @@ textarea.paste-area:focus { border-color: var(--accent); }
 .cybernet-tutorial-nav { margin-top: 10px; justify-content: flex-end; }
 
 .workflow-hero,
+.repo-setup-hero,
 .cybernet-hero,
 .software-tracker-hero {
   flex-shrink: 0;
@@ -1126,14 +1128,22 @@ textarea.paste-area:focus { border-color: var(--accent); }
   background: linear-gradient(135deg, rgba(34,197,94,0.12), rgba(79,142,247,0.05));
 }
 
+.repo-setup-hero {
+  border-color: rgba(245, 158, 11, 0.34);
+  background: linear-gradient(135deg, rgba(245,158,11,0.14), rgba(79,142,247,0.06));
+}
+
 .workflow-hero h2,
+.repo-setup-hero h2,
 .cybernet-hero h2,
 .software-tracker-hero h2 { font-size: 20px; margin-bottom: 6px; }
 
+.repo-setup-hero-subtitle,
 .cybernet-hero-subtitle,
 .software-tracker-hero-subtitle { color: var(--text-dim); font-size: 13px; max-width: 52rem; }
 
 .workflow-progress-rail,
+.repo-setup-progress-rail,
 .cybernet-progress-rail,
 .software-tracker-progress-rail {
   display: flex;
@@ -1145,6 +1155,7 @@ textarea.paste-area:focus { border-color: var(--accent); }
 }
 
 .workflow-progress-rail li,
+.repo-setup-progress-rail li,
 .cybernet-progress-rail li,
 .software-tracker-progress-rail li {
   font-size: 11px;
@@ -1156,6 +1167,7 @@ textarea.paste-area:focus { border-color: var(--accent); }
 }
 
 .workflow-progress-rail li.active,
+.repo-setup-progress-rail li.active,
 .cybernet-progress-rail li.active,
 .software-tracker-progress-rail li.active {
   border-color: var(--accent);
@@ -1171,13 +1183,21 @@ textarea.paste-area:focus { border-color: var(--accent); }
   box-shadow: 0 0 18px rgba(34, 197, 94, 0.35);
 }
 
+.repo-setup-progress-rail li.active {
+  border-color: rgba(245, 158, 11, 0.75);
+  background: rgba(245, 158, 11, 0.26);
+  box-shadow: 0 0 18px rgba(245, 158, 11, 0.4);
+}
+
 .workflow-progress-rail li.done,
+.repo-setup-progress-rail li.done,
 .cybernet-progress-rail li.done,
 .software-tracker-progress-rail li.done {
   border-color: rgba(34, 197, 94, 0.35);
   color: var(--success);
 }
 
+.repo-setup-hero-actions,
 .software-tracker-hero-actions,
 .cybernet-hero-actions {
   display: flex;
@@ -1186,6 +1206,7 @@ textarea.paste-area:focus { border-color: var(--accent); }
   align-items: center;
 }
 
+.repo-setup-hero-status,
 .software-tracker-hero-status,
 .cybernet-hero-status {
   margin: 10px 0 0;
@@ -1194,12 +1215,15 @@ textarea.paste-area:focus { border-color: var(--accent); }
   color: var(--text-dim);
 }
 
+.repo-setup-hero-status.is-busy,
 .software-tracker-hero-status.is-busy,
 .cybernet-hero-status.is-busy { color: var(--info); }
 
+.repo-setup-hero-status.is-open,
 .software-tracker-hero-status.is-open,
 .cybernet-hero-status.is-open { color: var(--success); }
 
+.repo-setup-hero-status.is-error,
 .software-tracker-hero-status.is-error,
 .cybernet-hero-status.is-error { color: var(--error); }
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -111,16 +111,63 @@
     <button class="btn-secondary btn-compact" id="advanced-tools-toggle" type="button" aria-expanded="false" aria-controls="advanced-section">Advanced Tools</button>
   </div>
 
+  <section id="repo-setup-hero" class="workflow-hero repo-setup-hero" aria-label="Repo Setup">
+    <div class="repo-setup-hero-inner">
+      <h2>Repo Setup</h2>
+      <p class="repo-setup-hero-subtitle">Clone or update SysAdminSuite, open the dashboard, then pick the workflow you need.</p>
+      <ol class="workflow-progress-rail repo-setup-progress-rail" id="repo-setup-progress-rail" aria-label="Repo setup progress">
+        <li data-step="0">Get repo</li>
+        <li data-step="1">Open dashboard</li>
+        <li data-step="2">Update safely</li>
+        <li data-step="3">Pick workflow</li>
+        <li data-step="4">Ready</li>
+      </ol>
+      <div class="repo-setup-hero-actions" id="repo-setup-hero-actions">
+        <button class="btn-primary" id="hero-start-setup" type="button">Start Repo Setup</button>
+        <button class="btn-secondary" id="hero-open-cybernet" type="button">I'm ready — open Cybernet Survey</button>
+      </div>
+      <p id="repo-setup-hero-status" class="repo-setup-hero-status hidden" role="status" aria-live="polite"></p>
+    </div>
+  </section>
+
+  <section id="repo-setup-tutorial" class="workflow-tutorial repo-setup-tutorial hidden" aria-label="Repo setup wizard">
+    <div class="workflow-step-kicker" id="repo-setup-step-kicker">Step 1 of 5</div>
+    <div class="workflow-step-card">
+      <div class="workflow-step-content">
+        <h3 id="repo-setup-step-title">Get SysAdminSuite</h3>
+        <p id="repo-setup-step-body"></p>
+        <ul id="repo-setup-step-checks"></ul>
+      </div>
+      <div class="workflow-command-panel" id="repo-setup-command-panel">
+        <div class="command-panel-title">Command or action outside the dashboard</div>
+        <div class="command-panel-runner" id="repo-setup-command-runner">
+          Use this only when the step tells you to. The dashboard never updates the repo without approval.
+        </div>
+        <textarea id="repo-setup-step-command" readonly spellcheck="false"></textarea>
+        <div class="command-panel-note" id="repo-setup-step-note"></div>
+      </div>
+    </div>
+    <div class="workflow-tutorial-nav">
+      <button class="btn-secondary" id="repo-setup-prev" type="button">← Back</button>
+      <button class="btn-secondary hidden" id="repo-setup-copy" type="button">Copy Command</button>
+      <button class="btn-primary" id="repo-setup-next" type="button">Next →</button>
+    </div>
+    <div class="repo-setup-wizard-footer hidden" id="repo-setup-wizard-footer">
+      <button class="btn-primary" id="repo-setup-open-cybernet" type="button">Open Cybernet Survey</button>
+    </div>
+  </section>
+
   <section id="cybernet-hero" class="workflow-hero cybernet-hero" aria-label="Cybernet Survey">
     <div class="cybernet-hero-inner">
       <h2>Cybernet Survey</h2>
-      <p class="cybernet-hero-subtitle">Find, verify, and package Cybernet targets from approved target sources.</p>
+      <p class="cybernet-hero-subtitle">Start the survey, load approved targets, run read-only checks, finish, and review the results.</p>
       <ol class="workflow-progress-rail cybernet-progress-rail" id="cybernet-progress-rail" aria-label="Survey progress">
-        <li data-step="0">Targets</li>
-        <li data-step="1">Network posture</li>
-        <li data-step="2">Identity evidence</li>
-        <li data-step="3">Reachability</li>
-        <li data-step="4">Review package</li>
+        <li data-step="0">Start</li>
+        <li data-step="1">Load targets</li>
+        <li data-step="2">Network posture</li>
+        <li data-step="3">Identity evidence</li>
+        <li data-step="4">Reachability</li>
+        <li data-step="5">Review results</li>
       </ol>
       <div class="cybernet-hero-actions" id="cybernet-hero-actions">
         <button class="btn-primary" id="hero-start-survey" type="button">Start Cybernet Survey</button>
@@ -131,7 +178,7 @@
   </section>
 
   <section id="cybernet-tutorial" class="workflow-tutorial cybernet-tutorial hidden" aria-label="Cybernet survey wizard">
-    <div class="workflow-step-kicker" id="cybernet-step-kicker">Step 1 of 5</div>
+    <div class="workflow-step-kicker" id="cybernet-step-kicker">Step 1 of 6</div>
     <div class="cybernet-step-progress" id="cybernet-step-progress" aria-hidden="true"></div>
     <div class="workflow-step-card cybernet-step-card">
       <div class="workflow-step-content cybernet-step-content">
@@ -360,6 +407,7 @@
 })();
 </script>
 <script src="js/cybernet-os-preflight.js"></script>
+<script src="js/launch-repo-setup-tutorial.js"></script>
 <script src="js/launch-cybernet-tutorial.js"></script>
 </body>
 </html>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -8,6 +8,7 @@ import { getTasksHTML, initTasksPanel, renderTasksPanel } from './panel-tasks.js
 import { getNetworkHTML, initNetworkPanel, renderNetworkPanel } from './panel-network.js';
 import { getSoftwareHTML, initSoftwarePanel, renderSoftwarePanel } from './panel-software.js';
 import { initSoftwareTrackerTutorial } from './software-tracker-tutorial.js';
+import { initRepoSetupTutorial } from './repo-setup-tutorial.js';
 import {
   setSoftwareInstallPlan,
   clearSoftwareInstallPlan,
@@ -72,12 +73,14 @@ const TYPE_TO_PANELS = {
 // ── Bootstrap ──────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
   buildLayout();
+  initRepoSetupShell();
   initCybernetShell();
   initSoftwareTrackerShell();
   initTabs();
   initIngestion();
   initModeToggle();
   initLiveMode();
+  initRepoSetupTutorial();
   initCybernetTutorial();
   initSoftwareTrackerTutorial();
   initPasteModal();
@@ -140,6 +143,67 @@ function switchTab(tab) {
 }
 
 // ── Cybernet-first shell ─────────────────────────────────────────────────────
+function initRepoSetupShell() {
+  const startBtn = document.getElementById('hero-start-setup');
+  const tutorial = document.getElementById('repo-setup-tutorial');
+  const statusEl = document.getElementById('repo-setup-hero-status');
+
+  const setHeroStatus = (msg, kind) => {
+    if (!statusEl) return;
+    statusEl.textContent = msg || '';
+    statusEl.classList.remove('is-busy', 'is-open', 'is-error');
+    if (kind) statusEl.classList.add(kind);
+    statusEl.classList.toggle('hidden', !msg);
+  };
+
+  const tutorialIsVisible = () => {
+    if (!tutorial) return false;
+    if (tutorial.classList.contains('hidden')) return false;
+    const cs = window.getComputedStyle(tutorial);
+    return cs.display !== 'none' && cs.visibility !== 'hidden';
+  };
+
+  const startRepoSetupTutorial = (opts) => {
+    const source = (opts && opts.source) || 'manual';
+    if (!tutorial || !startBtn) {
+      setHeroStatus('Could not open repo setup. Reload the dashboard or start Cybernet Survey directly.', 'is-error');
+      toast('Repo setup tutorial is unavailable. Reload the dashboard.', 'error');
+      return false;
+    }
+
+    setHeroStatus('Opening repo setup…', 'is-busy');
+    tutorial.style.display = '';
+    tutorial.classList.remove('hidden');
+    if (typeof window.__sasResetRepoSetupWizard === 'function') {
+      try { window.__sasResetRepoSetupWizard(); } catch (_) { /* non-fatal */ }
+    }
+
+    if (!tutorialIsVisible()) {
+      tutorial.classList.add('hidden');
+      setHeroStatus('Could not open repo setup. Try again or start Cybernet Survey.', 'is-error');
+      toast('Could not open repo setup. Try again.', 'error');
+      return false;
+    }
+
+    startBtn.textContent = 'Restart Repo Setup';
+    startBtn.setAttribute('aria-label', 'Restart repo setup from step 1');
+    setHeroStatus('Repo setup open below.', 'is-open');
+    if (source !== 'silent') {
+      window.setTimeout(() => {
+        tutorial.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 30);
+    }
+    return true;
+  };
+
+  startBtn?.addEventListener('click', () => startRepoSetupTutorial({ source: 'manual' }));
+  document.getElementById('hero-open-cybernet')?.addEventListener('click', () => {
+    if (typeof window.startCybernetTutorial === 'function') window.startCybernetTutorial({ source: 'manual' });
+    else document.getElementById('hero-start-survey')?.click();
+  });
+  window.startRepoSetupTutorial = startRepoSetupTutorial;
+}
+
 function initCybernetShell() {
   const startBtn = document.getElementById('hero-start-survey');
   const tutorial = document.getElementById('cybernet-tutorial');
@@ -704,13 +768,28 @@ function initPasteModal() {
 // ── Cybernet Survey Wizard ───────────────────────────────────────────────────
 const CYBERNET_TUTORIAL_STEPS = [
   {
-    title: 'Prepare your target list',
-    railLabel: 'Targets',
-    body: 'First, make a simple list of the computers you want to check. Put one computer name or IP address on each line. This only prepares a local file for the next steps.',
+    title: 'Start the Cybernet survey',
+    railLabel: 'Start',
+    body: 'This tutorial teaches the field survey from beginning to end. You will load approved targets, run read-only checks from an admin machine, bring the files back, and review the dashboard results.',
+    command: '',
+    checks: [
+      'The dashboard does not run probes by itself.',
+      'You copy commands when the tutorial gives them, run them on an admin machine, then load the output files back here.',
+      'Use approved target sources only; do not broaden the survey from guessed hosts.'
+    ],
+    nextAction: 'Read this, then click Next to load or prepare your targets.',
+    note: 'Start here for Cybernet field work. Repo setup is a separate tutorial above.',
+    optional: false
+  },
+  {
+    title: 'Load your targets',
+    railLabel: 'Load targets',
+    body: 'Make the list of Cybernet computers you are allowed to check. Put one computer name or IP address on each line. This creates the target file used by the next checks.',
     command: "mkdir -p /tmp/sas-cybernet\nprintf '%s\\n' 'WMH300OPR001' 'WMH300OPR002' > /tmp/sas-cybernet/targets.txt",
     checks: [
       'Use only computer names, IPv4 addresses, or IPv6 addresses.',
       'Do not paste passwords, usernames, tickets, or notes into this file.',
+      'AD registered population is the source of registered Cybernet population; the target list is not proof by itself.',
       'If the list came from another source, you can normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
     ],
     nextAction: 'Copy this local setup command, run it on your admin machine, then come back and click Next.',
@@ -718,7 +797,7 @@ const CYBERNET_TUTORIAL_STEPS = [
     optional: false
   },
   {
-    title: 'Prove network posture first',
+    title: 'Check network posture',
     railLabel: 'Network posture',
     body: 'Now check whether your admin machine can see the targets at all. This catches guest Wi-Fi, wrong VLAN, DNS, SMB, and RPC problems before anyone blames the tool.',
     command: 'bash bash/transport/sas-network-preflight.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --ports 135,445,3389,9100 \\\n  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru',
@@ -732,7 +811,7 @@ const CYBERNET_TUTORIAL_STEPS = [
     optional: false
   },
   {
-    title: 'Acquire Cybernet identity evidence',
+    title: 'Collect identity evidence',
     railLabel: 'Identity evidence',
     body: 'Collect read-only identity clues from each target. The command records what it can safely observe, such as DNS, ping status, MAC hints, and transport notes.',
     command: 'bash bash/transport/sas-workstation-identity.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru',
@@ -748,10 +827,11 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Optional reachability check',
     railLabel: 'Reachability',
-    body: 'This is an extra confirmation pass for approved targets. Use it only when you need low-noise port evidence after the posture and identity checks.',
+    body: 'This is an extra confirmation pass for approved targets. Use it only when you need low-noise survey discipline for port evidence after the posture and identity checks.',
     command: 'mkdir -p logs/targets logs/nmap\ncp /tmp/sas-cybernet/targets.txt logs/targets/cybernet_confirm_hosts.txt\nbash survey/sas-run-naabu-pipeline.sh --site cybernet \\\n  --profile keyports_cybernet_json \\\n  --list logs/targets/cybernet_confirm_hosts.txt \\\n  --out logs/nmap/cybernet_naabu.json',
     checks: [
       'Profile: keyports_cybernet_json (-ec -silent -json).',
+      'Naabu/Nmap output is reachability validation only.',
       'Doctrine: docs/LOW_NOISE_SURVEY_DOCTRINE.md — local evidence only, no target-side writes.',
       'This step is optional. Skip it when the earlier evidence is enough.'
     ],
@@ -760,16 +840,18 @@ const CYBERNET_TUTORIAL_STEPS = [
     optional: true
   },
   {
-    title: 'Load evidence and review',
-    railLabel: 'Review package',
-    body: 'Bring the files back to this dashboard. Drag the CSV or JSON outputs into Load Evidence, then review the summary before calling the result good or bad.',
+    title: 'Finish and review results',
+    railLabel: 'Review results',
+    body: 'Bring the files back to this dashboard. Drop the CSV or JSON outputs into Load Evidence, then read Review Results for the survey summary and next action.',
     command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/cybernet_*_targets.csv (manifest, not evidence)',
     checks: [
+      'Load Evidence is where files go in.',
+      'Review Results is where the Cybernet summary appears after evidence is loaded.',
+      'Open network evidence details when you need row-level DNS, ping, protocol, or reachability detail.',
       'Classify environment blocks separately from product defects.',
-      'Keep smoke-test evidence separate from feature validation.',
       'Treat manifest rows as target lists, not reachability or identity proof.'
     ],
-    nextAction: 'Click Load resulting evidence, then drop the files into the highlighted box.',
+    nextAction: 'Click Load resulting evidence, drop the files into the highlighted box, then read Review Results.',
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
   }

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -3147,6 +3147,212 @@ _exports.SOFTWARE_TRACKER_TUTORIAL_STEPS = SOFTWARE_TRACKER_TUTORIAL_STEPS;
 })();
 var initSoftwareTrackerTutorial = _exports.initSoftwareTrackerTutorial, SOFTWARE_TRACKER_TUTORIAL_STEPS = _exports.SOFTWARE_TRACKER_TUTORIAL_STEPS;
 
+// ====== repo-setup-tutorial.js ======
+(function () {
+// repo-setup-tutorial.js — dashboard front-door tutorial for clone/update/open.
+
+const REPO_SETUP_TUTORIAL_STEPS = [
+  {
+    title: 'Get SysAdminSuite',
+    railLabel: 'Get repo',
+    body: 'Start by getting one clean copy of SysAdminSuite. Pick a parent folder such as Desktop or dev, then clone into it. Do not create a SysAdminSuite folder first.',
+    command: 'git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git',
+    checks: [
+      'The command creates the SysAdminSuite folder for you.',
+      'Avoid the common nested path: SysAdminSuite\\SysAdminSuite.',
+      'No Git available? Use the approved field release package instead of a raw source clone.'
+    ],
+    nextAction: 'Copy this only if you need to clone. After the folder exists, open it and click Next.',
+    note: 'Source clones are for IT/developer machines. Field PCs without the .NET SDK should use the field release ZIP.',
+    hasCommand: true
+  },
+  {
+    title: 'Open the dashboard',
+    railLabel: 'Open dashboard',
+    body: 'Open the SysAdminSuite folder and double-click the dashboard launcher. The launcher starts the local dashboard host and opens this browser page.',
+    command: 'START-HERE-SysAdminSuite-Dashboard.bat',
+    checks: [
+      'Run it from the repo root, not from a subfolder.',
+      'First launch may take a minute while the dashboard app is prepared.',
+      'If the machine cannot build the app, ask for the packaged field release or IT preparation.'
+    ],
+    nextAction: 'Find the launcher at the top of the repo and double-click it. Then click Next.',
+    note: 'The .cmd shortcuts are aliases, but the .bat launcher is the documented front door.',
+    hasCommand: false
+  },
+  {
+    title: 'Update safely',
+    railLabel: 'Update safely',
+    body: 'Updates are opt-in. If a newer clean main or field package is available, the launcher asks before applying it. Nothing should silently update underneath a technician.',
+    command: '# Source clone rule: approve first, then fast-forward clean main only.\n# ZIP / field package rule: approve first, then apply a checksum-verified package.',
+    checks: [
+      'Source clones update only from clean main with a fast-forward.',
+      'Field packages update only from a checksum-verified package.',
+      'Never use reset, branch deletion, or silent updates as the field path.'
+    ],
+    nextAction: 'Read this once. If the launcher asks to update, approve only when you are ready.',
+    note: 'Approved update flow is documented in docs/APPROVED_UPDATE_FLOW.md.',
+    hasCommand: false
+  },
+  {
+    title: 'Pick the workflow',
+    railLabel: 'Pick workflow',
+    body: 'Now choose what you came here to do. Cybernet Survey teaches target loading, network posture, identity evidence, optional reachability, and where results appear.',
+    command: '# Click Start Cybernet Survey for Cybernet field work.\n# Click Start Software Tracker Install only for the guarded install workflow.',
+    checks: [
+      'Use Cybernet Survey for Cybernet / Neuron target work.',
+      'Use Software Tracker Install for dry-run install planning and guarded execute.',
+      'Use Load Evidence when you already have output files to review.'
+    ],
+    nextAction: 'Click Next to finish setup, then choose the workflow button the dashboard highlights.',
+    note: 'Most Cybernet field work starts with Start Cybernet Survey.',
+    hasCommand: false
+  },
+  {
+    title: 'Ready for Cybernet Survey',
+    railLabel: 'Ready',
+    body: 'Setup is done. The next tutorial teaches the Cybernet survey from start to finish: start, load targets, run checks, finish, and review results.',
+    command: '# No command here. Click Open Cybernet Survey below.',
+    checks: [
+      'You know where the repo lives.',
+      'You know which launcher opens the dashboard.',
+      'You know updates require approval before changes are applied.'
+    ],
+    nextAction: 'Click Open Cybernet Survey to start the field survey tutorial.',
+    note: 'The Cybernet tutorial is separate so setup does not get mixed with field survey work.',
+    hasCommand: false,
+    finalAction: true
+  }
+];
+
+function initRepoSetupTutorial() {
+  const root = document.getElementById('repo-setup-tutorial');
+  if (!root) return;
+
+  let idx = 0;
+  let copiedThisStep = false;
+  const title = document.getElementById('repo-setup-step-title');
+  const body = document.getElementById('repo-setup-step-body');
+  const kicker = document.getElementById('repo-setup-step-kicker');
+  const checks = document.getElementById('repo-setup-step-checks');
+  const command = document.getElementById('repo-setup-step-command');
+  const runner = document.getElementById('repo-setup-command-runner');
+  const note = document.getElementById('repo-setup-step-note');
+  const commandPanel = document.getElementById('repo-setup-command-panel');
+  const prev = document.getElementById('repo-setup-prev');
+  const next = document.getElementById('repo-setup-next');
+  const copy = document.getElementById('repo-setup-copy');
+  const footer = document.getElementById('repo-setup-wizard-footer');
+  const openCybernet = document.getElementById('repo-setup-open-cybernet');
+  const cybernetStart = document.getElementById('hero-start-survey');
+  const progressRail = document.getElementById('repo-setup-progress-rail');
+
+  function updateProgressRail() {
+    progressRail?.querySelectorAll('li').forEach((li, i) => {
+      li.classList.toggle('active', i === idx);
+      li.classList.toggle('done', i < idx);
+    });
+  }
+
+  function updateGuideState(hasCommand) {
+    const finalStep = idx === REPO_SETUP_TUTORIAL_STEPS.length - 1;
+    copy?.classList.toggle('sas-guide-glow', hasCommand && !copiedThisStep);
+    next?.classList.toggle('sas-guide-glow', (hasCommand && copiedThisStep) || (!hasCommand && !finalStep));
+    openCybernet?.classList.toggle('sas-guide-glow', finalStep);
+    cybernetStart?.classList.toggle('sas-guide-glow', finalStep);
+    commandPanel?.classList.toggle('sas-guide-panel', hasCommand && !copiedThisStep);
+  }
+
+  function render() {
+    const step = REPO_SETUP_TUTORIAL_STEPS[idx];
+    if (!step) return;
+    copiedThisStep = false;
+    const hasCommand = !!step.hasCommand;
+    kicker.textContent = `Step ${idx + 1} of ${REPO_SETUP_TUTORIAL_STEPS.length} — ${step.railLabel}`;
+    title.textContent = step.title;
+    body.textContent = step.body;
+    checks.innerHTML = step.checks.map(item => `<li>${sanitize(item)}</li>`).join('');
+    commandPanel?.classList.toggle('hidden', !hasCommand);
+    if (command) command.value = hasCommand ? step.command : '';
+    if (runner) runner.textContent = step.nextAction || 'Read the step, then click Next.';
+    if (note) note.textContent = step.note || '';
+    if (prev) prev.disabled = idx === 0;
+    if (next) next.textContent = step.finalAction ? 'Finish setup' : hasCommand ? 'Next after cloning →' : 'Next →';
+    copy?.classList.toggle('hidden', !hasCommand);
+    footer?.classList.toggle('hidden', !step.finalAction);
+    updateProgressRail();
+    updateGuideState(hasCommand);
+  }
+
+  function copyCommand() {
+    const text = command?.value || '';
+    if (!text) return;
+    const originalNote = note?.textContent || '';
+    const write = navigator.clipboard && typeof navigator.clipboard.writeText === 'function'
+      ? navigator.clipboard.writeText(text)
+      : new Promise((resolve, reject) => {
+          command.focus();
+          command.select();
+          try { document.execCommand('copy') ? resolve() : reject(new Error('copy unavailable')); }
+          catch (err) { reject(err); }
+        });
+    write
+      .then(() => {
+        copiedThisStep = true;
+        toast('Repo setup command copied.', 'success');
+        if (note) note.textContent = 'Command copied.';
+        updateGuideState(true);
+      })
+      .catch(() => {
+        toast('Select and copy the command manually.', 'warning');
+        if (note) note.textContent = `${originalNote} Select the command text and copy it manually if clipboard access is blocked.`;
+      })
+      .finally(() => {
+        if (note) window.setTimeout(() => { if (note.textContent === 'Command copied.') note.textContent = originalNote; }, 2200);
+      });
+  }
+
+  function openCybernetSurvey() {
+    cybernetStart?.classList.remove('sas-guide-glow');
+    openCybernet?.classList.remove('sas-guide-glow');
+    if (typeof window.startCybernetTutorial === 'function') {
+      window.startCybernetTutorial({ source: 'manual' });
+    } else {
+      cybernetStart?.click();
+    }
+  }
+
+  prev?.addEventListener('click', () => { if (idx > 0) { idx--; render(); } });
+  next?.addEventListener('click', () => {
+    const step = REPO_SETUP_TUTORIAL_STEPS[idx];
+    const hasCommand = !!step?.hasCommand;
+    if (hasCommand && step.requireCopy && !copiedThisStep) {
+      toast('Copy the clone command first, or continue only if the repo already exists.', 'warning');
+      return;
+    }
+    if (idx < REPO_SETUP_TUTORIAL_STEPS.length - 1) {
+      idx++;
+      render();
+    } else {
+      toast('Repo setup complete — choose Cybernet Survey when ready.', 'success');
+      document.getElementById('cybernet-hero')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      render();
+    }
+  });
+  copy?.addEventListener('click', copyCommand);
+  openCybernet?.addEventListener('click', openCybernetSurvey);
+
+  window.__sasResetRepoSetupWizard = () => { idx = 0; copiedThisStep = false; render(); };
+
+  render();
+}
+
+// expose exports to bundle scope
+_exports.initRepoSetupTutorial = initRepoSetupTutorial;
+_exports.REPO_SETUP_TUTORIAL_STEPS = REPO_SETUP_TUTORIAL_STEPS;
+})();
+var initRepoSetupTutorial = _exports.initRepoSetupTutorial, REPO_SETUP_TUTORIAL_STEPS = _exports.REPO_SETUP_TUTORIAL_STEPS;
+
 // ====== panel-software.js ======
 (function () {
 // panel-software.js — SysAdmin Suite Software Tracker panel
@@ -3846,27 +4052,33 @@ const STEPS = [
     target: '#header',
     title: 'Welcome to SysAdmin Suite Dashboard',
     body:
-      'This dashboard guides Cybernet field surveys — find targets, verify network posture, ' +
-      'collect identity evidence, and package results for review. ' +
-      "Let's walk through the Cybernet-first workflow.",
+      'This dashboard has two different tutorials: <strong>Repo Setup</strong> teaches clone, update, and opening the app; ' +
+      '<strong>Cybernet Survey</strong> teaches field survey work from targets to results.',
+    position: 'bottom',
+  },
+  {
+    target: '#repo-setup-hero',
+    title: 'Repo setup tutorial',
+    body:
+      'Start here when someone needs to get the repo, avoid nested folders, understand approved updates, ' +
+      'and learn which launcher opens the dashboard.',
     position: 'bottom',
   },
   {
     target: '#hero-start-survey',
-    title: 'Start here',
+    title: 'Cybernet survey tutorial',
     body:
       'Tap <strong>Start Cybernet Survey</strong> to open the step-by-step wizard. ' +
-      'It walks you through target prep, network checks, identity evidence, reachability, ' +
-      'and packaging — with copy-ready commands for each step.',
+      'It teaches how to start, load targets, run network and identity checks, finish, and read results.',
     position: 'bottom',
   },
   {
     target: '#cybernet-progress-rail',
     title: 'Survey progress',
     body:
-      'The progress rail shows where you are in the five-step survey: ' +
-      '<em>Targets</em> → <em>Network posture</em> → <em>Identity evidence</em> → ' +
-      '<em>Reachability</em> → <em>Review package</em>. ' +
+      'The progress rail shows where you are in the six-step survey: ' +
+      '<em>Start</em> → <em>Load targets</em> → <em>Network posture</em> → ' +
+      '<em>Identity evidence</em> → <em>Reachability</em> → <em>Review results</em>. ' +
       'Labels update as you advance through the wizard.',
     position: 'bottom',
   },
@@ -3889,7 +4101,7 @@ const STEPS = [
     body:
       'Once recognized evidence is loaded, the review summary appears here — ' +
       'a consolidated readout of your Cybernet survey package. ' +
-      'Use the link below to open detailed network evidence when you need more depth.',
+      'Use <strong>Open network evidence details</strong> when you need row-level DNS, ping, port, or identity detail.',
     position: 'bottom',
     reveal: () => {
       document.getElementById('cybernet-review')?.classList.remove('hidden');
@@ -3931,7 +4143,7 @@ const STEPS = [
     target: '#sas-tour-launch-btn',
     title: "You're all set!",
     body:
-      'That covers the Cybernet-first workflow on the SysAdmin Suite Dashboard.<br><br>' +
+      'That covers the dashboard map: setup first, then the workflow tutorial for the work at hand.<br><br>' +
       'You can relaunch this tour from <strong>Interactive tour</strong> inside ' +
       '<strong>Advanced Tools</strong>, or by pressing ' +
       '<kbd style="background:#0d1420;color:#f6ad55;' +
@@ -4419,12 +4631,14 @@ const TYPE_TO_PANELS = {
 // ── Bootstrap ──────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
   buildLayout();
+  initRepoSetupShell();
   initCybernetShell();
   initSoftwareTrackerShell();
   initTabs();
   initIngestion();
   initModeToggle();
   initLiveMode();
+  initRepoSetupTutorial();
   initCybernetTutorial();
   initSoftwareTrackerTutorial();
   initPasteModal();
@@ -4487,6 +4701,67 @@ function switchTab(tab) {
 }
 
 // ── Cybernet-first shell ─────────────────────────────────────────────────────
+function initRepoSetupShell() {
+  const startBtn = document.getElementById('hero-start-setup');
+  const tutorial = document.getElementById('repo-setup-tutorial');
+  const statusEl = document.getElementById('repo-setup-hero-status');
+
+  const setHeroStatus = (msg, kind) => {
+    if (!statusEl) return;
+    statusEl.textContent = msg || '';
+    statusEl.classList.remove('is-busy', 'is-open', 'is-error');
+    if (kind) statusEl.classList.add(kind);
+    statusEl.classList.toggle('hidden', !msg);
+  };
+
+  const tutorialIsVisible = () => {
+    if (!tutorial) return false;
+    if (tutorial.classList.contains('hidden')) return false;
+    const cs = window.getComputedStyle(tutorial);
+    return cs.display !== 'none' && cs.visibility !== 'hidden';
+  };
+
+  const startRepoSetupTutorial = (opts) => {
+    const source = (opts && opts.source) || 'manual';
+    if (!tutorial || !startBtn) {
+      setHeroStatus('Could not open repo setup. Reload the dashboard or start Cybernet Survey directly.', 'is-error');
+      toast('Repo setup tutorial is unavailable. Reload the dashboard.', 'error');
+      return false;
+    }
+
+    setHeroStatus('Opening repo setup…', 'is-busy');
+    tutorial.style.display = '';
+    tutorial.classList.remove('hidden');
+    if (typeof window.__sasResetRepoSetupWizard === 'function') {
+      try { window.__sasResetRepoSetupWizard(); } catch (_) { /* non-fatal */ }
+    }
+
+    if (!tutorialIsVisible()) {
+      tutorial.classList.add('hidden');
+      setHeroStatus('Could not open repo setup. Try again or start Cybernet Survey.', 'is-error');
+      toast('Could not open repo setup. Try again.', 'error');
+      return false;
+    }
+
+    startBtn.textContent = 'Restart Repo Setup';
+    startBtn.setAttribute('aria-label', 'Restart repo setup from step 1');
+    setHeroStatus('Repo setup open below.', 'is-open');
+    if (source !== 'silent') {
+      window.setTimeout(() => {
+        tutorial.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 30);
+    }
+    return true;
+  };
+
+  startBtn?.addEventListener('click', () => startRepoSetupTutorial({ source: 'manual' }));
+  document.getElementById('hero-open-cybernet')?.addEventListener('click', () => {
+    if (typeof window.startCybernetTutorial === 'function') window.startCybernetTutorial({ source: 'manual' });
+    else document.getElementById('hero-start-survey')?.click();
+  });
+  window.startRepoSetupTutorial = startRepoSetupTutorial;
+}
+
 function initCybernetShell() {
   const startBtn = document.getElementById('hero-start-survey');
   const tutorial = document.getElementById('cybernet-tutorial');
@@ -5051,13 +5326,28 @@ function initPasteModal() {
 // ── Cybernet Survey Wizard ───────────────────────────────────────────────────
 const CYBERNET_TUTORIAL_STEPS = [
   {
-    title: 'Prepare your target list',
-    railLabel: 'Targets',
-    body: 'First, make a simple list of the computers you want to check. Put one computer name or IP address on each line. This only prepares a local file for the next steps.',
+    title: 'Start the Cybernet survey',
+    railLabel: 'Start',
+    body: 'This tutorial teaches the field survey from beginning to end. You will load approved targets, run read-only checks from an admin machine, bring the files back, and review the dashboard results.',
+    command: '',
+    checks: [
+      'The dashboard does not run probes by itself.',
+      'You copy commands when the tutorial gives them, run them on an admin machine, then load the output files back here.',
+      'Use approved target sources only; do not broaden the survey from guessed hosts.'
+    ],
+    nextAction: 'Read this, then click Next to load or prepare your targets.',
+    note: 'Start here for Cybernet field work. Repo setup is a separate tutorial above.',
+    optional: false
+  },
+  {
+    title: 'Load your targets',
+    railLabel: 'Load targets',
+    body: 'Make the list of Cybernet computers you are allowed to check. Put one computer name or IP address on each line. This creates the target file used by the next checks.',
     command: "mkdir -p /tmp/sas-cybernet\nprintf '%s\\n' 'WMH300OPR001' 'WMH300OPR002' > /tmp/sas-cybernet/targets.txt",
     checks: [
       'Use only computer names, IPv4 addresses, or IPv6 addresses.',
       'Do not paste passwords, usernames, tickets, or notes into this file.',
+      'AD registered population is the source of registered Cybernet population; the target list is not proof by itself.',
       'If the list came from another source, you can normalize with ./survey/sas-survey-targets.sh --device-type Cybernet --file /tmp/sas-cybernet/targets.txt (output is not dashboard-importable yet).'
     ],
     nextAction: 'Copy this local setup command, run it on your admin machine, then come back and click Next.',
@@ -5065,7 +5355,7 @@ const CYBERNET_TUTORIAL_STEPS = [
     optional: false
   },
   {
-    title: 'Prove network posture first',
+    title: 'Check network posture',
     railLabel: 'Network posture',
     body: 'Now check whether your admin machine can see the targets at all. This catches guest Wi-Fi, wrong VLAN, DNS, SMB, and RPC problems before anyone blames the tool.',
     command: 'bash bash/transport/sas-network-preflight.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --ports 135,445,3389,9100 \\\n  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru',
@@ -5079,7 +5369,7 @@ const CYBERNET_TUTORIAL_STEPS = [
     optional: false
   },
   {
-    title: 'Acquire Cybernet identity evidence',
+    title: 'Collect identity evidence',
     railLabel: 'Identity evidence',
     body: 'Collect read-only identity clues from each target. The command records what it can safely observe, such as DNS, ping status, MAC hints, and transport notes.',
     command: 'bash bash/transport/sas-workstation-identity.sh \\\n  --targets-file /tmp/sas-cybernet/targets.txt \\\n  --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru',
@@ -5095,10 +5385,11 @@ const CYBERNET_TUTORIAL_STEPS = [
   {
     title: 'Optional reachability check',
     railLabel: 'Reachability',
-    body: 'This is an extra confirmation pass for approved targets. Use it only when you need low-noise port evidence after the posture and identity checks.',
+    body: 'This is an extra confirmation pass for approved targets. Use it only when you need low-noise survey discipline for port evidence after the posture and identity checks.',
     command: 'mkdir -p logs/targets logs/nmap\ncp /tmp/sas-cybernet/targets.txt logs/targets/cybernet_confirm_hosts.txt\nbash survey/sas-run-naabu-pipeline.sh --site cybernet \\\n  --profile keyports_cybernet_json \\\n  --list logs/targets/cybernet_confirm_hosts.txt \\\n  --out logs/nmap/cybernet_naabu.json',
     checks: [
       'Profile: keyports_cybernet_json (-ec -silent -json).',
+      'Naabu/Nmap output is reachability validation only.',
       'Doctrine: docs/LOW_NOISE_SURVEY_DOCTRINE.md — local evidence only, no target-side writes.',
       'This step is optional. Skip it when the earlier evidence is enough.'
     ],
@@ -5107,16 +5398,18 @@ const CYBERNET_TUTORIAL_STEPS = [
     optional: true
   },
   {
-    title: 'Load evidence and review',
-    railLabel: 'Review package',
-    body: 'Bring the files back to this dashboard. Drag the CSV or JSON outputs into Load Evidence, then review the summary before calling the result good or bad.',
+    title: 'Finish and review results',
+    railLabel: 'Review results',
+    body: 'Bring the files back to this dashboard. Drop the CSV or JSON outputs into Load Evidence, then read Review Results for the survey summary and next action.',
     command: '# Use Load Evidence in the dashboard for:\n# /tmp/sas-cybernet/network_preflight.csv\n# /tmp/sas-cybernet/workstation_identity.csv\n# logs/nmap/cybernet_naabu.json (optional)\n# survey/output/cybernet_*_targets.csv (manifest, not evidence)',
     checks: [
+      'Load Evidence is where files go in.',
+      'Review Results is where the Cybernet summary appears after evidence is loaded.',
+      'Open network evidence details when you need row-level DNS, ping, protocol, or reachability detail.',
       'Classify environment blocks separately from product defects.',
-      'Keep smoke-test evidence separate from feature validation.',
       'Treat manifest rows as target lists, not reachability or identity proof.'
     ],
-    nextAction: 'Click Load resulting evidence, then drop the files into the highlighted box.',
+    nextAction: 'Click Load resulting evidence, drop the files into the highlighted box, then read Review Results.',
     note: 'Click Load resulting evidence below, or use Load Evidence on the hero card.',
     optional: false
   }

--- a/dashboard/js/cybernet-os-preflight.js
+++ b/dashboard/js/cybernet-os-preflight.js
@@ -181,13 +181,16 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
     const commandEl = document.getElementById('cybernet-step-command');
     const noteEl = document.getElementById('cybernet-step-note');
     const osNoteEl = document.getElementById('cybernet-os-note');
+    const cardEl = document.getElementById('cybernet-os-preflight');
     if (!titleEl || !commandEl) return;
 
     const os = selectedOs();
     const title = titleEl.textContent.trim();
+    const shouldShow = title === 'Check network posture' || title === 'Collect identity evidence';
+    if (cardEl) cardEl.classList.toggle('hidden', !shouldShow);
     if (osNoteEl) osNoteEl.textContent = notes[os] || notes[AUTO];
 
-    if (title === 'Prove network posture first') {
+    if (title === 'Check network posture') {
       commandEl.value = preflightCommandFor(os);
       if (noteEl) noteEl.textContent = os === AUTO
         ? 'Run one matching section outside the dashboard, then drag network_preflight.csv back into Load Evidence.'
@@ -196,7 +199,7 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
         : 'Load network_preflight.csv into the Network tab after the command finishes.';
     }
 
-    if (title === 'Acquire Cybernet identity evidence') {
+    if (title === 'Collect identity evidence') {
       commandEl.value = identityCommandFor(os);
       if (noteEl) noteEl.textContent = os === AUTO
         ? 'Run one matching section outside the dashboard, then drag workstation_identity.csv back into Load Evidence.'

--- a/dashboard/js/launch-repo-setup-tutorial.js
+++ b/dashboard/js/launch-repo-setup-tutorial.js
@@ -1,0 +1,48 @@
+// launch-repo-setup-tutorial.js
+// Opens the repo setup tutorial when launched with ?tutorial=setup.
+(function () {
+  'use strict';
+
+  function shouldStart() {
+    const params = new URLSearchParams(window.location.search || '');
+    const tutorial = (params.get('tutorial') || '').toLowerCase();
+    const start = (params.get('start') || '').toLowerCase();
+    const hash = (window.location.hash || '').toLowerCase();
+    return tutorial === 'setup' ||
+      tutorial === 'repo-setup' ||
+      start === 'setup' ||
+      start === 'repo-setup' ||
+      hash === '#repo-setup-tutorial' ||
+      hash === '#start-repo-setup';
+  }
+
+  function startTutorial(attemptsRemaining) {
+    if (!shouldStart()) return;
+
+    const startButton = document.getElementById('hero-start-setup');
+    const tutorial = document.getElementById('repo-setup-tutorial');
+
+    if (typeof window.startRepoSetupTutorial === 'function' && tutorial) {
+      window.startRepoSetupTutorial({ source: 'query' });
+      return;
+    }
+
+    if (startButton && tutorial) {
+      startButton.click();
+      window.setTimeout(function () {
+        tutorial.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 50);
+      return;
+    }
+
+    if (attemptsRemaining > 0) {
+      window.setTimeout(function () { startTutorial(attemptsRemaining - 1); }, 100);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { startTutorial(25); });
+  } else {
+    startTutorial(25);
+  }
+})();

--- a/dashboard/js/repo-setup-tutorial.js
+++ b/dashboard/js/repo-setup-tutorial.js
@@ -1,0 +1,199 @@
+// repo-setup-tutorial.js — dashboard front-door tutorial for clone/update/open.
+
+import { sanitize, toast } from './utils.js';
+
+export const REPO_SETUP_TUTORIAL_STEPS = [
+  {
+    title: 'Get SysAdminSuite',
+    railLabel: 'Get repo',
+    body: 'Start by getting one clean copy of SysAdminSuite. Pick a parent folder such as Desktop or dev, then clone into it. Do not create a SysAdminSuite folder first.',
+    command: 'git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git',
+    checks: [
+      'The command creates the SysAdminSuite folder for you.',
+      'Avoid the common nested path: SysAdminSuite\\SysAdminSuite.',
+      'No Git available? Use the approved field release package instead of a raw source clone.'
+    ],
+    nextAction: 'Copy this only if you need to clone. After the folder exists, open it and click Next.',
+    note: 'Source clones are for IT/developer machines. Field PCs without the .NET SDK should use the field release ZIP.',
+    hasCommand: true
+  },
+  {
+    title: 'Open the dashboard',
+    railLabel: 'Open dashboard',
+    body: 'Open the SysAdminSuite folder and double-click the dashboard launcher. The launcher starts the local dashboard host and opens this browser page.',
+    command: 'START-HERE-SysAdminSuite-Dashboard.bat',
+    checks: [
+      'Run it from the repo root, not from a subfolder.',
+      'First launch may take a minute while the dashboard app is prepared.',
+      'If the machine cannot build the app, ask for the packaged field release or IT preparation.'
+    ],
+    nextAction: 'Find the launcher at the top of the repo and double-click it. Then click Next.',
+    note: 'The .cmd shortcuts are aliases, but the .bat launcher is the documented front door.',
+    hasCommand: false
+  },
+  {
+    title: 'Update safely',
+    railLabel: 'Update safely',
+    body: 'Updates are opt-in. If a newer clean main or field package is available, the launcher asks before applying it. Nothing should silently update underneath a technician.',
+    command: '# Source clone rule: approve first, then fast-forward clean main only.\n# ZIP / field package rule: approve first, then apply a checksum-verified package.',
+    checks: [
+      'Source clones update only from clean main with a fast-forward.',
+      'Field packages update only from a checksum-verified package.',
+      'Never use reset, branch deletion, or silent updates as the field path.'
+    ],
+    nextAction: 'Read this once. If the launcher asks to update, approve only when you are ready.',
+    note: 'Approved update flow is documented in docs/APPROVED_UPDATE_FLOW.md.',
+    hasCommand: false
+  },
+  {
+    title: 'Pick the workflow',
+    railLabel: 'Pick workflow',
+    body: 'Now choose what you came here to do. Cybernet Survey teaches target loading, network posture, identity evidence, optional reachability, and where results appear.',
+    command: '# Click Start Cybernet Survey for Cybernet field work.\n# Click Start Software Tracker Install only for the guarded install workflow.',
+    checks: [
+      'Use Cybernet Survey for Cybernet / Neuron target work.',
+      'Use Software Tracker Install for dry-run install planning and guarded execute.',
+      'Use Load Evidence when you already have output files to review.'
+    ],
+    nextAction: 'Click Next to finish setup, then choose the workflow button the dashboard highlights.',
+    note: 'Most Cybernet field work starts with Start Cybernet Survey.',
+    hasCommand: false
+  },
+  {
+    title: 'Ready for Cybernet Survey',
+    railLabel: 'Ready',
+    body: 'Setup is done. The next tutorial teaches the Cybernet survey from start to finish: start, load targets, run checks, finish, and review results.',
+    command: '# No command here. Click Open Cybernet Survey below.',
+    checks: [
+      'You know where the repo lives.',
+      'You know which launcher opens the dashboard.',
+      'You know updates require approval before changes are applied.'
+    ],
+    nextAction: 'Click Open Cybernet Survey to start the field survey tutorial.',
+    note: 'The Cybernet tutorial is separate so setup does not get mixed with field survey work.',
+    hasCommand: false,
+    finalAction: true
+  }
+];
+
+export function initRepoSetupTutorial() {
+  const root = document.getElementById('repo-setup-tutorial');
+  if (!root) return;
+
+  let idx = 0;
+  let copiedThisStep = false;
+  const title = document.getElementById('repo-setup-step-title');
+  const body = document.getElementById('repo-setup-step-body');
+  const kicker = document.getElementById('repo-setup-step-kicker');
+  const checks = document.getElementById('repo-setup-step-checks');
+  const command = document.getElementById('repo-setup-step-command');
+  const runner = document.getElementById('repo-setup-command-runner');
+  const note = document.getElementById('repo-setup-step-note');
+  const commandPanel = document.getElementById('repo-setup-command-panel');
+  const prev = document.getElementById('repo-setup-prev');
+  const next = document.getElementById('repo-setup-next');
+  const copy = document.getElementById('repo-setup-copy');
+  const footer = document.getElementById('repo-setup-wizard-footer');
+  const openCybernet = document.getElementById('repo-setup-open-cybernet');
+  const cybernetStart = document.getElementById('hero-start-survey');
+  const progressRail = document.getElementById('repo-setup-progress-rail');
+
+  function updateProgressRail() {
+    progressRail?.querySelectorAll('li').forEach((li, i) => {
+      li.classList.toggle('active', i === idx);
+      li.classList.toggle('done', i < idx);
+    });
+  }
+
+  function updateGuideState(hasCommand) {
+    const finalStep = idx === REPO_SETUP_TUTORIAL_STEPS.length - 1;
+    copy?.classList.toggle('sas-guide-glow', hasCommand && !copiedThisStep);
+    next?.classList.toggle('sas-guide-glow', (hasCommand && copiedThisStep) || (!hasCommand && !finalStep));
+    openCybernet?.classList.toggle('sas-guide-glow', finalStep);
+    cybernetStart?.classList.toggle('sas-guide-glow', finalStep);
+    commandPanel?.classList.toggle('sas-guide-panel', hasCommand && !copiedThisStep);
+  }
+
+  function render() {
+    const step = REPO_SETUP_TUTORIAL_STEPS[idx];
+    if (!step) return;
+    copiedThisStep = false;
+    const hasCommand = !!step.hasCommand;
+    kicker.textContent = `Step ${idx + 1} of ${REPO_SETUP_TUTORIAL_STEPS.length} — ${step.railLabel}`;
+    title.textContent = step.title;
+    body.textContent = step.body;
+    checks.innerHTML = step.checks.map(item => `<li>${sanitize(item)}</li>`).join('');
+    commandPanel?.classList.toggle('hidden', !hasCommand);
+    if (command) command.value = hasCommand ? step.command : '';
+    if (runner) runner.textContent = step.nextAction || 'Read the step, then click Next.';
+    if (note) note.textContent = step.note || '';
+    if (prev) prev.disabled = idx === 0;
+    if (next) next.textContent = step.finalAction ? 'Finish setup' : hasCommand ? 'Next after cloning →' : 'Next →';
+    copy?.classList.toggle('hidden', !hasCommand);
+    footer?.classList.toggle('hidden', !step.finalAction);
+    updateProgressRail();
+    updateGuideState(hasCommand);
+  }
+
+  function copyCommand() {
+    const text = command?.value || '';
+    if (!text) return;
+    const originalNote = note?.textContent || '';
+    const write = navigator.clipboard && typeof navigator.clipboard.writeText === 'function'
+      ? navigator.clipboard.writeText(text)
+      : new Promise((resolve, reject) => {
+          command.focus();
+          command.select();
+          try { document.execCommand('copy') ? resolve() : reject(new Error('copy unavailable')); }
+          catch (err) { reject(err); }
+        });
+    write
+      .then(() => {
+        copiedThisStep = true;
+        toast('Repo setup command copied.', 'success');
+        if (note) note.textContent = 'Command copied.';
+        updateGuideState(true);
+      })
+      .catch(() => {
+        toast('Select and copy the command manually.', 'warning');
+        if (note) note.textContent = `${originalNote} Select the command text and copy it manually if clipboard access is blocked.`;
+      })
+      .finally(() => {
+        if (note) window.setTimeout(() => { if (note.textContent === 'Command copied.') note.textContent = originalNote; }, 2200);
+      });
+  }
+
+  function openCybernetSurvey() {
+    cybernetStart?.classList.remove('sas-guide-glow');
+    openCybernet?.classList.remove('sas-guide-glow');
+    if (typeof window.startCybernetTutorial === 'function') {
+      window.startCybernetTutorial({ source: 'manual' });
+    } else {
+      cybernetStart?.click();
+    }
+  }
+
+  prev?.addEventListener('click', () => { if (idx > 0) { idx--; render(); } });
+  next?.addEventListener('click', () => {
+    const step = REPO_SETUP_TUTORIAL_STEPS[idx];
+    const hasCommand = !!step?.hasCommand;
+    if (hasCommand && step.requireCopy && !copiedThisStep) {
+      toast('Copy the clone command first, or continue only if the repo already exists.', 'warning');
+      return;
+    }
+    if (idx < REPO_SETUP_TUTORIAL_STEPS.length - 1) {
+      idx++;
+      render();
+    } else {
+      toast('Repo setup complete — choose Cybernet Survey when ready.', 'success');
+      document.getElementById('cybernet-hero')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      render();
+    }
+  });
+  copy?.addEventListener('click', copyCommand);
+  openCybernet?.addEventListener('click', openCybernetSurvey);
+
+  window.__sasResetRepoSetupWizard = () => { idx = 0; copiedThisStep = false; render(); };
+
+  render();
+}

--- a/dashboard/js/tour.js
+++ b/dashboard/js/tour.js
@@ -10,27 +10,33 @@ const STEPS = [
     target: '#header',
     title: 'Welcome to SysAdmin Suite Dashboard',
     body:
-      'This dashboard guides Cybernet field surveys — find targets, verify network posture, ' +
-      'collect identity evidence, and package results for review. ' +
-      "Let's walk through the Cybernet-first workflow.",
+      'This dashboard has two different tutorials: <strong>Repo Setup</strong> teaches clone, update, and opening the app; ' +
+      '<strong>Cybernet Survey</strong> teaches field survey work from targets to results.',
+    position: 'bottom',
+  },
+  {
+    target: '#repo-setup-hero',
+    title: 'Repo setup tutorial',
+    body:
+      'Start here when someone needs to get the repo, avoid nested folders, understand approved updates, ' +
+      'and learn which launcher opens the dashboard.',
     position: 'bottom',
   },
   {
     target: '#hero-start-survey',
-    title: 'Start here',
+    title: 'Cybernet survey tutorial',
     body:
       'Tap <strong>Start Cybernet Survey</strong> to open the step-by-step wizard. ' +
-      'It walks you through target prep, network checks, identity evidence, reachability, ' +
-      'and packaging — with copy-ready commands for each step.',
+      'It teaches how to start, load targets, run network and identity checks, finish, and read results.',
     position: 'bottom',
   },
   {
     target: '#cybernet-progress-rail',
     title: 'Survey progress',
     body:
-      'The progress rail shows where you are in the five-step survey: ' +
-      '<em>Targets</em> → <em>Network posture</em> → <em>Identity evidence</em> → ' +
-      '<em>Reachability</em> → <em>Review package</em>. ' +
+      'The progress rail shows where you are in the six-step survey: ' +
+      '<em>Start</em> → <em>Load targets</em> → <em>Network posture</em> → ' +
+      '<em>Identity evidence</em> → <em>Reachability</em> → <em>Review results</em>. ' +
       'Labels update as you advance through the wizard.',
     position: 'bottom',
   },
@@ -53,7 +59,7 @@ const STEPS = [
     body:
       'Once recognized evidence is loaded, the review summary appears here — ' +
       'a consolidated readout of your Cybernet survey package. ' +
-      'Use the link below to open detailed network evidence when you need more depth.',
+      'Use <strong>Open network evidence details</strong> when you need row-level DNS, ping, port, or identity detail.',
     position: 'bottom',
     reveal: () => {
       document.getElementById('cybernet-review')?.classList.remove('hidden');
@@ -95,7 +101,7 @@ const STEPS = [
     target: '#sas-tour-launch-btn',
     title: "You're all set!",
     body:
-      'That covers the Cybernet-first workflow on the SysAdmin Suite Dashboard.<br><br>' +
+      'That covers the dashboard map: setup first, then the workflow tutorial for the work at hand.<br><br>' +
       'You can relaunch this tour from <strong>Interactive tour</strong> inside ' +
       '<strong>Advanced Tools</strong>, or by pressing ' +
       '<kbd style="background:#0d1420;color:#f6ad55;' +

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -174,10 +174,17 @@ if (failed > 0) process.exit(1);
 const indexHtml = readFileSync(join(__dir, 'index.html'), 'utf8');
 
 const shellChecks = [
+  ['repo-setup-hero', 'Repo Setup hero'],
+  ['id="hero-start-setup"', 'Primary CTA Start Repo Setup'],
+  ['id="repo-setup-tutorial"', 'Repo Setup tutorial container'],
+  ['id="hero-open-cybernet"', 'Repo setup handoff to Cybernet'],
   ['cybernet-hero', 'Cybernet-first hero'],
   ['software-tracker-hero', 'Software Tracker install hero'],
   ['id="hero-start-install"', 'Primary CTA Start Software Tracker Install'],
   ['workflow-tutorial', 'Shared workflow tutorial CSS class'],
+  ['Start', 'Cybernet Start rail label'],
+  ['Load targets', 'Cybernet Load targets rail label'],
+  ['Review results', 'Cybernet Review results rail label'],
   ['id="hero-start-survey"', 'Primary CTA Start Cybernet Survey'],
   ['Start Cybernet Survey', 'Start Cybernet Survey label'],
   ['id="hero-load-evidence"', 'Load Evidence entry'],
@@ -191,6 +198,9 @@ const shellChecks = [
 // Wizard command contracts live in app.js (bundled); verify source for CI without loading bundle
 const appJs = readFileSync(join(__dir, 'js', 'app.js'), 'utf8');
 const contractChecks = [
+  ['initRepoSetupTutorial', 'Repo Setup tutorial init'],
+  ['initRepoSetupShell', 'Repo Setup hero shell'],
+  ['window.startRepoSetupTutorial', 'Repo Setup transition exposed'],
   ['software-tracker-install-plan', 'install plan parser type wired'],
   ['setSoftwareInstallPlan', 'install plan state wiring'],
   ['initSoftwareTrackerTutorial', 'Software Tracker tutorial init'],
@@ -345,9 +355,9 @@ for (const [, selector] of tourTargetMatches) {
 const doneBeforeInit = /localStorage\.setItem\(\s*['"]sas_tour_v1_done['"][\s\S]*?\n[\s\S]*?initTour\s*\(\s*\)/.test(appJs);
 tourAssert(doneBeforeInit, 'auto-launch-suppressed-before-initTour');
 
-// Cybernet-first tour targets
-for (const needle of ['#hero-start-survey', '#cybernet-review', '#advanced-tools-toggle']) {
-  tourAssert(tourJs.includes(`target: '${needle}'`), `cybernet-target:${needle}`);
+// Dashboard map tour targets
+for (const needle of ['#repo-setup-hero', '#hero-start-survey', '#cybernet-review', '#advanced-tools-toggle']) {
+  tourAssert(tourJs.includes(`target: '${needle}'`), `dashboard-map-target:${needle}`);
 }
 
 // Stale pre-refactor copy must not appear
@@ -373,6 +383,7 @@ if (tourFailed > 0) process.exit(1);
 const bundleJs = readFileSync(join(__dir, 'js', 'bundle.js'), 'utf8');
 const preflightJs = readFileSync(join(__dir, 'js', 'cybernet-os-preflight.js'), 'utf8');
 const launchJs = readFileSync(join(__dir, 'js', 'launch-cybernet-tutorial.js'), 'utf8');
+const launchSetupJs = readFileSync(join(__dir, 'js', 'launch-repo-setup-tutorial.js'), 'utf8');
 
 let startPassed = 0;
 let startFailed = 0;
@@ -382,8 +393,11 @@ function startAssert(ok, label, detail) {
 }
 
 startAssert(indexHtml.includes('id="cybernet-hero-status"'), 'hero-status-in-html', 'missing cybernet-hero-status');
+startAssert(indexHtml.includes('id="repo-setup-hero-status"'), 'setup-hero-status-in-html', 'missing repo-setup-hero-status');
 startAssert(appJs.includes('startCybernetTutorial'), 'explicit-transition', 'app.js missing startCybernetTutorial');
 startAssert(appJs.includes('window.startCybernetTutorial'), 'transition-exposed', 'app.js does not expose startCybernetTutorial');
+startAssert(appJs.includes('startRepoSetupTutorial'), 'setup-explicit-transition', 'app.js missing startRepoSetupTutorial');
+startAssert(appJs.includes('window.startRepoSetupTutorial'), 'setup-transition-exposed', 'app.js does not expose startRepoSetupTutorial');
 startAssert(appJs.includes('getComputedStyle'), 'verifies-visibility', 'app.js does not verify tutorial visibility');
 startAssert(appJs.includes("tutorial.style.display = ''"), 'clears-inline-none', 'app.js does not clear a stale inline display:none');
 startAssert(/Restart Cybernet Survey/.test(appJs), 'recovery-control', 'app.js missing Restart recovery control');
@@ -395,8 +409,14 @@ startAssert(!preflightJs.includes('syncTutorialVisibility'), 'preflight-not-gati
   'cybernet-os-preflight.js still forces the wizard hidden');
 startAssert(launchJs.includes('window.startCybernetTutorial'), 'auto-start-uses-transition',
   'launch-cybernet-tutorial.js does not use the verified transition');
+startAssert(launchSetupJs.includes('window.startRepoSetupTutorial'), 'setup-auto-start-uses-transition',
+  'launch-repo-setup-tutorial.js does not use the verified transition');
+startAssert(launchSetupJs.includes("tutorial === 'setup'"), 'setup-query-supported',
+  'launch-repo-setup-tutorial.js does not support ?tutorial=setup');
 startAssert(bundleJs.includes('initSoftwareTrackerTutorial'), 'bundle-software-tutorial',
   'bundle.js is stale — missing Software Tracker tutorial; rebuild with: node dashboard/build-bundle.js');
+startAssert(bundleJs.includes('initRepoSetupTutorial'), 'bundle-repo-setup-tutorial',
+  'bundle.js is stale — missing Repo Setup tutorial; rebuild with: node dashboard/build-bundle.js');
 startAssert(bundleJs.includes('startCybernetTutorial'), 'bundle-not-stale',
   'bundle.js is stale — rebuild with: node dashboard/build-bundle.js');
 

--- a/dashboard/start-button-smoke.js
+++ b/dashboard/start-button-smoke.js
@@ -13,6 +13,7 @@
 //   3. Rogue inline display:none on the wizard (the original bug) — opening must
 //      clear it so the wizard still shows.
 //   4. ?tutorial=cybernet auto-start — routes through the same verified path.
+//   5. ?tutorial=setup auto-start — routes through the Repo Setup verified path.
 
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
@@ -100,6 +101,12 @@ const startBtn = seed('hero-start-survey');
 startBtn.textContent = 'Start Cybernet Survey';
 seed('cybernet-hero-actions');
 seed('cybernet-hero-status', ['hidden']);
+const setupTutorial = seed('repo-setup-tutorial', ['hidden']);
+const setupStartBtn = seed('hero-start-setup');
+setupStartBtn.textContent = 'Start Repo Setup';
+seed('repo-setup-hero-actions');
+seed('repo-setup-hero-status', ['hidden']);
+seed('hero-open-cybernet');
 seed('toast-container');
 
 const document = {
@@ -192,6 +199,7 @@ fireDomReady();
 assert(!isVisible(tutorial), 'initial-wizard-hidden', 'wizard should start hidden');
 assert(startBtn.textContent === 'Start Cybernet Survey', 'initial-start-label', `was "${startBtn.textContent}"`);
 assert(typeof window.startCybernetTutorial === 'function', 'transition-exposed', 'window.startCybernetTutorial missing');
+assert(typeof window.startRepoSetupTutorial === 'function', 'setup-transition-exposed', 'window.startRepoSetupTutorial missing');
 
 // State 3 (the original bug): a rogue inline display:none must not survive open.
 tutorial.style.display = 'none';
@@ -219,6 +227,17 @@ runScript('js/launch-cybernet-tutorial.js');
 assert(isVisible(tutorial), 'auto-start-opens-wizard', 'auto-start left the wizard hidden');
 assert(/restart/i.test(startBtn.textContent), 'auto-start-transforms-start',
   `auto-start did not transform Start (was "${startBtn.textContent}")`);
+
+// State 5: ?tutorial=setup auto-start uses the Repo Setup verified path.
+setupTutorial.classList.add('hidden');
+setupTutorial.style.display = 'none';
+setupStartBtn.textContent = 'Start Repo Setup';
+window.location.search = '?tutorial=setup';
+document.readyState = 'complete';
+runScript('js/launch-repo-setup-tutorial.js');
+assert(isVisible(setupTutorial), 'setup-auto-start-opens-wizard', 'setup auto-start left the wizard hidden');
+assert(/restart/i.test(setupStartBtn.textContent), 'setup-auto-start-transforms-start',
+  `setup auto-start did not transform Start (was "${setupStartBtn.textContent}")`);
 
 console.log(`\nStart button: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md
+++ b/docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md
@@ -1,0 +1,95 @@
+# Dashboard Dependency Bootstrap
+
+SysAdminSuite dashboard launchers prepare the local dashboard host before the
+browser opens. The bootstrap is Bash-first and uses official Microsoft .NET
+installers only.
+
+## What Gets Ensured
+
+The dashboard host is a framework-dependent Windows app. It needs:
+
+- `.NET 8 ASP.NET Core Runtime` (`Microsoft.AspNetCore.App`)
+- `.NET 8 Windows Desktop Runtime` (`Microsoft.WindowsDesktop.App`)
+- `.NET 8 SDK` only when a source checkout has no built host yet
+
+Pinned installer metadata lives in [`Config/dotnet-bootstrap.json`](../Config/dotnet-bootstrap.json).
+Downloaded installers are cached under `tools/cache/dotnet/`, which is ignored
+by git.
+
+## First-Run Flow
+
+```mermaid
+flowchart TD
+    launcher[DoubleClick_Launcher]
+    bash[Git_Bash_Bootstrap]
+    hostFound{Host_Exe_Found}
+    runtime[Ensure_DotNet_Runtimes]
+    sdk[Ensure_DotNet_SDK]
+    publish[Publish_Host_To_AppBin]
+    start[Start_Dashboard_Host]
+    browser[Open_Browser]
+
+    launcher --> bash
+    bash --> hostFound
+    hostFound -->|yes| runtime
+    hostFound -->|no| sdk
+    sdk --> publish
+    publish --> runtime
+    runtime --> start
+    start --> browser
+```
+
+## Launcher Contract
+
+`START-HERE-SysAdminSuite-Dashboard.bat` is the field front door. It calls
+`Launch-SysAdminSuiteDashboard.Host.bat`, which calls:
+
+```bash
+bash scripts/ensure-dashboard-host.sh
+```
+
+That script:
+
+1. Reuses an existing host if one is present.
+2. Ensures the required .NET 8 runtimes system-wide.
+3. Installs the official Microsoft .NET 8 SDK only when a source checkout must
+   build the host.
+4. Publishes the host to `app/bin/`, an ignored packaged-layout path reused by
+   later launches.
+
+The browser URL cannot install dependencies on its own. If a user types
+`http://127.0.0.1:5000/dashboard/` and nothing is listening, they must run the
+launcher first.
+
+## Browser, CMD, And EXE Entry Points
+
+- `.bat` and `.cmd` launchers run the Bash bootstrap before opening the browser.
+- Browser-only entry works after the local host is already running; it cannot
+  install OS dependencies by itself.
+- Framework-dependent `.NET` EXEs cannot bootstrap a missing .NET runtime before
+  process startup. EXE-first delivery needs either a self-contained publish or a
+  small native bootstrapper; until then, use `START-HERE-SysAdminSuite-Dashboard.bat`
+  or its `.cmd` aliases as the dependency-preparing front door.
+
+## Safety And Hygiene
+
+- No `winget`, Chocolatey, or third-party package sources are used.
+- Installer hashes come from Microsoft .NET release metadata and are verified
+  with SHA512 before execution.
+- `--dry-run` is available for contract tests and operator review.
+- Installer cache and publish outputs stay local and ignored.
+- System-wide installation may create normal OS, installer, and endpoint
+  telemetry. The suite uses scope control and clear operator intent; it does
+  not attempt to hide or suppress logs.
+
+## Failure Guidance
+
+| Failure | Likely Cause | Next Action |
+|---------|--------------|-------------|
+| Git Bash missing | Git for Windows is not installed or not on PATH | Install Git for Windows or use the field release package |
+| Download/checksum failure | Microsoft download blocked or tampered/incomplete file | Retry on approved network or have IT stage the field release |
+| Install failure | Administrator approval required or installer blocked | Have IT/admin prepare the workstation |
+| Build failure | SDK install blocked or source checkout incomplete | Use the field release package or inspect build output |
+
+Field release packages remain valid for locked-down PCs. They avoid the SDK
+build path and ship a pre-built host under `app/bin/`.

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -5,12 +5,14 @@
 ## Field user answer (plain language)
 
 > Double-click **`START-HERE-SysAdminSuite-Dashboard.bat`** at the repo root.
-> Your browser opens `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
+> Your browser opens `http://127.0.0.1:5000/dashboard/?tutorial=setup`.
 > CLI tools are optional — use them only when the dashboard or a runbook says so.
 
-On first run the launcher will **automatically prepare (build) the dashboard host** if it is missing — it runs `tools/publish-dashboard-entrypoint.ps1` for the user, waits for the host to respond on port 5000, and only then opens the browser. Field users are never told to run the publish command by hand. If the build cannot run (no .NET SDK), the launcher shows a field-safe message directing the user to the **field release package** or IT/admin preparation.
+On first run the launcher will **automatically prepare the dashboard host** if dependencies or the host are missing — it runs `scripts/ensure-dashboard-host.sh` through Git Bash, installs official Microsoft .NET 8 dependencies system-wide when needed, waits for the host to respond on port 5000, and only then opens the browser. Field users are never told to run the publish command by hand. If Microsoft downloads, installer approval, or the build cannot run, the launcher shows a field-safe message directing the user to the **field release package** or IT/admin preparation.
 
 **Field release package (no SDK):** [`DASHBOARD_FIELD_RELEASE.md`](DASHBOARD_FIELD_RELEASE.md) — pre-built zip with `app/bin/SysAdminSuite.DashboardHost.exe`.
+
+**Dependency bootstrap:** [`DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](DASHBOARD_DEPENDENCY_BOOTSTRAP.md) — pinned Microsoft installers, SHA512 verification, ignored local cache.
 
 **Updates:** launcher checks are opt-in and must prompt before applying changes. Source clones use a clean `main` fast-forward; ZIP/field packages use checksum-verified manifests. See [`APPROVED_UPDATE_FLOW.md`](APPROVED_UPDATE_FLOW.md).
 
@@ -26,23 +28,24 @@ git clone https://github.com/EndeavorEverlasting/SysAdminSuite.git
 
 This creates the `SysAdminSuite` folder; they then open it and double-click `START-HERE-SysAdminSuite-Dashboard.bat`.
 
-Warn against the common mistake: do **not** create a `SysAdminSuite` folder first and clone inside it, which produces `SysAdminSuite\SysAdminSuite` and hides the launcher one level deep. ZIP download via the GitHub **Code** button is an equivalent no-Git path for developers; **field users without the .NET SDK** should use the dashboard field release package instead ([`DASHBOARD_FIELD_RELEASE.md`](DASHBOARD_FIELD_RELEASE.md)).
+Warn against the common mistake: do **not** create a `SysAdminSuite` folder first and clone inside it, which produces `SysAdminSuite\SysAdminSuite` and hides the launcher one level deep. ZIP download via the GitHub **Code** button is an equivalent no-Git path for developers. Locked-down field PCs where Microsoft downloads or admin installs are blocked should use the dashboard field release package instead ([`DASHBOARD_FIELD_RELEASE.md`](DASHBOARD_FIELD_RELEASE.md)).
 
 ## Launcher matrix
 
 | File | Audience | What it does |
 |------|----------|--------------|
-| `START-HERE-SysAdminSuite-Dashboard.bat` | **Field users (primary)** | Friendly console, starts host, opens browser; Cybernet + Software Tracker front-door workflows |
+| `START-HERE-SysAdminSuite-Dashboard.bat` | **Field users (primary)** | Friendly console, starts host, opens browser; Repo Setup, Cybernet, and Software Tracker front-door workflows |
 
-After the dashboard loads, field users see two front-door heroes:
+After the dashboard loads, field users see three front-door heroes:
 
+- **Repo Setup** — `Start Repo Setup` (clone/download, update approval, and launcher basics)
 - **Cybernet Survey** — `Start Cybernet Survey` (target acquisition wizard)
 - **Software Tracker Install** — `Start Software Tracker Install` (dry-run → approve → guarded execute tutorial)
 
 Software Tracker install details: [`SOFTWARE_TRACKER_INSTALLS.md`](SOFTWARE_TRACKER_INSTALLS.md).
 | `START-HERE-SysAdminSuite-Dashboard.cmd` | Compatibility alias | Calls the `.bat` launcher |
 | `SysAdminSuite Dashboard.cmd` | Field desktops / shortcuts | Alias of the START-HERE `.bat` |
-| `Launch-SysAdminSuiteDashboard.Host.bat` | IT / developers | Spawns tray host only (no extra messaging) |
+| `Launch-SysAdminSuiteDashboard.Host.bat` | IT / developers | Ensures dependencies/host via Bash bootstrap, then spawns tray host |
 | `Launch-SysAdminSuite-Runtime.bat` `[3]` | Portable zip | Menu entry for .NET host |
 | `Launch-SysAdminSuiteDashboard.bat` | Permissive sites | Legacy PS + Python path |
 | `dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe` | **Local build only** | Not committed; see publish script below |
@@ -67,13 +70,18 @@ Agents must **not** tell lay users to run `python3 -m http.server`, raw `dotnet`
 4. `src/SysAdminSuite.DashboardHost/bin/Release/net8.0-windows/...`
 5. `src/SysAdminSuite.DashboardHost/bin/Debug/net8.0-windows/...`
 
+If no host exists, `scripts/ensure-dashboard-host.sh` ensures the .NET 8 SDK
+and publishes to ignored `app/bin/` so later launches reuse the packaged layout.
+If a framework-dependent host exists, the same bootstrap ensures
+`Microsoft.AspNetCore.App` and `Microsoft.WindowsDesktop.App` 8.x are installed.
+
 ## Build local EXE (developer / IT)
 
 ```powershell
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools\publish-dashboard-entrypoint.ps1
 ```
 
-Requires .NET 8 SDK to build; .NET 8 runtime on the target to run (framework-dependent publish).
+Manual publish remains available for IT, but it is no longer the first-run field path. Requires .NET 8 SDK to build; the launched host requires .NET 8 ASP.NET Core and Windows Desktop runtimes when framework-dependent.
 
 ## Browser tab icon (Harold)
 
@@ -88,14 +96,16 @@ See [`dashboard/README.md`](../dashboard/README.md) — **Loading experience (Hi
 
 | Symptom | Action |
 |---------|--------|
-| Browser did not open | Paste `http://127.0.0.1:5000/dashboard/?tutorial=cybernet` |
-| Host exe not found | The `.bat` builds it automatically on first run. If the build fails, get the packaged release or have IT/admin prepare the machine (do not tell field users to run publish by hand) |
+| Browser did not open | If the host is already running, paste `http://127.0.0.1:5000/dashboard/?tutorial=setup`; if nothing is listening, run `START-HERE-SysAdminSuite-Dashboard.bat` first |
+| Host exe not found | The `.bat` prepares it automatically on first run. If bootstrap fails, get the packaged release or have IT/admin prepare the machine (do not tell field users to run publish by hand) |
+| Dependency bootstrap failed | Check Git Bash, Microsoft download access, checksum verification, and administrator approval; see `DASHBOARD_DEPENDENCY_BOOTSTRAP.md` |
 | Port 5000 in use | Stop prior instance from tray icon |
 | User asks "do I run code?" | Point to `START-HERE-SysAdminSuite-Dashboard.bat` double-click; read [`START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) |
 
 ## Related docs
 
 - [`START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) — lay user guide
+- [`docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](DASHBOARD_DEPENDENCY_BOOTSTRAP.md) — first-run .NET dependency bootstrap
 - [`docs/GUI_HOST_MIGRATION.md`](GUI_HOST_MIGRATION.md) — launcher technical matrix
 - [`docs/DASHBOARD_EXE_FUTURE_SPRINT.md`](DASHBOARD_EXE_FUTURE_SPRINT.md) — planned EXE sprint
 - [`START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md) — advanced CLI path

--- a/docs/DASHBOARD_EXE_FUTURE_SPRINT.md
+++ b/docs/DASHBOARD_EXE_FUTURE_SPRINT.md
@@ -26,7 +26,7 @@ Give field users an `.exe` they can pin, shortcut, or receive in a portable zip 
    - Optional: copy into portable zip `app/bin/` via `New-PortableArtifact.ps1`
 
 2. **Root shortcut**
-   - Either commit a small bootstrap `.exe` that shells the host, or document that portable zip includes the exe at a fixed path
+   - Either commit a small native bootstrap `.exe` that runs the dashboard dependency bootstrap before shelling the host, or document that portable zip includes a self-contained exe at a fixed path
    - Keep the `.bat` launcher (and `.cmd` aliases) as fallback for git clones
 
 3. **Signing / trust**
@@ -49,6 +49,7 @@ Give field users an `.exe` they can pin, shortcut, or receive in a portable zip 
 ## Acceptance criteria
 
 - [ ] Field tech double-clicks one obvious `.exe` (or portable zip entry) with no dotnet/SDK on machine (if self-contained) or documented runtime prerequisite (if framework-dependent)
+- [ ] EXE-first path is honest about bootstrap limits: framework-dependent .NET EXEs cannot install a missing runtime before process startup; use self-contained publish or a native bootstrapper for no-runtime machines
 - [ ] Browser opens `http://127.0.0.1:5000/dashboard/` with Harold favicon
 - [ ] Tray icon works (Open / Copy URL / Stop)
 - [ ] `START-HERE-SysAdminSuite-Dashboard.bat` (and `.cmd` aliases) still work for git-clone workflows

--- a/docs/DASHBOARD_FIELD_RELEASE.md
+++ b/docs/DASHBOARD_FIELD_RELEASE.md
@@ -1,15 +1,18 @@
 # Dashboard Field Release Package
 
-**Agent canonical reference** for how field users get the dashboard **without** the .NET SDK.
+**Agent canonical reference** for how field users get the dashboard when source
+checkout dependency bootstrap is not appropriate or is blocked.
 
 ## Two delivery paths
 
 | Path | Who | What you get | .NET SDK on target? | Launcher behavior |
 |------|-----|--------------|---------------------|-------------------|
-| **Source clone** | Developers, IT building from git | Full repository | Helpful on first run (auto-build) | Prepares `dist/` or `tools/publish/` on first double-click if SDK present |
-| **Field release package** | Technicians, lay users | Pre-built ZIP with host under `app/bin/` | **Not required** (runtime only) | Double-click starts immediately; no build step |
+| **Source clone** | Developers, IT building from git | Full repository | Can be installed by bootstrap if missing | Downloads official Microsoft .NET dependencies if needed, then prepares `app/bin/` |
+| **Field release package** | Technicians, lay users on locked-down PCs | Pre-built ZIP with host under `app/bin/` | **Not required** | Double-click starts included host; runtime bootstrap may still run if framework-dependent runtimes are missing |
 
-Field users on locked-down PCs should receive the **field release package**, not a raw git clone.
+Field users on locked-down PCs where Microsoft downloads or administrator
+installer approval are blocked should receive the **field release package**, not
+a raw git clone.
 
 Updates are also package-based for this path. The launcher may prompt when a
 trusted manifest says a newer field package is available; it uses a
@@ -44,7 +47,7 @@ FIELD-RELEASE-README.txt
 1. Copy the zip (and manifest) to an approved channel (internal share, GitHub Release asset, Software Center).
 2. Field user extracts the zip to a folder of their choice.
 3. Field user double-clicks `START-HERE-SysAdminSuite-Dashboard.bat`.
-4. Browser opens `http://127.0.0.1:5000/dashboard/?tutorial=cybernet`.
+4. Browser opens `http://127.0.0.1:5000/dashboard/?tutorial=setup`.
 
 No git, no dotnet SDK, no manual publish command.
 
@@ -59,18 +62,19 @@ The root `.bat` tells the user which path applies:
 | Situation | User sees |
 |-----------|-----------|
 | Packaged release (`app/bin/` host present) | “Packaged field release detected — no build step required” |
-| Source clone, SDK available | “Source checkout — may be prepared on first run” then auto-build |
-| Source clone, no SDK | Field-safe error: ask for field release package or IT prep |
+| Source clone, dependencies missing | “Source checkout — may be prepared on first run” then Microsoft .NET bootstrap and auto-build |
+| Source clone, bootstrap blocked | Field-safe error: ask for field release package or IT prep |
 
 ## Requirements on target workstation
 
 - Windows 10 or later
-- .NET 8 **runtime** (framework-dependent publish; SDK not required for field package)
-- No internet required after the package is extracted
+- .NET 8 ASP.NET Core and Windows Desktop runtimes for framework-dependent packages
+- No internet required after dependencies are installed or the package is extracted
 
 ## Related docs
 
 - [`DASHBOARD_ENTRYPOINT.md`](DASHBOARD_ENTRYPOINT.md) — launcher matrix and troubleshooting
+- [`DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](DASHBOARD_DEPENDENCY_BOOTSTRAP.md) — source checkout dependency bootstrap
 - [`START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) — lay-user guide (applies inside both clone and field package)
 - [`DEPLOYMENT_ARTIFACTS.md`](DEPLOYMENT_ARTIFACTS.md) — full portable runtime zip (broader than dashboard-only)
 - [`releases/PUBLISH.md`](releases/PUBLISH.md) — publishing checksums and channels

--- a/docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md
+++ b/docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md
@@ -14,16 +14,16 @@ Use this when you have approved target documentation, a local admin workstation,
 | No evasion | Do not use decoys, spoofing, stealth flags, vuln scripts, brute force, or credential attacks. This is inventory discovery, not magic ninja theater. |
 | Nmap is not a serial oracle | Nmap can help with live hosts, DNS, MACs, and open ports. Device serial matching comes from trackers, AD/CMDB exports, known manifests, or approved host probes. |
 
-## Dashboard quick path (Cybernet-first UI)
+## Dashboard quick path (Cybernet Survey UI)
 
-The dashboard leads with **Start Cybernet Survey**, not Live Mode. Use this path when you already have a target list and want posture, identity, and optional reachability evidence reviewed in one place.
+The dashboard opens Repo Setup first, then lets you choose **Start Cybernet Survey**. Use the survey path when you already have or can prepare an approved target list and want posture, identity, and optional reachability evidence reviewed in one place.
 
-1. Open `http://localhost:8000/dashboard/` (see [`dashboard/README.md`](../../dashboard/README.md)).
-2. Click **Start Cybernet Survey** and walk the wizard: Targets → Network posture → Identity evidence → optional Reachability → Review package.
+1. Open `http://127.0.0.1:5000/dashboard/?tutorial=setup` (see [`dashboard/README.md`](../../dashboard/README.md)).
+2. Click **Start Cybernet Survey** and walk the wizard: Start → Load targets → Network posture → Identity evidence → optional Reachability → Review results.
 3. Copy and run the posture and identity commands on the admin workstation.
-4. Optionally run step 4 (**Optional reachability check**; profile `keyports_cybernet_json` in step details) when port confirmation is justified.
+4. Optionally run **Optional reachability check**; profile `keyports_cybernet_json` in step details when port confirmation is justified.
 5. Click **Load Evidence** and import the resulting CSVs/JSON.
-6. Read **Review Results**; use **Advanced Tools** for detailed panels or **Generate Survey Commands** (legacy Live Mode) only when needed.
+6. Read **Review Results**; use **Open network evidence details** or **Advanced Tools** for detailed panels only when needed.
 
 The CLI steps below cover the full subnet-discovery orchestrator path (local context, DNS list, Nmap, resolve, package). Use that path when you need approved CIDR discovery, not just a guided target-list survey.
 

--- a/scripts/ensure-dashboard-host.sh
+++ b/scripts/ensure-dashboard-host.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Prepare the SysAdminSuite dashboard host for first use.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRY_RUN=0
+CONFIGURATION="Release"
+RUNTIME_IDENTIFIER="win-x64"
+PUBLISH_DIR="${REPO_ROOT}/app/bin"
+PROJECT="${REPO_ROOT}/src/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.csproj"
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/ensure-dashboard-host.sh [--dry-run]
+
+Ensures the dashboard host can run on this Windows workstation. Existing host
+executables are reused. If the host is missing on a source checkout, the script
+ensures the .NET 8 SDK, publishes the host into app/bin/, and ensures required
+.NET 8 runtime frameworks are installed system-wide.
+
+Options:
+  --dry-run   Print planned actions only
+  -h, --help  Show help
+USAGE
+}
+
+log() { printf '[ensure-dashboard-host] %s\n' "$*" >&2; }
+fail() { printf '[ensure-dashboard-host] ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+dotnet_cmd() {
+  if command -v dotnet.exe >/dev/null 2>&1; then command -v dotnet.exe; return 0; fi
+  if command -v dotnet >/dev/null 2>&1; then command -v dotnet; return 0; fi
+  if [[ -x "/c/Program Files/dotnet/dotnet.exe" ]]; then printf '%s\n' "/c/Program Files/dotnet/dotnet.exe"; return 0; fi
+  if [[ -x "/c/Program Files (x86)/dotnet/dotnet.exe" ]]; then printf '%s\n' "/c/Program Files (x86)/dotnet/dotnet.exe"; return 0; fi
+  return 1
+}
+
+find_host() {
+  local candidates=(
+    "${REPO_ROOT}/app/bin/SysAdminSuite.DashboardHost.exe"
+    "${REPO_ROOT}/dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe"
+    "${REPO_ROOT}/tools/publish/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.exe"
+    "${REPO_ROOT}/src/SysAdminSuite.DashboardHost/bin/Release/net8.0-windows/SysAdminSuite.DashboardHost.exe"
+    "${REPO_ROOT}/src/SysAdminSuite.DashboardHost/bin/Debug/net8.0-windows/SysAdminSuite.DashboardHost.exe"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_runtime() {
+  local args=()
+  [[ "$DRY_RUN" -eq 1 ]] && args+=(--dry-run)
+  bash "${SCRIPT_DIR}/ensure-dotnet-runtime.sh" "${args[@]}"
+}
+
+ensure_sdk() {
+  local args=()
+  [[ "$DRY_RUN" -eq 1 ]] && args+=(--dry-run)
+  bash "${SCRIPT_DIR}/ensure-dotnet-sdk.sh" "${args[@]}"
+}
+
+publish_host() {
+  local dotnet_bin
+  [[ -f "$PROJECT" ]] || fail "Dashboard host project not found: $PROJECT" 3
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY-RUN: would publish dashboard host to $PUBLISH_DIR"
+    log "DRY-RUN: dotnet publish $PROJECT -c $CONFIGURATION -r $RUNTIME_IDENTIFIER --self-contained false -o $PUBLISH_DIR"
+    return 0
+  fi
+  dotnet_bin="$(dotnet_cmd)" || fail ".NET SDK install completed, but dotnet is still not visible" 3
+  mkdir -p "$PUBLISH_DIR"
+  log "Publishing dashboard host to app/bin for future first-run reuse..."
+  "$dotnet_bin" publish "$PROJECT" -c "$CONFIGURATION" -r "$RUNTIME_IDENTIFIER" --self-contained false -o "$PUBLISH_DIR" \
+    || fail "dotnet publish failed" 3
+}
+
+if host_path="$(find_host)"; then
+  log "Found dashboard host: $host_path"
+  ensure_runtime
+  printf '%s\n' "$host_path"
+  exit 0
+fi
+
+log "Dashboard host missing; preparing source checkout for first use."
+ensure_sdk
+publish_host
+ensure_runtime
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '%s\n' "${PUBLISH_DIR}/SysAdminSuite.DashboardHost.exe"
+  exit 0
+fi
+
+host_path="$(find_host)" || fail "Dashboard host could not be built or located" 3
+printf '%s\n' "$host_path"

--- a/scripts/ensure-dotnet-runtime.sh
+++ b/scripts/ensure-dotnet-runtime.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Ensure dashboard-required .NET 8 runtimes are installed system-wide.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG="${REPO_ROOT}/Config/dotnet-bootstrap.json"
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/ensure-dotnet-runtime.sh [--dry-run]
+
+Ensures the system-wide .NET 8 shared frameworks required by the dashboard host:
+  - Microsoft.AspNetCore.App
+  - Microsoft.WindowsDesktop.App
+
+Missing runtimes are downloaded from pinned Microsoft URLs in
+Config/dotnet-bootstrap.json and verified with SHA512 before installation.
+
+Options:
+  --dry-run   Print planned download/install actions only
+  -h, --help  Show help
+USAGE
+}
+
+log() { printf '[ensure-dotnet-runtime] %s\n' "$*" >&2; }
+fail() { printf '[ensure-dotnet-runtime] ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -f "$CONFIG" ]] || fail "Missing bootstrap config: $CONFIG"
+
+json_value() {
+  local section="$1" key="$2"
+  awk -v section="\"${section}\"" -v key="\"${key}\"" '
+    $0 ~ section { in_section=1; next }
+    in_section && $0 ~ /^[[:space:]]*}/ { exit }
+    in_section && $0 ~ key {
+      sub(/^[^:]*:[[:space:]]*"/, "")
+      sub(/",[[:space:]]*$/, "")
+      sub(/"[[:space:]]*$/, "")
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+cache_dir() {
+  local configured
+  configured="$(awk '
+    /"cacheDir"/ {
+      sub(/^[^:]*:[[:space:]]*"/, "")
+      sub(/",[[:space:]]*$/, "")
+      sub(/"[[:space:]]*$/, "")
+      print
+      exit
+    }
+  ' "$CONFIG")"
+  printf '%s\n' "${REPO_ROOT}/${configured:-tools/cache/dotnet}"
+}
+
+dotnet_cmd() {
+  if command -v dotnet.exe >/dev/null 2>&1; then command -v dotnet.exe; return 0; fi
+  if command -v dotnet >/dev/null 2>&1; then command -v dotnet; return 0; fi
+  if [[ -x "/c/Program Files/dotnet/dotnet.exe" ]]; then printf '%s\n' "/c/Program Files/dotnet/dotnet.exe"; return 0; fi
+  if [[ -x "/c/Program Files (x86)/dotnet/dotnet.exe" ]]; then printf '%s\n' "/c/Program Files (x86)/dotnet/dotnet.exe"; return 0; fi
+  return 1
+}
+
+runtime_present() {
+  local framework="$1" version_prefix="$2" dotnet_bin
+  dotnet_bin="$(dotnet_cmd)" || return 1
+  "$dotnet_bin" --list-runtimes 2>/dev/null | grep -Eq "^${framework}[[:space:]]+${version_prefix}"
+}
+
+download_file() {
+  local url="$1" target="$2"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY-RUN: would download $url -> $target"
+    return 0
+  fi
+  mkdir -p "$(dirname "$target")"
+  if command -v curl.exe >/dev/null 2>&1; then
+    curl.exe -fsSL --retry 3 --retry-delay 2 -o "$target" "$url"
+  elif command -v curl >/dev/null 2>&1; then
+    curl -fsSL --retry 3 --retry-delay 2 -o "$target" "$url"
+  else
+    fail "curl.exe or curl is required to download Microsoft .NET installers" 2
+  fi
+}
+
+actual_sha512() {
+  local path="$1"
+  if command -v sha512sum >/dev/null 2>&1; then
+    sha512sum "$path" | awk '{print tolower($1)}'
+    return 0
+  fi
+  if command -v certutil.exe >/dev/null 2>&1; then
+    certutil.exe -hashfile "$(windows_path "$path")" SHA512 2>/dev/null \
+      | tr -d '\r ' \
+      | awk 'length($0) == 128 { print tolower($0); exit }'
+    return 0
+  fi
+  fail "sha512sum or certutil.exe is required to verify .NET installers" 2
+}
+
+windows_path() {
+  local path="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$path"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+verify_hash() {
+  local path="$1" expected="$2" actual
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY-RUN: would verify SHA512 for $path"
+    return 0
+  fi
+  actual="$(actual_sha512 "$path")"
+  [[ "${actual,,}" == "${expected,,}" ]] || fail "SHA512 mismatch for $path" 2
+}
+
+install_exe() {
+  local path="$1" silent_args="$2" display="$3"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY-RUN: would install $display system-wide with: $silent_args"
+    return 0
+  fi
+  log "Installing $display system-wide. This may require administrator approval..."
+  cmd.exe /c "\"$(windows_path "$path")\" $silent_args" || fail "$display installer failed; IT/admin elevation may be required" 3
+}
+
+ensure_component() {
+  local component="$1" display framework version_prefix file_name url hash silent_args cache installer
+  display="$(json_value "$component" displayName)"
+  framework="$(json_value "$component" sharedFramework)"
+  version_prefix="$(json_value "$component" versionPrefix)"
+  file_name="$(json_value "$component" fileName)"
+  url="$(json_value "$component" url)"
+  hash="$(json_value "$component" sha512)"
+  silent_args="$(json_value "$component" silentArgs)"
+
+  [[ -n "$display" && -n "$framework" && -n "$version_prefix" && -n "$file_name" && -n "$url" && -n "$hash" ]] \
+    || fail "Incomplete config for component: $component"
+
+  if runtime_present "$framework" "$version_prefix"; then
+    log "$display already present."
+    return 0
+  fi
+
+  cache="$(cache_dir)"
+  installer="${cache}/${file_name}"
+  log "$display is missing; preparing Microsoft installer."
+  if [[ ! -s "$installer" || "$DRY_RUN" -eq 1 ]]; then
+    download_file "$url" "$installer"
+  else
+    log "Using cached installer: $installer"
+  fi
+  verify_hash "$installer" "$hash"
+  install_exe "$installer" "$silent_args" "$display"
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    return 0
+  fi
+  runtime_present "$framework" "$version_prefix" || fail "$display is still not visible to dotnet after install" 3
+}
+
+ensure_component aspnetcoreRuntime
+ensure_component windowsDesktopRuntime
+log "Dashboard .NET runtime dependencies are ready."

--- a/scripts/ensure-dotnet-sdk.sh
+++ b/scripts/ensure-dotnet-sdk.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Ensure .NET 8 SDK is installed system-wide for source-checkout dashboard builds.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG="${REPO_ROOT}/Config/dotnet-bootstrap.json"
+DRY_RUN=0
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/ensure-dotnet-sdk.sh [--dry-run]
+
+Ensures a system-wide .NET 8 SDK is available. If missing, downloads the pinned
+Microsoft SDK installer from Config/dotnet-bootstrap.json, verifies SHA512, and
+runs the official installer.
+
+Options:
+  --dry-run   Print planned download/install actions only
+  -h, --help  Show help
+USAGE
+}
+
+log() { printf '[ensure-dotnet-sdk] %s\n' "$*" >&2; }
+fail() { printf '[ensure-dotnet-sdk] ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -f "$CONFIG" ]] || fail "Missing bootstrap config: $CONFIG"
+
+json_value() {
+  local section="$1" key="$2"
+  awk -v section="\"${section}\"" -v key="\"${key}\"" '
+    $0 ~ section { in_section=1; next }
+    in_section && $0 ~ /^[[:space:]]*}/ { exit }
+    in_section && $0 ~ key {
+      sub(/^[^:]*:[[:space:]]*"/, "")
+      sub(/",[[:space:]]*$/, "")
+      sub(/"[[:space:]]*$/, "")
+      print
+      exit
+    }
+  ' "$CONFIG"
+}
+
+cache_dir() {
+  local configured
+  configured="$(awk '
+    /"cacheDir"/ {
+      sub(/^[^:]*:[[:space:]]*"/, "")
+      sub(/",[[:space:]]*$/, "")
+      sub(/"[[:space:]]*$/, "")
+      print
+      exit
+    }
+  ' "$CONFIG")"
+  printf '%s\n' "${REPO_ROOT}/${configured:-tools/cache/dotnet}"
+}
+
+dotnet_cmd() {
+  if command -v dotnet.exe >/dev/null 2>&1; then command -v dotnet.exe; return 0; fi
+  if command -v dotnet >/dev/null 2>&1; then command -v dotnet; return 0; fi
+  if [[ -x "/c/Program Files/dotnet/dotnet.exe" ]]; then printf '%s\n' "/c/Program Files/dotnet/dotnet.exe"; return 0; fi
+  if [[ -x "/c/Program Files (x86)/dotnet/dotnet.exe" ]]; then printf '%s\n' "/c/Program Files (x86)/dotnet/dotnet.exe"; return 0; fi
+  return 1
+}
+
+sdk_present() {
+  local version_prefix="$1" dotnet_bin
+  dotnet_bin="$(dotnet_cmd)" || return 1
+  "$dotnet_bin" --list-sdks 2>/dev/null | grep -Eq "^${version_prefix}"
+}
+
+download_file() {
+  local url="$1" target="$2"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY-RUN: would download $url -> $target"
+    return 0
+  fi
+  mkdir -p "$(dirname "$target")"
+  if command -v curl.exe >/dev/null 2>&1; then
+    curl.exe -fsSL --retry 3 --retry-delay 2 -o "$target" "$url"
+  elif command -v curl >/dev/null 2>&1; then
+    curl -fsSL --retry 3 --retry-delay 2 -o "$target" "$url"
+  else
+    fail "curl.exe or curl is required to download Microsoft .NET installers" 2
+  fi
+}
+
+windows_path() {
+  local path="$1"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$path"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+actual_sha512() {
+  local path="$1"
+  if command -v sha512sum >/dev/null 2>&1; then
+    sha512sum "$path" | awk '{print tolower($1)}'
+    return 0
+  fi
+  if command -v certutil.exe >/dev/null 2>&1; then
+    certutil.exe -hashfile "$(windows_path "$path")" SHA512 2>/dev/null \
+      | tr -d '\r ' \
+      | awk 'length($0) == 128 { print tolower($0); exit }'
+    return 0
+  fi
+  fail "sha512sum or certutil.exe is required to verify .NET installers" 2
+}
+
+verify_hash() {
+  local path="$1" expected="$2" actual
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY-RUN: would verify SHA512 for $path"
+    return 0
+  fi
+  actual="$(actual_sha512 "$path")"
+  [[ "${actual,,}" == "${expected,,}" ]] || fail "SHA512 mismatch for $path" 2
+}
+
+install_exe() {
+  local path="$1" silent_args="$2" display="$3"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY-RUN: would install $display system-wide with: $silent_args"
+    return 0
+  fi
+  log "Installing $display system-wide. This may require administrator approval..."
+  cmd.exe /c "\"$(windows_path "$path")\" $silent_args" || fail "$display installer failed; IT/admin elevation may be required" 3
+}
+
+display="$(json_value sdk displayName)"
+version_prefix="$(json_value sdk sdkVersionPrefix)"
+file_name="$(json_value sdk fileName)"
+url="$(json_value sdk url)"
+hash="$(json_value sdk sha512)"
+silent_args="$(json_value sdk silentArgs)"
+
+[[ -n "$display" && -n "$version_prefix" && -n "$file_name" && -n "$url" && -n "$hash" ]] \
+  || fail "Incomplete SDK config"
+
+if sdk_present "$version_prefix"; then
+  log "$display already present."
+  exit 0
+fi
+
+cache="$(cache_dir)"
+installer="${cache}/${file_name}"
+log "$display is missing; preparing Microsoft installer."
+if [[ ! -s "$installer" || "$DRY_RUN" -eq 1 ]]; then
+  download_file "$url" "$installer"
+else
+  log "Using cached installer: $installer"
+fi
+verify_hash "$installer" "$hash"
+install_exe "$installer" "$silent_args" "$display"
+
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  sdk_present "$version_prefix" || fail "$display is still not visible to dotnet after install" 3
+fi
+log "Dashboard .NET SDK dependency is ready."

--- a/survey/README.md
+++ b/survey/README.md
@@ -4,7 +4,7 @@ This directory contains Bash-first survey tooling for SysAdminSuite.
 
 ## Primary Field Tutorial: Cybernet / Neuron Network Survey
 
-**Default front door:** double-click [`../START-HERE-SysAdminSuite-Dashboard.bat`](../START-HERE-SysAdminSuite-Dashboard.bat) and use **Start Cybernet Survey** in the dashboard. On first run the launcher may **automatically prepare (build) the dashboard app** before opening the browser; field users do not run any command by hand. Machines **without the .NET SDK** should use the dashboard field release package ([`../docs/DASHBOARD_FIELD_RELEASE.md`](../docs/DASHBOARD_FIELD_RELEASE.md)), not a source clone. CLI is available for specific advanced survey use cases only.
+**Default front door:** double-click [`../START-HERE-SysAdminSuite-Dashboard.bat`](../START-HERE-SysAdminSuite-Dashboard.bat) and use **Start Cybernet Survey** in the dashboard. On first run the launcher may **automatically prepare the dashboard app** before opening the browser; field users do not run any command by hand. Source clones can bootstrap official Microsoft .NET dependencies when downloads and administrator approval are available. Locked-down PCs should use the dashboard field release package ([`../docs/DASHBOARD_FIELD_RELEASE.md`](../docs/DASHBOARD_FIELD_RELEASE.md)). CLI is available for specific advanced survey use cases only.
 
 The current priority tutorial for field technicians is:
 


### PR DESCRIPTION
## Summary

This separates the dashboard's teaching flow into the two jobs field techs actually need:

- **Repo Setup** is now the default tutorial from the double-click launcher (`?tutorial=setup`): clone/download, open the launcher, approved updates, and workflow selection.
- **Cybernet Survey** is now an explicit survey tutorial: start, load targets, network posture, identity evidence, optional reachability, and where to review results.
- The optional OS/shell command filter now only appears on Cybernet command-running steps, not at the beginning of the tutorial.
- The interactive tour, docs, launcher contracts, and dashboard smoke tests now reflect the setup-first map and six-step Cybernet survey.
- Preserves and validates the first-run dashboard dependency bootstrap overlap for source checkouts.

## Test plan

- [x] `node dashboard/build-bundle.js`
- [x] `node --check dashboard/js/app.js; node --check dashboard/js/repo-setup-tutorial.js; node --check dashboard/js/launch-repo-setup-tutorial.js; node --check dashboard/js/bundle.js; node --check dashboard/js/cybernet-os-preflight.js`
- [x] `node dashboard/smoke-test.js`
- [x] `node dashboard/start-button-smoke.js`
- [x] `C:\Program Files\Git\bin\bash.exe Tests/bash/test_dashboard_tutorial_launcher_contracts.sh`
- [x] `C:\Program Files\Git\bin\bash.exe Tests/bash/test_dashboard_entrypoint_contracts.sh`
- [x] `C:\Program Files\Git\bin\bash.exe Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh`