### PR TITLE
Harden toolbox status tutorial follow-up

### DIFF
--- a/Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh
+++ b/Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh
@@ -12,6 +12,7 @@ config="$repo_root/Config/dotnet-bootstrap.json"
 runtime_script="$repo_root/scripts/ensure-dotnet-runtime.sh"
 sdk_script="$repo_root/scripts/ensure-dotnet-sdk.sh"
 host_script="$repo_root/scripts/ensure-dashboard-host.sh"
+toolbox_writer="$repo_root/scripts/sas-write-toolbox-status.sh"
 host_bat="$repo_root/Launch-SysAdminSuiteDashboard.Host.bat"
 start_bat="$repo_root/START-HERE-SysAdminSuite-Dashboard.bat"
 gitignore="$repo_root/.gitignore"
@@ -20,6 +21,7 @@ gitignore="$repo_root/.gitignore"
 [[ -f "$runtime_script" ]] || fail "missing ensure-dotnet-runtime.sh"
 [[ -f "$sdk_script" ]] || fail "missing ensure-dotnet-sdk.sh"
 [[ -f "$host_script" ]] || fail "missing ensure-dashboard-host.sh"
+[[ -f "$toolbox_writer" ]] || fail "missing toolbox status writer"
 
 grep -Fq 'dotnetcli.blob.core.windows.net/dotnet/release-metadata/8.0/releases.json' "$config" \
   || fail "bootstrap config does not cite official .NET release metadata"
@@ -64,6 +66,8 @@ grep -Fq 'ensure-dashboard-host.sh' "$host_bat" \
   || fail "host launcher does not call dashboard bootstrap"
 grep -Fq 'Git\bin\bash.exe' "$host_bat" \
   || fail "host launcher does not prefer Git Bash"
+grep -Fq 'sas-write-toolbox-status.sh' "$host_bat" \
+  || fail "host launcher does not write dashboard toolbox status"
 grep -Fq 'Microsoft .NET dependencies' "$start_bat" \
   || fail "root launcher does not tell users about Microsoft .NET bootstrap"
 grep -Fq 'administrator approval' "$start_bat" \

--- a/Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh
+++ b/Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh
@@ -34,6 +34,8 @@ grep -Fq '__sasToolboxActionNeeded' "$launch_js" || fail "toolbox launcher missi
 grep -Fq '__sasToolboxActionNeeded' "$repo_setup_launch_js" || fail "repo setup launcher does not respect toolbox-first precedence"
 grep -Fq 'initToolboxTutorial' "$app_js" || fail "app.js does not initialize toolbox tutorial"
 grep -Fq 'startToolboxTutorial' "$app_js" || fail "app.js missing toolbox hero shell"
+grep -Fq '__sasFetchedToolboxStatus' "$app_js" || fail "app.js does not preserve fetched toolbox status"
+grep -Fq '__sasFetchedToolboxStatus' "$launch_js" || fail "toolbox launcher does not record fetched toolbox status"
 grep -Fq 'toolbox-status' "$parsers_js" || fail "parsers missing toolbox-status type"
 grep -Fq 'dashboard/js/toolbox-tutorial.js' "$build_bundle" || fail "bundle build missing toolbox tutorial"
 grep -Fq 'sas-write-toolbox-status.sh' "$host_bat" || fail "host launcher does not write toolbox status"

--- a/Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh
+++ b/Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh
@@ -2,47 +2,49 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-index="$repo_root/dashboard/index.html"
-tutorial="$repo_root/dashboard/js/toolbox-tutorial.js"
-launcher="$repo_root/dashboard/js/launch-toolbox-tutorial.js"
-app="$repo_root/dashboard/js/app.js"
-bundle="$repo_root/dashboard/js/bundle.js"
-host_bat="$repo_root/Launch-SysAdminSuiteDashboard.Host.bat"
-writer="$repo_root/scripts/sas-write-toolbox-status.sh"
 
 fail() {
   echo "FAIL: $*" >&2
   exit 1
 }
 
-[[ -f "$index" ]] || fail "dashboard/index.html missing"
-[[ -f "$tutorial" ]] || fail "toolbox-tutorial.js missing"
-[[ -f "$launcher" ]] || fail "launch-toolbox-tutorial.js missing"
-[[ -f "$app" ]] || fail "app.js missing"
-[[ -f "$bundle" ]] || fail "bundle.js missing"
+index_html="$repo_root/dashboard/index.html"
+toolbox_js="$repo_root/dashboard/js/toolbox-tutorial.js"
+launch_js="$repo_root/dashboard/js/launch-toolbox-tutorial.js"
+repo_setup_launch_js="$repo_root/dashboard/js/launch-repo-setup-tutorial.js"
+app_js="$repo_root/dashboard/js/app.js"
+parsers_js="$repo_root/dashboard/js/parsers.js"
+build_bundle="$repo_root/dashboard/build-bundle.js"
+host_bat="$repo_root/Launch-SysAdminSuiteDashboard.Host.bat"
+start_bat="$repo_root/START-HERE-SysAdminSuite-Dashboard.bat"
+gitignore="$repo_root/.gitignore"
 
-for id in toolbox-hero toolbox-tutorial toolbox-checklist toolbox-status-banner; do
-  grep -q "id=\"${id}\"" "$index" || fail "index.html missing #${id}"
+[[ -f "$toolbox_js" ]] || fail "missing toolbox tutorial JS"
+[[ -f "$launch_js" ]] || fail "missing toolbox launch JS"
+
+for needle in 'id="toolbox-status-banner"' 'id="toolbox-hero"' 'id="toolbox-checklist"' 'id="toolbox-tutorial"' 'id="hero-start-toolbox"'; do
+  grep -Fq "$needle" "$index_html" || fail "dashboard index missing $needle"
 done
 
-grep -q 'sas-guide-glow' "$tutorial" || fail "toolbox-tutorial.js must use sas-guide-glow"
-grep -q '__sasApplyToolboxStatus' "$tutorial" || fail "toolbox-tutorial.js must define __sasApplyToolboxStatus"
-grep -q 'buildStepsFromStatus' "$tutorial" || fail "toolbox-tutorial.js must build dynamic steps"
+grep -Fq 'sas-guide-glow' "$toolbox_js" || fail "toolbox tutorial does not apply guide glow"
+grep -Fq '__sasApplyToolboxStatus' "$toolbox_js" || fail "toolbox tutorial missing status apply hook"
+grep -Fq 'buildStepsFromStatus' "$toolbox_js" || fail "toolbox tutorial missing dynamic step builder"
+grep -Fq 'toolbox-status.json?ts=' "$launch_js" || fail "toolbox launcher does not fetch runtime status JSON"
+grep -Fq '__sasToolboxActionNeeded' "$launch_js" || fail "toolbox launcher missing toolbox-first precedence flag"
+grep -Fq '__sasToolboxActionNeeded' "$repo_setup_launch_js" || fail "repo setup launcher does not respect toolbox-first precedence"
+grep -Fq 'initToolboxTutorial' "$app_js" || fail "app.js does not initialize toolbox tutorial"
+grep -Fq 'startToolboxTutorial' "$app_js" || fail "app.js missing toolbox hero shell"
+grep -Fq 'toolbox-status' "$parsers_js" || fail "parsers missing toolbox-status type"
+grep -Fq 'dashboard/js/toolbox-tutorial.js' "$build_bundle" || fail "bundle build missing toolbox tutorial"
+grep -Fq 'sas-write-toolbox-status.sh' "$host_bat" || fail "host launcher does not write toolbox status"
+grep -Fq 'SAS_UPDATE_STATE' "$start_bat" || fail "START-HERE does not set update state"
+grep -Fq 'dashboard/toolbox-status.json' "$gitignore" || fail "runtime toolbox status is not ignored"
 
