### PR TITLE
Bridge launcher to a working dashboard server (Python fallback)

### DIFF
--- a/Launch-SysAdminSuiteDashboard.Host.bat
+++ b/Launch-SysAdminSuiteDashboard.Host.bat
@@ -25,15 +25,29 @@ if not defined BASH_EXE (
 echo Preparing dashboard dependencies and host for first use...
 "%BASH_EXE%" -lc "cd '%ROOT:\=/%' && bash scripts/ensure-dashboard-host.sh"
 set "ENSURE_RC=%errorlevel%"
-if "%ENSURE_RC%"=="2" exit /b 2
-if not "%ENSURE_RC%"=="0" exit /b 3
 
 if defined BASH_EXE (
     "%BASH_EXE%" -lc "cd '%ROOT:\=/%' && export SAS_UPDATE_STATE='%SAS_UPDATE_STATE%' SAS_UPDATE_MODE='%SAS_UPDATE_MODE%' && bash scripts/sas-write-toolbox-status.sh" 2>nul
 )
 
+if not "%ENSURE_RC%"=="0" (
+    rem The .NET dashboard host could not be prepared on this machine. Bridge the
+    rem gap with the local-only Python dashboard fallback so a double-click still
+    rem serves the dashboard instead of dead-ending to manual CLI usage.
+    call :start_fallback
+    if defined FALLBACK_OK exit /b 0
+    if "%ENSURE_RC%"=="2" exit /b 2
+    exit /b 3
+)
+
 call :find_host
-if not defined HOST_EXE exit /b 3
+if not defined HOST_EXE (
+    rem Host preparation reported success but no executable was located. Try the
+    rem local-only Python dashboard fallback before failing.
+    call :start_fallback
+    if defined FALLBACK_OK exit /b 0
+    exit /b 3
+)
 
 :start_host
 if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
@@ -52,8 +66,30 @@ if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%app
 if not defined HOST_EXE if exist "%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe" set "HOST_EXE=%ROOT%dist\SysAdminSuiteDashboard\SysAdminSuite Dashboard.exe"
 if not defined HOST_EXE if exist "%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%tools\publish\SysAdminSuite.DashboardHost\SysAdminSuite.DashboardHost.exe"
 if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\SysAdminSuite.DashboardHost.exe"
+rem Runtime-identifier (win-x64) builds land in a nested RID folder; include
+rem those so an already-built host is not missed and the launcher needlessly
+rem falls back.
+if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\win-x64\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\win-x64\SysAdminSuite.DashboardHost.exe"
+if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\win-x64\publish\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Release\net8.0-windows\win-x64\publish\SysAdminSuite.DashboardHost.exe"
 if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\SysAdminSuite.DashboardHost.exe"
+if not defined HOST_EXE if exist "%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\win-x64\SysAdminSuite.DashboardHost.exe" set "HOST_EXE=%ROOT%src\SysAdminSuite.DashboardHost\bin\Debug\net8.0-windows\win-x64\SysAdminSuite.DashboardHost.exe"
 exit /b 0
+
+:start_fallback
+rem Local-only Python dashboard fallback. Keeps the double-click front door
+rem working when the .NET host is unavailable. server.py is the suite's own
+rem server (not a raw python -m http.server) and binds 127.0.0.1 only.
+set "FALLBACK_OK="
+set "PY_OK="
+where py >nul 2>nul && set "PY_OK=1"
+if not defined PY_OK where python >nul 2>nul && set "PY_OK=1"
+if not defined PY_OK where python3 >nul 2>nul && set "PY_OK=1"
+if not defined PY_OK goto :eof
+if not exist "%ROOT%server.py" goto :eof
+echo The .NET dashboard host is unavailable; starting the local Python dashboard fallback...
+start "SysAdminSuite Dashboard (fallback)" /MIN "%BASH_EXE%" -lc "cd '%ROOT:\=/%' && SAS_DASHBOARD_BIND=127.0.0.1 SAS_DASHBOARD_PORT=5000 bash scripts/sas-serve-dashboard-fallback.sh"
+set "FALLBACK_OK=1"
+goto :eof
 
 :find_bash
 set "BASH_EXE="

--- a/Tests/bash/test_dashboard_entrypoint_contracts.sh
+++ b/Tests/bash/test_dashboard_entrypoint_contracts.sh
@@ -16,6 +16,9 @@ readme="$repo_root/README.md"
 survey_readme="$repo_root/survey/README.md"
 agents="$repo_root/AGENTS.md"
 index="$repo_root/dashboard/index.html"
+fallback_script="$repo_root/scripts/sas-serve-dashboard-fallback.sh"
+server_py="$repo_root/server.py"
+ensure_host="$repo_root/scripts/ensure-dashboard-host.sh"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -95,6 +98,27 @@ grep -Fq 'Git\bin\bash.exe' "$host_bat" \
   || fail "host launcher does not prefer Git Bash for bootstrap"
 grep -Fq 'Microsoft .NET 8' "$host_bat" \
   || fail "host launcher does not describe Microsoft .NET bootstrap"
+
+# Local-only Python dashboard fallback: when the .NET host cannot be prepared or
+# located, the launcher must still serve the dashboard from server.py instead of
+# dead-ending technicians to manual CLI usage.
+[[ -f "$fallback_script" ]] || fail "scripts/sas-serve-dashboard-fallback.sh is missing"
+[[ -f "$server_py" ]] || fail "server.py is missing"
+[[ -f "$ensure_host" ]] || fail "scripts/ensure-dashboard-host.sh is missing"
+grep -Fq 'server.py' "$fallback_script" \
+  || fail "fallback script does not serve from server.py"
+grep -Fq '127.0.0.1' "$fallback_script" \
+  || fail "fallback script does not bind local-only (127.0.0.1)"
+grep -Fq ':start_fallback' "$host_bat" \
+  || fail "host launcher has no :start_fallback bridge routine"
+grep -Fq 'sas-serve-dashboard-fallback.sh' "$host_bat" \
+  || fail "host launcher does not invoke the dashboard fallback script"
+grep -Fq 'net8.0-windows\win-x64\SysAdminSuite.DashboardHost.exe' "$host_bat" \
+  || fail "host launcher find_host does not include the win-x64 RID build path"
+grep -Fq 'win-x64/SysAdminSuite.DashboardHost.exe' "$ensure_host" \
+  || fail "ensure-dashboard-host.sh find_host does not include the win-x64 RID build path"
+grep -Fq 'SAS_DASHBOARD_BIND' "$server_py" \
+  || fail "server.py does not honor SAS_DASHBOARD_BIND for local-only fallback binding"
 
 # The root .bat must NOT instruct field users to run the publish command by hand
 # as the normal path, and must not tell them to double-click again as a routine.

--- a/docs/DASHBOARD_SERVER_FALLBACK.md
+++ b/docs/DASHBOARD_SERVER_FALLBACK.md
@@ -1,0 +1,66 @@
+# Dashboard Server Fallback
+
+Agent + operator reference for how the dashboard guarantees a running local server.
+
+## Problem this solves
+
+The documented field front door is a double-click of
+`START-HERE-SysAdminSuite-Dashboard.bat`, which serves the dashboard at
+`http://127.0.0.1:5000/dashboard/`. The primary server is the .NET tray host
+(`src/SysAdminSuite.DashboardHost`), prepared on first run by
+`scripts/ensure-dashboard-host.sh` (`dotnet publish` into `app/bin`).
+
+On workstations without the .NET 8 SDK, with blocked Microsoft downloads, or
+with a failed build, that host is never produced. Previously the launcher then
+dead-ended with an "ask IT / use the field release" message, which pushed
+technicians toward raw `cmd`/PowerShell instead of the dashboard. The server
+"didn't actually launch."
+
+## The bridge
+
+The launcher now keeps a **local-only Python fallback** so a double-click still
+serves the dashboard:
+
+1. `Launch-SysAdminSuiteDashboard.Host.bat` tries the .NET host first (unchanged
+   priority). Its `:find_host` now also checks the `win-x64` runtime-identifier
+   build folders, so an already-built host is not missed.
+2. If the host cannot be prepared (`ensure-dashboard-host.sh` non-zero) or no
+   host executable is located, the launcher calls `:start_fallback`.
+3. `:start_fallback` launches `scripts/sas-serve-dashboard-fallback.sh`, which
+   finds a real Python (verified with `--version`, skipping the non-functional
+   Windows Store stubs) and runs the repo's own `server.py`.
+4. `server.py` serves the identical `/dashboard/` surface and now honors
+   `SAS_DASHBOARD_BIND` / `SAS_DASHBOARD_PORT`; the fallback binds `127.0.0.1:5000`.
+5. `START-HERE-SysAdminSuite-Dashboard.bat` then performs its existing health
+   check and opens the browser. No change to the user's steps.
+
+```mermaid
+flowchart TD
+    bat["Double-click START-HERE ...Dashboard.bat"] --> host["Launch ...Host.bat"]
+    host --> ensure["ensure-dashboard-host.sh (.NET host)"]
+    ensure --> found{".NET host available?"}
+    found -->|"yes"| dotnet["Start .NET tray host :5000"]
+    found -->|"no"| fallback["start_fallback -> sas-serve-dashboard-fallback.sh"]
+    fallback --> py{"Real Python found?"}
+    py -->|"yes"| serverpy["server.py serves 127.0.0.1:5000/dashboard/"]
+    py -->|"no"| guidance["Field-safe message: field release / IT prep"]
+    dotnet --> ready["Browser opens /dashboard/"]
+    serverpy --> ready
+```
+
+## Doctrine notes
+
+- This is an **internal launcher fallback**, not user-facing guidance. The
+  double-click `.bat` stays the front door and the .NET host stays primary.
+- It uses the suite's own `server.py`, never a raw `python -m http.server`, and
+  binds `127.0.0.1` only (local-only, not `0.0.0.0`).
+- The fallback is a static file server only; it does not run survey, credential,
+  or remote-command tooling.
+
+## Files
+
+- `scripts/sas-serve-dashboard-fallback.sh` - Bash-first fallback launcher.
+- `server.py` - shared static server, env-overridable bind/port.
+- `Launch-SysAdminSuiteDashboard.Host.bat` - `:start_fallback` + win-x64 paths.
+- `scripts/ensure-dashboard-host.sh` - win-x64 paths in `find_host`.
+- `Tests/bash/test_dashboard_entrypoint_contracts.sh` - fallback contracts.

--- a/scripts/ensure-dashboard-host.sh
+++ b/scripts/ensure-dashboard-host.sh
@@ -50,7 +50,10 @@ find_host() {
     "${REPO_ROOT}/dist/SysAdminSuiteDashboard/SysAdminSuite Dashboard.exe"
     "${REPO_ROOT}/tools/publish/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.exe"
     "${REPO_ROOT}/src/SysAdminSuite.DashboardHost/bin/Release/net8.0-windows/SysAdminSuite.DashboardHost.exe"
+    "${REPO_ROOT}/src/SysAdminSuite.DashboardHost/bin/Release/net8.0-windows/win-x64/SysAdminSuite.DashboardHost.exe"
+    "${REPO_ROOT}/src/SysAdminSuite.DashboardHost/bin/Release/net8.0-windows/win-x64/publish/SysAdminSuite.DashboardHost.exe"
     "${REPO_ROOT}/src/SysAdminSuite.DashboardHost/bin/Debug/net8.0-windows/SysAdminSuite.DashboardHost.exe"
+    "${REPO_ROOT}/src/SysAdminSuite.DashboardHost/bin/Debug/net8.0-windows/win-x64/SysAdminSuite.DashboardHost.exe"
   )
   local candidate
   for candidate in "${candidates[@]}"; do

--- a/scripts/sas-serve-dashboard-fallback.sh
+++ b/scripts/sas-serve-dashboard-fallback.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# sas-serve-dashboard-fallback.sh
+#
+# Local-only dashboard server FALLBACK for Windows field workstations.
+#
+# The primary dashboard front door is the .NET tray host started by
+# Launch-SysAdminSuiteDashboard.Host.bat. When that host cannot be built or
+# located (no .NET SDK, blocked Microsoft downloads, build failure), a
+# double-click would otherwise dead-end and push technicians toward raw CLI.
+# This script bridges that gap by serving the SAME dashboard from the repo's
+# own server.py over http://127.0.0.1:5000/dashboard/.
+#
+# This is an internal launcher fallback, not user-facing guidance: the
+# double-click .bat remains the front door and the .NET host stays primary.
+# It is the suite's own server.py, not a raw "python -m http.server".
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SERVER_PY="${REPO_ROOT}/server.py"
+
+BIND="${SAS_DASHBOARD_BIND:-127.0.0.1}"
+PORT="${SAS_DASHBOARD_PORT:-5000}"
+
+log() { printf '[sas-serve-dashboard-fallback] %s\n' "$*" >&2; }
+fail() { printf '[sas-serve-dashboard-fallback] ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/sas-serve-dashboard-fallback.sh [--bind ADDR] [--port N]
+
+Serves the SysAdminSuite dashboard from server.py as a local-only fallback when
+the .NET dashboard host is unavailable. Defaults: 127.0.0.1:5000.
+
+Options:
+  --bind ADDR   Bind address (default: 127.0.0.1; env: SAS_DASHBOARD_BIND)
+  --port N      Port (default: 5000; env: SAS_DASHBOARD_PORT)
+  -h, --help    Show help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bind) BIND="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -f "$SERVER_PY" ]] || fail "server.py not found at $SERVER_PY" 1
+
+# Find a REAL Python. The Windows Store "python"/"python3" aliases under
+# WindowsApps are non-functional stubs that exit without serving, so every
+# candidate is verified with --version before it is trusted.
+find_python() {
+  local candidate
+  for candidate in "py -3" "python3" "python" "py"; do
+    if $candidate --version >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+PY="$(find_python)" || fail "No working Python found for the dashboard fallback server." 2
+
+export SAS_DASHBOARD_BIND="$BIND"
+export SAS_DASHBOARD_PORT="$PORT"
+
+log "Starting dashboard fallback server on http://${BIND}:${PORT}/dashboard/ via ${PY}"
+# Run from the repo root and hand the launcher a plain relative filename.
+# The Windows "py" launcher cannot open an MSYS-style absolute path
+# (e.g. /c/Users/.../server.py), so a cwd-relative name is used instead.
+cd "$REPO_ROOT"
+# shellcheck disable=SC2086
+exec $PY "$(basename "$SERVER_PY")"

--- a/server.py
+++ b/server.py
@@ -10,8 +10,11 @@ import os
 import subprocess
 from pathlib import Path
 
-PORT = 5000
-HOST = "0.0.0.0"
+# Bind/port are overridable so the Windows launcher can reuse this same server as
+# a local-only dashboard fallback (127.0.0.1) when the .NET host is unavailable.
+# Defaults preserve the original Replit behavior (0.0.0.0:5000).
+PORT = int(os.environ.get("SAS_DASHBOARD_PORT", "5000"))
+HOST = os.environ.get("SAS_DASHBOARD_BIND", "0.0.0.0")
 
 HTML = """<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
The double-click launcher only attempted the .NET tray host. When that host can't be built or located (no .NET SDK, blocked Microsoft downloads, a failed build, or an RID-nested `win-x64` build the launcher didn't search), nothing served `http://127.0.0.1:5000` and technicians fell back to manual `cmd`/PowerShell. This bridges that gap.

- **server.py**: honors `SAS_DASHBOARD_BIND` / `SAS_DASHBOARD_PORT` (defaults preserved: `0.0.0.0:5000`).
- **scripts/sas-serve-dashboard-fallback.sh** (new): Bash-first launcher that verifies a real Python (`--version`, skipping the non-functional Windows Store stubs) and serves the suite's own `server.py` on `127.0.0.1:5000`.
- **Launch-SysAdminSuiteDashboard.Host.bat**: adds `:start_fallback` (used when the .NET host is unavailable) and the missing `win-x64` RID paths to `:find_host`.
- **scripts/ensure-dashboard-host.sh**: `find_host` also checks `win-x64` RID folders.
- **docs/DASHBOARD_SERVER_FALLBACK.md** (new): documents the bridge.

The .NET host stays **primary** and the double-click `.bat` stays the front door. The fallback is an internal launcher mechanism (not user-facing CLI guidance), uses the suite's own `server.py` (not a raw `python -m http.server`), and binds `127.0.0.1` only.

## Test plan
- [x] `Tests/bash/test_dashboard_entrypoint_contracts.sh` (extended with fallback contracts) - PASS
- [x] `Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh` - PASS
- [x] `bash -n` syntax check on new/changed shell scripts - PASS
- [x] Empirical: `server.py` with `SAS_DASHBOARD_BIND=127.0.0.1` binds `127.0.0.1:5000` (not `0.0.0.0`), serves `/dashboard/` (200, real app) and `/dashboard/js/bundle.js` (200)
- [x] Empirical: fallback launched via the exact Host.bat mechanism (`cmd start /MIN bash ... sas-serve-dashboard-fallback.sh`) serves the dashboard and stops cleanly

Built additively on top of the merged toolbox feature (PR #102); developed in an isolated worktree to avoid colliding with concurrent agent work.