-grep -q 'toolbox-status.json' "$launcher" || fail "launch-toolbox-tutorial.js must fetch toolbox-status.json"
-grep -q 'actionNeeded' "$launcher" || fail "launch-toolbox-tutorial.js must respect actionNeeded"
-grep -q 'startRepoSetupWhenReady' "$launcher" || fail "launcher must fall back to repo setup when toolbox is clear"
+for fixture in toolbox-status-all-ok.json toolbox-status-missing-naabu.json toolbox-status-update-available.json; do
+  [[ -f "$repo_root/dashboard/samples/$fixture" ]] || fail "missing sample fixture: $fixture"
+  python -m json.tool "$repo_root/dashboard/samples/$fixture" >/dev/null || fail "invalid fixture JSON: $fixture"
+done
 
-grep -q 'initToolboxShell' "$app" || fail "app.js must define initToolboxShell"
-grep -q 'window.startToolboxTutorial' "$app" || fail "app.js must expose startToolboxTutorial"
-grep -q 'initToolboxTutorial' "$bundle" || fail "bundle must include initToolboxTutorial"
-
-grep -q 'launch-toolbox-tutorial.js' "$index" || fail "index must load launch-toolbox-tutorial.js"
-grep -q 'sas-write-toolbox-status.sh' "$host_bat" || fail "host launcher must invoke toolbox status writer"
-
-grep -q 'dashboard/toolbox-status.json' "$repo_root/.gitignore" || fail ".gitignore must cover live toolbox status"
-
-[[ -f "$repo_root/dashboard/samples/toolbox-status-missing-naabu.json" ]] || fail "missing naabu sample fixture"
 [[ -f "$repo_root/docs/DASHBOARD_TOOLBOX_TUTORIAL.md" ]] || fail "DASHBOARD_TOOLBOX_TUTORIAL.md missing"
 
-echo "OK: dashboard toolbox tutorial contracts"
+echo "PASS: Dashboard toolbox tutorial contracts"

--- a/Tests/bash/test_toolbox_probe_contracts.sh
+++ b/Tests/bash/test_toolbox_probe_contracts.sh
@@ -2,6 +2,68 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+manifest="$repo_root/Config/toolbox-dependencies.json"
+probe="$repo_root/scripts/sas-probe-toolbox.sh"
+writer="$repo_root/scripts/sas-write-toolbox-status.sh"
+dotnet_cfg="$repo_root/Config/dotnet-bootstrap.json"
+naabu_profiles="$repo_root/survey/naabu_profiles.json"
+
+[[ -f "$manifest" ]] || fail "missing toolbox dependency manifest"
+[[ -f "$probe" ]] || fail "missing toolbox probe"
+[[ -f "$writer" ]] || fail "missing toolbox writer"
+
+for id in repo git_bash cmd powershell pwsh python dotnet_aspnet dotnet_desktop dotnet_sdk dashboard_host naabu nmap curl unzip; do
+  grep -Fq "\"id\": \"$id\"" "$manifest" || fail "manifest missing tool id: $id"
+done
+
+grep -Fq '"release": "8.0.28"' "$dotnet_cfg" || fail "dotnet bootstrap release pin changed without contract update"
+grep -Fq '"sdkVersion": "8.0.422"' "$dotnet_cfg" || fail "dotnet bootstrap SDK pin changed without contract update"
+grep -Fq '"pinnedVersion": "8.0.28"' "$manifest" || fail "manifest missing .NET runtime pin"
+grep -Fq '"pinnedVersion": "8.0.422"' "$manifest" || fail "manifest missing .NET SDK pin"
+grep -Fq '"pinnedVersion": "2.6.1"' "$manifest" || fail "manifest missing naabu pin"
+grep -Fiq 'low-noise survey discipline' "$naabu_profiles" || fail "naabu doctrine source missing low-noise language"
+
+if grep -Eiq 'winget|choco|chocolatey' "$manifest" "$probe" "$writer"; then
+  fail "toolbox probe path must not use winget/choco"
+fi
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+bash "$probe" --dry-run > "$tmp"
+python -m json.tool "$tmp" >/dev/null || fail "probe did not emit valid JSON"
+python - "$tmp" <<'PY' || exit 1
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+assert data["schema"] == 1
+assert isinstance(data.get("tools"), list) and data["tools"]
+assert all("status" in item for item in data["tools"])
+assert data.get("repo", {}).get("updateState") is not None
+PY
+
+bash "$writer" --dry-run > "$tmp"
+python - "$tmp" <<'PY' || exit 1
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+assert isinstance(data.get("actionNeeded"), bool)
+summary = data.get("summary", {})
+for key in ("total", "ok", "needsAction", "missing", "outdated", "blocked", "unknown"):
+    assert key in summary, key
+PY
+
+echo "PASS: Toolbox probe contracts"
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 manifest="$repo_root/Config/toolbox-dependencies.json"
 probe="$repo_root/scripts/sas-probe-toolbox.sh"
 writer="$repo_root/scripts/sas-write-toolbox-status.sh"

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -643,6 +643,9 @@ function rebuildToolboxStatusFromChips() {
   if (latest && typeof window.__sasApplyToolboxStatus === 'function') {
     window.__sasLastToolboxStatus = latest;
     window.__sasApplyToolboxStatus(latest);
+  } else if (window.__sasFetchedToolboxStatus && typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = window.__sasFetchedToolboxStatus;
+    window.__sasApplyToolboxStatus(window.__sasFetchedToolboxStatus);
   } else if (typeof window.__sasApplyToolboxStatus === 'function') {
     window.__sasLastToolboxStatus = null;
     window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
@@ -719,8 +722,9 @@ function clearAllData(silent = false) {
   refreshAllPanels();
   updateStatusFooter(null);
   if (typeof window.__sasApplyToolboxStatus === 'function') {
-    window.__sasLastToolboxStatus = null;
-    window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
+    const status = window.__sasFetchedToolboxStatus || { tools: [], actionNeeded: false, summary: { needsAction: 0 } };
+    window.__sasLastToolboxStatus = window.__sasFetchedToolboxStatus || null;
+    window.__sasApplyToolboxStatus(status);
   }
   updateCybernetReview();
   if (!silent) toast('All evidence cleared.', 'info');

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -578,6 +578,20 @@ async function processFile(file) {
       return;
     }
 
+    if (parsedData.type === 'toolbox-status') {
+      if (typeof window.__sasApplyToolboxStatus === 'function') {
+        window.__sasLastToolboxStatus = parsedData.data;
+        window.__sasApplyToolboxStatus(parsedData.data);
+      }
+      const count = parsedData.rows?.length ?? 0;
+      addFileChip(name, count > 0 ? 'ok' : 'warn', parsedData.type, count, parsedData);
+      toast(`Loaded toolbox status — ${parsedData.data?.summary?.needsAction ?? 0} item(s) need attention.`, 'success');
+      if (parsedData.data?.actionNeeded && typeof window.startToolboxTutorial === 'function') {
+        window.startToolboxTutorial({ source: 'loaded-file', status: parsedData.data });
+      }
+      return;
+    }
+
     store = mergeDataStore(store, parsedData);
     refreshAllPanels();
 
@@ -619,6 +633,22 @@ function rebuildInstallPlanFromChips() {
   else clearSoftwareInstallPlan();
 }
 
+function rebuildToolboxStatusFromChips() {
+  let latest = null;
+  for (const f of loadedFiles) {
+    if (f.parsedData?.type === 'toolbox-status') {
+      latest = f.parsedData.data;
+    }
+  }
+  if (latest && typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = latest;
+    window.__sasApplyToolboxStatus(latest);
+  } else if (typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = null;
+    window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
+  }
+}
+
 function rebuildStoreFromChips() {
   store = {};
   let latestStatus = null;
@@ -631,6 +661,7 @@ function rebuildStoreFromChips() {
     }
   }
   rebuildInstallPlanFromChips();
+  rebuildToolboxStatusFromChips();
   updateStatusFooter(latestStatus); // null clears footer if no status chip remains
   refreshAllPanels();
 }
@@ -650,6 +681,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'naabu-reachability': '🔌',
     'ad-registered-population': '🏢',
     'software-tracker': '📦', 'software-tracker-install-plan': '📋',
+    'toolbox-status': '🧰',
     'cybernet-target-manifest': '🎯', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
@@ -686,6 +718,10 @@ function clearAllData(silent = false) {
   document.getElementById('loaded-files').innerHTML = '';
   refreshAllPanels();
   updateStatusFooter(null);
+  if (typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = null;
+    window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
+  }
   updateCybernetReview();
   if (!silent) toast('All evidence cleared.', 'info');
 }

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -343,6 +343,7 @@ function detectFileType(filename, content) {
 
   // JSON detection — check filename hints first, then probe content
   if (fn.endsWith('.json')) {
+    if (fn.includes('toolbox-status') || fn.includes('toolbox_status')) return 'toolbox-status';
     if (fn.includes('install-summary') || fn.includes('install_summary')) return 'software-tracker-install-plan';
     if (fn.includes('status')) return 'status-json';
     if (fn.includes('sources') || fn.includes('software') || fn.includes('apps')) return 'software-tracker';
@@ -356,6 +357,9 @@ function detectFileType(filename, content) {
       const snip = content.slice(0, 400).toLowerCase();
       if (snip.includes('"items"') && snip.includes('"summary"') && snip.includes('"status"')) {
         return 'software-tracker-install-plan';
+      }
+      if (snip.includes('"tools"') && snip.includes('"actionneeded"') && snip.includes('"repo"')) {
+        return 'toolbox-status';
       }
       if (snip.includes('"taskname"') || snip.includes('"outcome"') ||
           snip.includes('"taskid"') || snip.includes('"events"')) return 'remote-task';
@@ -438,6 +442,7 @@ function parseFileContent(type, content, filename) {
     case 'cybernet-target-manifest': return parseCybernetTargetManifest(content);
     case 'smb-recon': return parseSmbRecon(content);
     case 'status-json': return parseStatusJson(content);
+    case 'toolbox-status': return parseToolboxStatus(content, filename);
     case 'remote-task': return parseRemoteTask(content);
     case 'software-tracker': return parseSoftwareTracker(content, filename);
     case 'software-tracker-install-plan': return parseSoftwareTrackerInstallPlan(content, filename);
@@ -764,6 +769,22 @@ function parseSoftwareTrackerInstallPlan(content, filename) {
     rows: items,
     data: { items, summary },
     meta: { count: items.length, filename },
+  };
+}
+
+function parseToolboxStatus(content, filename) {
+  let parsed;
+  try {
+    parsed = typeof content === 'string' ? JSON.parse(content) : content;
+  } catch (err) {
+    return { type: 'toolbox-status', rows: [], data: { tools: [], actionNeeded: false }, meta: { error: err.message, filename } };
+  }
+  const tools = Array.isArray(parsed?.tools) ? parsed.tools : [];
+  return {
+    type: 'toolbox-status',
+    rows: tools,
+    data: parsed,
+    meta: { count: tools.length, filename },
   };
 }
 
@@ -3428,7 +3449,7 @@ function initToolboxTutorial() {
   const root = document.getElementById('toolbox-tutorial');
   if (!root) return;
 
-  let steps = [];
+  let steps = buildStepsFromStatus({ tools: [], actionNeeded: false });
   let idx = 0;
   let copiedThisStep = false;
 
@@ -3467,6 +3488,13 @@ function initToolboxTutorial() {
       li.classList.toggle('active', i === idx);
       li.classList.toggle('done', i < idx);
     });
+  }
+
+  function rebuildProgressRail() {
+    if (!progressRail) return;
+    progressRail.innerHTML = steps.map((step, i) =>
+      `<li data-step="${i}" data-tool-id="${sanitize(step.toolId || '')}">${sanitize(step.railLabel || step.title)}</li>`
+    ).join('');
   }
 
   function render() {
@@ -3550,15 +3578,21 @@ function initToolboxTutorial() {
     steps = buildStepsFromStatus(status);
     idx = 0;
     copiedThisStep = false;
+    rebuildProgressRail();
+    renderToolboxChecklist(status);
+    updateToolboxBanner(status);
+    window.dispatchEvent(new CustomEvent('sas-toolbox-status', { detail: status }));
     render();
   };
 
   window.__sasResetToolboxWizard = () => {
     idx = 0;
     copiedThisStep = false;
+    rebuildProgressRail();
     render();
   };
 
+  rebuildProgressRail();
   render();
 }
 
@@ -3580,7 +3614,8 @@ function renderToolboxChecklist(status) {
 function updateToolboxBanner(status) {
   const banner = document.getElementById('toolbox-status-banner');
   if (!banner) return;
-  const count = status?.summary?.needsAction ?? 0;
+  const count = status?.summary?.needsAction ??
+    (status?.tools || []).filter(tool => ACTION_STATUSES.has(tool.status)).length;
   if (status?.actionNeeded && count > 0) {
     banner.textContent = `${count} toolbox item${count === 1 ? '' : 's'} need attention — click to open the guided fix wizard`;
     banner.classList.remove('hidden');
@@ -3590,6 +3625,9 @@ function updateToolboxBanner(status) {
     banner.classList.remove('sas-guide-glow');
   }
 }
+
+window.__sasRenderToolboxChecklist = renderToolboxChecklist;
+window.__sasUpdateToolboxBanner = updateToolboxBanner;
 
 // expose exports to bundle scope
 _exports.initToolboxTutorial = initToolboxTutorial;
@@ -5380,6 +5418,20 @@ async function processFile(file) {
       return;
     }
 
+    if (parsedData.type === 'toolbox-status') {
+      if (typeof window.__sasApplyToolboxStatus === 'function') {
+        window.__sasLastToolboxStatus = parsedData.data;
+        window.__sasApplyToolboxStatus(parsedData.data);
+      }
+      const count = parsedData.rows?.length ?? 0;
+      addFileChip(name, count > 0 ? 'ok' : 'warn', parsedData.type, count, parsedData);
+      toast(`Loaded toolbox status — ${parsedData.data?.summary?.needsAction ?? 0} item(s) need attention.`, 'success');
+      if (parsedData.data?.actionNeeded && typeof window.startToolboxTutorial === 'function') {
+        window.startToolboxTutorial({ source: 'loaded-file', status: parsedData.data });
+      }
+      return;
+    }
+
     store = mergeDataStore(store, parsedData);
     refreshAllPanels();
 
@@ -5421,6 +5473,22 @@ function rebuildInstallPlanFromChips() {
   else clearSoftwareInstallPlan();
 }
 
+function rebuildToolboxStatusFromChips() {
+  let latest = null;
+  for (const f of loadedFiles) {
+    if (f.parsedData?.type === 'toolbox-status') {
+      latest = f.parsedData.data;
+    }
+  }
+  if (latest && typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = latest;
+    window.__sasApplyToolboxStatus(latest);
+  } else if (typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = null;
+    window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
+  }
+}
+
 function rebuildStoreFromChips() {
   store = {};
   let latestStatus = null;
@@ -5433,6 +5501,7 @@ function rebuildStoreFromChips() {
     }
   }
   rebuildInstallPlanFromChips();
+  rebuildToolboxStatusFromChips();
   updateStatusFooter(latestStatus); // null clears footer if no status chip remains
   refreshAllPanels();
 }
@@ -5452,6 +5521,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'naabu-reachability': '🔌',
     'ad-registered-population': '🏢',
     'software-tracker': '📦', 'software-tracker-install-plan': '📋',
+    'toolbox-status': '🧰',
     'cybernet-target-manifest': '🎯', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
@@ -5488,6 +5558,10 @@ function clearAllData(silent = false) {
   document.getElementById('loaded-files').innerHTML = '';
   refreshAllPanels();
   updateStatusFooter(null);
+  if (typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = null;
+    window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
+  }
   updateCybernetReview();
   if (!silent) toast('All evidence cleared.', 'info');
 }

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -5483,6 +5483,9 @@ function rebuildToolboxStatusFromChips() {
   if (latest && typeof window.__sasApplyToolboxStatus === 'function') {
     window.__sasLastToolboxStatus = latest;
     window.__sasApplyToolboxStatus(latest);
+  } else if (window.__sasFetchedToolboxStatus && typeof window.__sasApplyToolboxStatus === 'function') {
+    window.__sasLastToolboxStatus = window.__sasFetchedToolboxStatus;
+    window.__sasApplyToolboxStatus(window.__sasFetchedToolboxStatus);
   } else if (typeof window.__sasApplyToolboxStatus === 'function') {
     window.__sasLastToolboxStatus = null;
     window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
@@ -5559,8 +5562,9 @@ function clearAllData(silent = false) {
   refreshAllPanels();
   updateStatusFooter(null);
   if (typeof window.__sasApplyToolboxStatus === 'function') {
-    window.__sasLastToolboxStatus = null;
-    window.__sasApplyToolboxStatus({ tools: [], actionNeeded: false, summary: { needsAction: 0 } });
+    const status = window.__sasFetchedToolboxStatus || { tools: [], actionNeeded: false, summary: { needsAction: 0 } };
+    window.__sasLastToolboxStatus = window.__sasFetchedToolboxStatus || null;
+    window.__sasApplyToolboxStatus(status);
   }
   updateCybernetReview();
   if (!silent) toast('All evidence cleared.', 'info');

--- a/dashboard/js/launch-repo-setup-tutorial.js
+++ b/dashboard/js/launch-repo-setup-tutorial.js
@@ -18,6 +18,11 @@
 
   function startTutorial(attemptsRemaining) {
     if (!shouldStart()) return;
+    if (window.__sasToolboxStatusPending && attemptsRemaining > 0) {
+      window.setTimeout(function () { startTutorial(attemptsRemaining - 1); }, 100);
+      return;
+    }
+    if (window.__sasToolboxActionNeeded) return;
 
     const startButton = document.getElementById('hero-start-setup');
     const tutorial = document.getElementById('repo-setup-tutorial');

--- a/dashboard/js/launch-toolbox-tutorial.js
+++ b/dashboard/js/launch-toolbox-tutorial.js
@@ -71,6 +71,7 @@
   function handleStatus(status) {
     applyStatus(status);
     window.__sasLastToolboxStatus = status;
+    window.__sasFetchedToolboxStatus = status;
     window.__sasToolboxStatusPending = false;
     window.__sasToolboxActionNeeded = !!status.actionNeeded;
 
@@ -108,6 +109,7 @@
       .then(function (status) {
         applyStatus(status);
         window.__sasLastToolboxStatus = status;
+        window.__sasFetchedToolboxStatus = status;
         toastIfNeeded(status);
       })
       .catch(function () {

--- a/dashboard/js/launch-toolbox-tutorial.js
+++ b/dashboard/js/launch-toolbox-tutorial.js
@@ -4,6 +4,8 @@
   'use strict';
 
   var pollTimer = null;
+  window.__sasToolboxStatusPending = true;
+  window.__sasToolboxActionNeeded = false;
 
   function shouldStartSetup() {
     var params = new URLSearchParams(window.location.search || '');
@@ -25,11 +27,11 @@
   }
 
   function applyStatus(status) {
-    if (typeof window.renderToolboxChecklist === 'function') {
-      window.renderToolboxChecklist(status);
+    if (typeof window.__sasRenderToolboxChecklist === 'function') {
+      window.__sasRenderToolboxChecklist(status);
     }
-    if (typeof window.updateToolboxBanner === 'function') {
-      window.updateToolboxBanner(status);
+    if (typeof window.__sasUpdateToolboxBanner === 'function') {
+      window.__sasUpdateToolboxBanner(status);
     }
     if (typeof window.__sasApplyToolboxStatus === 'function') {
       window.__sasApplyToolboxStatus(status);
@@ -69,6 +71,8 @@
   function handleStatus(status) {
     applyStatus(status);
     window.__sasLastToolboxStatus = status;
+    window.__sasToolboxStatusPending = false;
+    window.__sasToolboxActionNeeded = !!status.actionNeeded;
 
     if (shouldStartToolbox()) {
       startToolboxWhenReady(status, 25);
@@ -89,6 +93,8 @@
     fetchStatus()
       .then(handleStatus)
       .catch(function () {
+        window.__sasToolboxStatusPending = false;
+        window.__sasToolboxActionNeeded = false;
         if (shouldStartToolbox()) {
           startToolboxWhenReady({ tools: [], actionNeeded: false }, 25);
         } else if (shouldStartSetup()) {

--- a/dashboard/js/parsers.js
+++ b/dashboard/js/parsers.js
@@ -116,6 +116,7 @@ export function detectFileType(filename, content) {
 
   // JSON detection — check filename hints first, then probe content
   if (fn.endsWith('.json')) {
+    if (fn.includes('toolbox-status') || fn.includes('toolbox_status')) return 'toolbox-status';
     if (fn.includes('install-summary') || fn.includes('install_summary')) return 'software-tracker-install-plan';
     if (fn.includes('status')) return 'status-json';
     if (fn.includes('sources') || fn.includes('software') || fn.includes('apps')) return 'software-tracker';
@@ -129,6 +130,9 @@ export function detectFileType(filename, content) {
       const snip = content.slice(0, 400).toLowerCase();
       if (snip.includes('"items"') && snip.includes('"summary"') && snip.includes('"status"')) {
         return 'software-tracker-install-plan';
+      }
+      if (snip.includes('"tools"') && snip.includes('"actionneeded"') && snip.includes('"repo"')) {
+        return 'toolbox-status';
       }
       if (snip.includes('"taskname"') || snip.includes('"outcome"') ||
           snip.includes('"taskid"') || snip.includes('"events"')) return 'remote-task';
@@ -211,6 +215,7 @@ export function parseFileContent(type, content, filename) {
     case 'cybernet-target-manifest': return parseCybernetTargetManifest(content);
     case 'smb-recon': return parseSmbRecon(content);
     case 'status-json': return parseStatusJson(content);
+    case 'toolbox-status': return parseToolboxStatus(content, filename);
     case 'remote-task': return parseRemoteTask(content);
     case 'software-tracker': return parseSoftwareTracker(content, filename);
     case 'software-tracker-install-plan': return parseSoftwareTrackerInstallPlan(content, filename);
@@ -537,6 +542,22 @@ function parseSoftwareTrackerInstallPlan(content, filename) {
     rows: items,
     data: { items, summary },
     meta: { count: items.length, filename },
+  };
+}
+
+function parseToolboxStatus(content, filename) {
+  let parsed;
+  try {
+    parsed = typeof content === 'string' ? JSON.parse(content) : content;
+  } catch (err) {
+    return { type: 'toolbox-status', rows: [], data: { tools: [], actionNeeded: false }, meta: { error: err.message, filename } };
+  }
+  const tools = Array.isArray(parsed?.tools) ? parsed.tools : [];
+  return {
+    type: 'toolbox-status',
+    rows: tools,
+    data: parsed,
+    meta: { count: tools.length, filename },
   };
 }
 

--- a/dashboard/js/toolbox-tutorial.js
+++ b/dashboard/js/toolbox-tutorial.js
@@ -73,7 +73,7 @@ export function initToolboxTutorial() {
   const root = document.getElementById('toolbox-tutorial');
   if (!root) return;
 
-  let steps = [];
+  let steps = buildStepsFromStatus({ tools: [], actionNeeded: false });
   let idx = 0;
   let copiedThisStep = false;
 
@@ -112,6 +112,13 @@ export function initToolboxTutorial() {
       li.classList.toggle('active', i === idx);
       li.classList.toggle('done', i < idx);
     });
+  }
+
+  function rebuildProgressRail() {
+    if (!progressRail) return;
+    progressRail.innerHTML = steps.map((step, i) =>
+      `<li data-step="${i}" data-tool-id="${sanitize(step.toolId || '')}">${sanitize(step.railLabel || step.title)}</li>`
+    ).join('');
   }
 
   function render() {
@@ -195,15 +202,21 @@ export function initToolboxTutorial() {
     steps = buildStepsFromStatus(status);
     idx = 0;
     copiedThisStep = false;
+    rebuildProgressRail();
+    renderToolboxChecklist(status);
+    updateToolboxBanner(status);
+    window.dispatchEvent(new CustomEvent('sas-toolbox-status', { detail: status }));
     render();
   };
 
   window.__sasResetToolboxWizard = () => {
     idx = 0;
     copiedThisStep = false;
+    rebuildProgressRail();
     render();
   };
 
+  rebuildProgressRail();
   render();
 }
 
@@ -225,7 +238,8 @@ export function renderToolboxChecklist(status) {
 export function updateToolboxBanner(status) {
   const banner = document.getElementById('toolbox-status-banner');
   if (!banner) return;
-  const count = status?.summary?.needsAction ?? 0;
+  const count = status?.summary?.needsAction ??
+    (status?.tools || []).filter(tool => ACTION_STATUSES.has(tool.status)).length;
   if (status?.actionNeeded && count > 0) {
     banner.textContent = `${count} toolbox item${count === 1 ? '' : 's'} need attention — click to open the guided fix wizard`;
     banner.classList.remove('hidden');
@@ -235,3 +249,6 @@ export function updateToolboxBanner(status) {
     banner.classList.remove('sas-guide-glow');
   }
 }
+
+window.__sasRenderToolboxChecklist = renderToolboxChecklist;
+window.__sasUpdateToolboxBanner = updateToolboxBanner;

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -174,6 +174,11 @@ if (failed > 0) process.exit(1);
 const indexHtml = readFileSync(join(__dir, 'index.html'), 'utf8');
 
 const shellChecks = [
+  ['toolbox-status-banner', 'Toolbox status banner'],
+  ['toolbox-hero', 'Toolbox hero'],
+  ['id="hero-start-toolbox"', 'Primary CTA Start Toolbox Check'],
+  ['id="toolbox-checklist"', 'Toolbox checklist'],
+  ['id="toolbox-tutorial"', 'Toolbox tutorial container'],
   ['repo-setup-hero', 'Repo Setup hero'],
   ['id="hero-start-setup"', 'Primary CTA Start Repo Setup'],
   ['id="repo-setup-tutorial"', 'Repo Setup tutorial container'],
@@ -198,6 +203,10 @@ const shellChecks = [
 // Wizard command contracts live in app.js (bundled); verify source for CI without loading bundle
 const appJs = readFileSync(join(__dir, 'js', 'app.js'), 'utf8');
 const contractChecks = [
+  ['initToolboxTutorial', 'Toolbox tutorial init'],
+  ['initToolboxShell', 'Toolbox hero shell'],
+  ['window.startToolboxTutorial', 'Toolbox transition exposed'],
+  ['toolbox-status', 'Toolbox parser type wired'],
   ['initRepoSetupTutorial', 'Repo Setup tutorial init'],
   ['initRepoSetupShell', 'Repo Setup hero shell'],
   ['window.startRepoSetupTutorial', 'Repo Setup transition exposed'],
@@ -384,6 +393,7 @@ const bundleJs = readFileSync(join(__dir, 'js', 'bundle.js'), 'utf8');
 const preflightJs = readFileSync(join(__dir, 'js', 'cybernet-os-preflight.js'), 'utf8');
 const launchJs = readFileSync(join(__dir, 'js', 'launch-cybernet-tutorial.js'), 'utf8');
 const launchSetupJs = readFileSync(join(__dir, 'js', 'launch-repo-setup-tutorial.js'), 'utf8');
+const launchToolboxJs = readFileSync(join(__dir, 'js', 'launch-toolbox-tutorial.js'), 'utf8');
 
 let startPassed = 0;
 let startFailed = 0;
@@ -413,6 +423,14 @@ startAssert(launchSetupJs.includes('window.startRepoSetupTutorial'), 'setup-auto
   'launch-repo-setup-tutorial.js does not use the verified transition');
 startAssert(launchSetupJs.includes("tutorial === 'setup'"), 'setup-query-supported',
   'launch-repo-setup-tutorial.js does not support ?tutorial=setup');
+startAssert(launchToolboxJs.includes('toolbox-status.json?ts='), 'toolbox-fetches-status',
+  'launch-toolbox-tutorial.js does not fetch toolbox-status.json');
+startAssert(launchToolboxJs.includes('__sasToolboxActionNeeded'), 'toolbox-first-flag',
+  'launch-toolbox-tutorial.js does not set the toolbox-first flag');
+startAssert(launchSetupJs.includes('__sasToolboxActionNeeded'), 'setup-defers-to-toolbox',
+  'repo setup launcher does not defer when toolbox action is needed');
+startAssert(bundleJs.includes('initToolboxTutorial'), 'bundle-toolbox-tutorial',
+  'bundle.js is stale — missing Toolbox tutorial; rebuild with: node dashboard/build-bundle.js');
 startAssert(bundleJs.includes('initSoftwareTrackerTutorial'), 'bundle-software-tutorial',
   'bundle.js is stale — missing Software Tracker tutorial; rebuild with: node dashboard/build-bundle.js');
 startAssert(bundleJs.includes('initRepoSetupTutorial'), 'bundle-repo-setup-tutorial',

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -207,6 +207,7 @@ const contractChecks = [
   ['initToolboxShell', 'Toolbox hero shell'],
   ['window.startToolboxTutorial', 'Toolbox transition exposed'],
   ['toolbox-status', 'Toolbox parser type wired'],
+  ['__sasFetchedToolboxStatus', 'Toolbox fetched status preserved'],
   ['initRepoSetupTutorial', 'Repo Setup tutorial init'],
   ['initRepoSetupShell', 'Repo Setup hero shell'],
   ['window.startRepoSetupTutorial', 'Repo Setup transition exposed'],

--- a/docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md
+++ b/docs/DASHBOARD_DEPENDENCY_BOOTSTRAP.md
@@ -59,10 +59,15 @@ That script:
    build the host.
 4. Publishes the host to `app/bin/`, an ignored packaged-layout path reused by
    later launches.
+5. Writes ignored `dashboard/toolbox-status.json` for the browser checklist via
+   `scripts/sas-write-toolbox-status.sh`.
 
 The browser URL cannot install dependencies on its own. If a user types
 `http://127.0.0.1:5000/dashboard/` and nothing is listening, they must run the
 launcher first.
+
+The Toolbox Status tutorial consumes the status JSON written by the launcher.
+See [`DASHBOARD_TOOLBOX_TUTORIAL.md`](DASHBOARD_TOOLBOX_TUTORIAL.md).
 
 ## Browser, CMD, And EXE Entry Points
 
@@ -81,6 +86,7 @@ launcher first.
   with SHA512 before execution.
 - `--dry-run` is available for contract tests and operator review.
 - Installer cache and publish outputs stay local and ignored.
+- `dashboard/toolbox-status.json` is runtime machine state and stays ignored.
 - System-wide installation may create normal OS, installer, and endpoint
   telemetry. The suite uses scope control and clear operator intent; it does
   not attempt to hide or suppress logs.

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -14,7 +14,7 @@ On first run the launcher will **automatically prepare the dashboard host** if d
 
 **Dependency bootstrap:** [`DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](DASHBOARD_DEPENDENCY_BOOTSTRAP.md) — pinned Microsoft installers, SHA512 verification, ignored local cache.
 
-**Toolbox status + glowing fix wizard:** [`DASHBOARD_TOOLBOX_TUTORIAL.md`](DASHBOARD_TOOLBOX_TUTORIAL.md) — live probe of Git Bash, .NET, naabu, nmap, and more; auto-opens when something needs action.
+**Toolbox status:** [`DASHBOARD_TOOLBOX_TUTORIAL.md`](DASHBOARD_TOOLBOX_TUTORIAL.md) — live dependency checklist and glowing guided fixes for missing/outdated local tools.
 
 **Updates:** launcher checks are opt-in and must prompt before applying changes. Source clones use a clean `main` fast-forward; ZIP/field packages use checksum-verified manifests. See [`APPROVED_UPDATE_FLOW.md`](APPROVED_UPDATE_FLOW.md).
 
@@ -36,21 +36,23 @@ Warn against the common mistake: do **not** create a `SysAdminSuite` folder firs
 
 | File | Audience | What it does |
 |------|----------|--------------|
-| `START-HERE-SysAdminSuite-Dashboard.bat` | **Field users (primary)** | Friendly console, starts host, opens browser; Repo Setup, Cybernet, and Software Tracker front-door workflows |
-
-After the dashboard loads, field users see three front-door heroes:
-
-- **Repo Setup** — `Start Repo Setup` (clone/download, update approval, and launcher basics)
-- **Cybernet Survey** — `Start Cybernet Survey` (target acquisition wizard)
-- **Software Tracker Install** — `Start Software Tracker Install` (dry-run → approve → guarded execute tutorial)
-
-Software Tracker install details: [`SOFTWARE_TRACKER_INSTALLS.md`](SOFTWARE_TRACKER_INSTALLS.md).
+| `START-HERE-SysAdminSuite-Dashboard.bat` | **Field users (primary)** | Friendly console, starts host, writes toolbox status, opens browser; Toolbox, Repo Setup, Cybernet, and Software Tracker front-door workflows |
 | `START-HERE-SysAdminSuite-Dashboard.cmd` | Compatibility alias | Calls the `.bat` launcher |
 | `SysAdminSuite Dashboard.cmd` | Field desktops / shortcuts | Alias of the START-HERE `.bat` |
 | `Launch-SysAdminSuiteDashboard.Host.bat` | IT / developers | Ensures dependencies/host via Bash bootstrap, then spawns tray host |
 | `Launch-SysAdminSuite-Runtime.bat` `[3]` | Portable zip | Menu entry for .NET host |
 | `Launch-SysAdminSuiteDashboard.bat` | Permissive sites | Legacy PS + Python path |
 | `dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe` | **Local build only** | Not committed; see publish script below |
+
+After the dashboard loads, field users see four front-door heroes:
+
+- **Toolbox Check** — `Start Toolbox Check` (live dependency checklist and guided fixes)
+- **Repo Setup** — `Start Repo Setup` (clone/download, update approval, and launcher basics)
+- **Cybernet Survey** — `Start Cybernet Survey` (target acquisition wizard)
+- **Software Tracker Install** — `Start Software Tracker Install` (dry-run → approve → guarded execute tutorial)
+
+Software Tracker install details: [`SOFTWARE_TRACKER_INSTALLS.md`](SOFTWARE_TRACKER_INSTALLS.md).
+Toolbox details: [`DASHBOARD_TOOLBOX_TUTORIAL.md`](DASHBOARD_TOOLBOX_TUTORIAL.md).
 
 ## EXE policy (current vs future)
 

--- a/docs/DASHBOARD_TOOLBOX_TUTORIAL.md
+++ b/docs/DASHBOARD_TOOLBOX_TUTORIAL.md
@@ -1,81 +1,152 @@
 # Dashboard Toolbox Tutorial
 
-The dashboard **Toolbox Check** layer probes every tool the suite cares about, writes live status JSON for the browser, and auto-opens a glowing wizard when something is missing or outdated.
+The dashboard **Toolbox Check** layer is the live dependency checklist for the
+local workstation. It covers the repo update state, Git Bash, CMD, Windows
+PowerShell, PowerShell 7, Python, .NET runtimes and SDK, the dashboard host,
+naabu, nmap, curl, and unzip.
 
-## What gets probed
+This is not a .NET-only installer prompt. It is a unified toolbox health layer
+with a glowing wizard that points technicians to the exact next action when a
+tool is missing, outdated, blocked, or requires update review.
 
-| Tool | Tier | Auto-ensure | Tutorial fix |
-|------|------|-------------|--------------|
-| Repo / updates | required | Opt-in launcher update | Re-run `START-HERE-SysAdminSuite-Dashboard.bat` |
-| Git Bash | required | No (hard launcher gate) | Install Git for Windows |
-| CMD / Windows PowerShell | required | n/a | Informational |
-| PowerShell 7 | recommended | `bash/apps/sas-install-apps.sh` | Copy install guidance |
-| Python 3 | recommended | `bash/apps/sas-install-apps.sh` | Copy install guidance |
-| .NET ASP.NET Core RT | required | `bash scripts/ensure-dotnet-runtime.sh` | Copy ensure command |
-| .NET Windows Desktop RT | required | same | same |
-| .NET 8 SDK | workflow | `bash scripts/ensure-dotnet-sdk.sh` | Source checkout only; n/a on field release |
-| Dashboard host | required | Launcher bootstrap | Re-run launcher |
-| naabu | workflow | `bash survey/sas-ensure-naabu.sh` | Copy ensure command |
-| nmap | workflow | **Manual install only** | Doc link — no auto-download |
-| curl / unzip | required | Git Bash bundle | Repair Git Bash |
+## How It Works
 
-## Architecture
+1. `START-HERE-SysAdminSuite-Dashboard.bat` runs the approved update check and
+   exports `SAS_UPDATE_STATE` / `SAS_UPDATE_MODE`.
+2. `Launch-SysAdminSuiteDashboard.Host.bat` keeps Git Bash as the hard launcher
+   gate, prepares the dashboard host, then runs:
 
-1. **Manifest** — [`Config/toolbox-dependencies.json`](../Config/toolbox-dependencies.json) lists tools, tiers, pins, and ensure actions.
-2. **Probe** — [`scripts/sas-probe-toolbox.sh`](../scripts/sas-probe-toolbox.sh) read-only check; always exit 0.
-3. **Writer** — [`scripts/sas-write-toolbox-status.sh`](../scripts/sas-write-toolbox-status.sh) adds `actionNeeded` / `summary`; writes [`dashboard/toolbox-status.json`](../dashboard/toolbox-status.json) (gitignored).
-4. **Browser** — [`dashboard/js/launch-toolbox-tutorial.js`](../dashboard/js/launch-toolbox-tutorial.js) fetches status; toolbox wizard first when `actionNeeded`, else repo-setup for `?tutorial=setup`.
+   ```bash
+   bash scripts/sas-write-toolbox-status.sh
+   ```
+
+3. The writer calls `scripts/sas-probe-toolbox.sh`, enriches the result with
+   `actionNeeded` and `summary`, and writes ignored runtime JSON:
+
+   ```text
+   dashboard/toolbox-status.json
+   ```
+
+4. `dashboard/js/launch-toolbox-tutorial.js` fetches that JSON. If
+   `actionNeeded` is true, the Toolbox wizard opens before Repo Setup.
+
+## Probe Contract
+
+The committed manifest is
+[`Config/toolbox-dependencies.json`](../Config/toolbox-dependencies.json). Each
+tool entry defines:
+
+- `id`
+- `displayName`
+- `tier`
+- `workflows`
+- `pinnedVersion`
+- `probe`
+- `ensure`
+- `installDoc`
+- `statusHints`
+
+Status values are:
+
+```text
+ok
+missing
+outdated
+blocked
+unknown
+not_applicable
+```
 
 Pinned versions align with:
 
 - [`Config/dotnet-bootstrap.json`](../Config/dotnet-bootstrap.json)
 - [`Config/cybernet-naabu-profiles.json`](../Config/cybernet-naabu-profiles.json)
-- [`Config/sources.yaml`](../Config/sources.yaml) (PowerShell 7, Python)
+- [`Config/sources.yaml`](../Config/sources.yaml) for PowerShell 7 and Python
 
-## Glow behavior
+The probe is read-only and informational. It does not install tools, mutate the
+repo, or broaden any survey scope.
 
-Reuses `.sas-guide-glow` and `.sas-guide-panel` from the existing workflow tutorials:
+## Dashboard Behavior
 
-- One wizard step per failing tool (dynamic, not static).
-- Copy Command glows until copied → Next glows → final step Re-check glows.
-- Checklist row for the current tool also glows.
-- Banner glows when `actionNeeded`.
+When a required or workflow tool needs attention:
 
-## Re-check flow
+- `#toolbox-status-banner` glows at the top of the dashboard.
+- `#toolbox-checklist` shows one row per probed tool.
+- Rows needing action get the same `.sas-guide-glow` cue used by existing
+  dashboard tutorials.
+- `#toolbox-tutorial` builds one wizard step per failing tool.
+- The wizard glows **Copy Command**, then **Next**, then **Re-check toolbox**.
+
+If all probed tools are ready, the dashboard proceeds to Repo Setup when opened
+with `?tutorial=setup`.
+
+## What Gets Probed
+
+| Tool | Tier | Auto-ensure | Tutorial fix |
+|------|------|-------------|--------------|
+| Repo / updates | required | Opt-in launcher update | Re-run `START-HERE-SysAdminSuite-Dashboard.bat` |
+| Git Bash | required | No; hard launcher gate | Install Git for Windows or use field release |
+| CMD / Windows PowerShell | required | n/a | Informational |
+| PowerShell 7 | recommended | `bash/apps/sas-install-apps.sh` | Copy install guidance |
+| Python 3 | recommended | `bash/apps/sas-install-apps.sh` | Copy install guidance |
+| .NET ASP.NET Core Runtime | required | `bash scripts/ensure-dotnet-runtime.sh` | Copy ensure command |
+| .NET Windows Desktop Runtime | required | same | same |
+| .NET 8 SDK | workflow | `bash scripts/ensure-dotnet-sdk.sh` | Source checkout only; n/a on field release |
+| Dashboard host | required | Launcher bootstrap | Re-run launcher |
+| naabu | workflow | `bash survey/sas-ensure-naabu.sh` | Copy ensure command |
+| nmap | workflow | Manual install only | Doc link; no auto-download |
+| curl / unzip | required | Git Bash bundle | Repair Git Bash |
+
+## Re-check Flow
 
 After running an ensure script outside the dashboard, either:
 
-- Click **Re-check toolbox** in the wizard footer, or
-- Re-run `START-HERE-SysAdminSuite-Dashboard.bat` (launcher rewrites status JSON).
+- Click **Re-check toolbox** in the wizard footer.
+- Re-run `START-HERE-SysAdminSuite-Dashboard.bat`, which rewrites status JSON.
 
-## Sample fixtures
+## Sample Fixtures
 
-Committed under `dashboard/samples/` for manual smoke:
+Committed sanitized fixtures live under `dashboard/samples/`:
 
-- `toolbox-status-all-ok.json`
-- `toolbox-status-missing-naabu.json`
-- `toolbox-status-update-available.json`
+```text
+dashboard/samples/toolbox-status-all-ok.json
+dashboard/samples/toolbox-status-missing-naabu.json
+dashboard/samples/toolbox-status-update-available.json
+```
 
-Copy a sample to `dashboard/toolbox-status.json` to test the banner and wizard without re-probing.
+Copy one sample to the ignored runtime location to test the banner and wizard
+without re-probing:
 
-## Doctrine
+```bash
+cp dashboard/samples/toolbox-status-missing-naabu.json dashboard/toolbox-status.json
+```
 
-- **No winget/choco** in probe or tutorial commands.
-- **nmap**: detect and guide only.
-- **Git Bash**: launcher hard gate unchanged (exit 2).
-- **Consent-gated updates**: dashboard never silently mutates the repo.
+Do not commit `dashboard/toolbox-status.json`; it is runtime machine state.
 
-## Related docs
+## Guardrails
+
+- No `winget`, Chocolatey, or browser-driven installs are used in the toolbox
+  probe or tutorial commands.
+- nmap is detect-and-guide only on Northwell workstations. The dashboard never
+  auto-downloads it.
+- naabu install guidance uses `survey/sas-ensure-naabu.sh` and preserves the
+  low-noise survey discipline from `survey/naabu_profiles.json`.
+- Repo updates remain consent-gated in the launcher. The dashboard only points
+  the user back to `START-HERE-SysAdminSuite-Dashboard.bat`.
+- Git Bash remains a launcher-side hard gate because the browser cannot exist
+  before the host bootstrap runs.
+
+## Validation
+
+```bash
+bash scripts/sas-probe-toolbox.sh --dry-run | python -m json.tool
+bash Tests/bash/test_toolbox_probe_contracts.sh
+bash Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh
+```
+
+## Related Docs
 
 - [`DASHBOARD_ENTRYPOINT.md`](DASHBOARD_ENTRYPOINT.md)
 - [`DASHBOARD_DEPENDENCY_BOOTSTRAP.md`](DASHBOARD_DEPENDENCY_BOOTSTRAP.md)
 - [`NAABU_CYBERNET_PROFILES.md`](NAABU_CYBERNET_PROFILES.md)
 - [`APPROVED_UPDATE_FLOW.md`](APPROVED_UPDATE_FLOW.md)
-
-## Validation
-
-```bash
-bash scripts/sas-probe-toolbox.sh --dry-run | python3 -m json.tool
-bash Tests/bash/test_toolbox_probe_contracts.sh
-bash Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh
-```

--- a/docs/NAABU_CYBERNET_PROFILES.md
+++ b/docs/NAABU_CYBERNET_PROFILES.md
@@ -16,6 +16,10 @@ Downloads pinned `naabu.exe` to `bin/naabu.exe` from [ProjectDiscovery naabu rel
 
 **Other environments:** `winget install projectdiscovery.naabu` (or vendor PATH install) is acceptable when Git Bash ensure is not used; the suite still prefers the pinned GitHub download for reproducible versions.
 
+The dashboard Toolbox Status tutorial detects naabu/nmap readiness and points
+Northwell users back to this bootstrap path. See
+[`DASHBOARD_TOOLBOX_TUTORIAL.md`](DASHBOARD_TOOLBOX_TUTORIAL.md).
+
 ## Profile truth model
 
 Doctrine is the single source of truth. The runtime config is generated from it:


### PR DESCRIPTION
## Summary
- Tightens Toolbox Status auto-open precedence so Repo Setup waits while toolbox status is pending or needs action.
- Adds dropped `toolbox-status` fixture parsing, checklist/banner cleanup, and stronger contract/smoke coverage.
- Consolidates Toolbox Status docs and cross-links launcher/dependency/naabu guidance.

## Test plan
- `bash Tests/bash/test_toolbox_probe_contracts.sh`
- `bash Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh`
- `bash Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh`
- `for t in Tests/bash/test_*.sh; do bash "$t"; done`
- `node dashboard/smoke-test.js`
- `node dashboard/start-button-smoke.js`
- `python -m pytest -q Tests/test_software_tracker_installs.py`