### PR TITLE
Survey lanes and device classification

### DIFF
--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -69,7 +69,7 @@ Use the Cybernet-first dashboard when you want a guided wizard instead of memori
 5. **Load Evidence** — drop `network_preflight.csv`, `workstation_identity.csv`, optional reachability JSON, normalized target manifests, and AD population CSVs.
 6. **Review Results** — use the Cybernet review summary; open **Advanced Tools** only for detailed panels or legacy command generation.
 
-For subnet discovery and Nmap orchestration, use the CLI path below.
+For subnet discovery and Nmap orchestration, use the CLI path below. For **manifest lane vs subnet lane** and **serial vs hostname vs MAC** guidance, see [`docs/SURVEY_LANES.md`](docs/SURVEY_LANES.md).
 
 ## AD-first warning
 

--- a/Tests/bash/test-cybernet-subnet-location-contracts.sh
+++ b/Tests/bash/test-cybernet-subnet-location-contracts.sh
@@ -529,4 +529,7 @@ if "Allowed mixed prefix pairing" not in row.get("ReviewReason", ""):
 PY
 pass "case 23: AllowMixedWith emits subnet_location_allowed_mixed"
 
+grep -q '"DeviceRole"' "$PY" || fail "subnet location map missing DeviceRole column"
+pass "shared classifier DeviceRole column present in subnet location map"
+
 printf 'Cybernet subnet location inference contracts passed (23 synthetic cases).\n'

--- a/Tests/bash/test_survey_lanes_contracts.sh
+++ b/Tests/bash/test_survey_lanes_contracts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Contract tests for survey lanes and device classification sprint.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+[[ -f docs/SURVEY_LANES.md ]] || fail "docs/SURVEY_LANES.md missing"
+[[ -f survey/sas-survey-device-classify.py ]] || fail "survey/sas-survey-device-classify.py missing"
+[[ -f survey/sas-classify-dns-list-output.py ]] || fail "survey/sas-classify-dns-list-output.py missing"
+
+grep -q 'SURVEY_LANES.md' START-HERE-CYBERNET-NEURON-SURVEY.md || fail "START-HERE missing SURVEY_LANES link"
+grep -q 'SURVEY_LANES.md' survey/README.md || fail "survey/README missing SURVEY_LANES link"
+grep -q 'SURVEY_LANES.md' docs/DASHBOARD_ENTRYPOINT.md || fail "DASHBOARD_ENTRYPOINT missing SURVEY_LANES link"
+
+grep -q 'CLASSIFICATION_FIELDS' survey/sas-resolve-manifest-dns.py || fail "DNS resolver missing classification column wiring"
+grep -q 'DeviceRole' survey/sas-merge-cybernet-evidence.py || fail "merge evidence missing DeviceRole"
+grep -q 'REVIEW_INFRASTRUCTURE_NOT_TARGET' survey/sas-merge-cybernet-evidence.py || fail "merge missing infrastructure review status"
+
+python tests/survey/test_survey_device_classify.py
+
+pass "survey lanes contracts"

--- a/Tests/survey/test_survey_device_classify.py
+++ b/Tests/survey/test_survey_device_classify.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Offline unit tests for survey device classifier."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "survey" / "sas-survey-device-classify.py"
+
+
+def load_module():
+    import sys
+    spec = importlib.util.spec_from_file_location("sas_survey_device_classify", MODULE_PATH)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"could not load {MODULE_PATH}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = load_module()
+classify_device = MOD.classify_device
+
+
+def test_ap_reverse_dns():
+    result = classify_device(
+        hostname="NSUH-AP-12",
+        reverse_dns_names="ap-nsuh-floor3.example.org",
+        survey_lane="subnet_discovery",
+        in_manifest=False,
+    )
+    assert result.device_role == "infrastructure_access_point"
+    assert result.counts_toward_cybernet_population == "No"
+
+
+def test_cybernet_manifest_workstation():
+    result = classify_device(
+        hostname="NSUH12WMH01",
+        device_type="Cybernet",
+        serial="CYB-SERIAL-001",
+        identifier_type="Serial",
+        survey_lane="cybernet_manifest",
+        in_manifest=True,
+    )
+    assert result.device_role == "target_workstation"
+    assert result.counts_toward_cybernet_population == "Yes"
+    assert result.identifier_type == "Serial"
+    assert result.survey_authority == "serial"
+
+
+def test_printer_ports():
+    result = classify_device(
+        hostname="10.10.10.50",
+        open_ports=["9100", "445"],
+        survey_lane="subnet_discovery",
+        in_manifest=False,
+    )
+    assert result.device_role == "infrastructure_print"
+    assert result.counts_toward_cybernet_population == "No"
+
+
+def test_discovery_only_subnet_lane():
+    result = classify_device(
+        hostname="MYSTERY-HOST",
+        survey_lane="subnet_discovery",
+        in_manifest=False,
+    )
+    assert result.device_role == "discovery_only"
+    assert result.survey_authority == "subnet_inference_only"
+
+
+def test_aruba_vendor_ap():
+    result = classify_device(
+        hostname="10.1.1.5",
+        reverse_dns_names="wireless-controller",
+        mac_vendor="Aruba Networks",
+        survey_lane="subnet_discovery",
+        in_manifest=False,
+    )
+    assert result.device_role == "infrastructure_access_point"
+
+
+def test_classify_from_dns_row():
+    row = {
+        "HostName": "NSUH12WMH02",
+        "DeviceType": "Cybernet",
+        "Serial": "ABC123",
+        "ReverseNames": "",
+        "IdentifierType": "Serial",
+    }
+    out = MOD.classify_from_dns_row(row)
+    assert out["SurveyLane"] == "cybernet_manifest"
+    assert out["DeviceRole"] == "target_workstation"
+    assert "DeviceRole" in out
+
+
+def main() -> int:
+    tests = [
+        test_ap_reverse_dns,
+        test_cybernet_manifest_workstation,
+        test_printer_ports,
+        test_discovery_only_subnet_lane,
+        test_aruba_vendor_ap,
+        test_classify_from_dns_row,
+    ]
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"PASS {test.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"FAIL {test.__name__}: {exc}", file=sys.stderr)
+    if failed:
+        print(f"{failed} test(s) failed", file=sys.stderr)
+        return 1
+    print(f"All {len(tests)} classifier tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -39,6 +39,7 @@ const TYPE_SECTION_LABELS = {
   'smb-recon': 'Network review',
   'naabu-reachability': 'Reachability evidence',
   'cybernet-target-manifest': 'Target manifest',
+  'survey-classification': 'Survey classification',
   'ad-registered-population': 'AD registered population',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
@@ -685,7 +686,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'ad-registered-population': '🏢',
     'software-tracker': '📦', 'software-tracker-install-plan': '📋',
     'toolbox-status': '🧰',
-    'cybernet-target-manifest': '🎯', 'unknown': '❓'
+    'cybernet-target-manifest': '🎯', 'survey-classification': '🏷️', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
 
@@ -1538,6 +1539,7 @@ function updateCybernetReview() {
 
   const preflightRows = store.networkPreflight?.length || 0;
   const identityRows = store.workstationIdentity?.length || 0;
+  const classificationRows = store.surveyClassification || [];
   const targetCount = Math.max(_countUniqueTargets(store.networkPreflight), _countUniqueTargets(store.workstationIdentity));
   const reachRows = store.naabuReachability || [];
   const reachabilityCount = reachRows.length;
@@ -1545,8 +1547,8 @@ function updateCybernetReview() {
     const rv = (r.reachability || 'open').toLowerCase();
     return rv === 'open' || rv === '';
   }).length;
-  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachabilityCount > 0 ||
-    loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity' || f.type === 'naabu-reachability');
+  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachabilityCount > 0 || classificationRows.length > 0 ||
+    loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity' || f.type === 'naabu-reachability' || f.type === 'survey-classification');
 
   if (!hasEvidence) {
     section.classList.add('hidden');
@@ -1555,12 +1557,40 @@ function updateCybernetReview() {
 
   section.classList.remove('hidden');
   const guestWarn = _detectGuestNetworkWarning();
+
+  const manifestTargets = classificationRows.filter(r => {
+    const role = (r.deviceRole || '').toLowerCase();
+    const counts = (r.countsToward || '').toLowerCase();
+    return role === 'target_workstation' || counts === 'yes';
+  }).length;
+  const infrastructure = classificationRows.filter(r => {
+    const role = (r.deviceRole || '').toLowerCase();
+    return role.startsWith('infrastructure_');
+  }).length;
+  const needsReview = classificationRows.filter(r => {
+    const role = (r.deviceRole || '').toLowerCase();
+    const status = (r.overallStatus || '').toUpperCase();
+    return status.includes('REVIEW') || status.includes('CONFLICT') || role === 'discovery_only';
+  }).length;
+
   let nextAction = 'Review the summary, then open network evidence details if you need row-level triage.';
   if (!preflightRows) nextAction = 'Load network_preflight.csv to prove network posture.';
   else if (!identityRows) nextAction = 'Load workstation_identity.csv for identity evidence.';
   else if (guestWarn) nextAction = 'Fix network posture (segment/VPN) before running more probes.';
+  else if (infrastructure > 0 && manifestTargets === 0) nextAction = 'Infrastructure hosts found — review subnet lane output; not Cybernet target failures.';
+
+  const laneCallout = `<p class="cybernet-review-lane"><strong>Which survey lane?</strong> Manifest survey (serial-first AD rows) vs subnet discovery (approved CIDRs). See <code>docs/SURVEY_LANES.md</code>.</p>`;
+
+  const classificationBlock = classificationRows.length ? `
+    <ul class="cybernet-review-stats cybernet-review-buckets">
+      <li><strong>Manifest targets:</strong> ${manifestTargets}</li>
+      <li><strong>Infrastructure discovered:</strong> ${infrastructure}</li>
+      <li><strong>Needs review:</strong> ${needsReview}</li>
+    </ul>
+  ` : '';
 
   body.innerHTML = `
+    ${laneCallout}
     <ul class="cybernet-review-stats">
       <li><strong>Targets in evidence:</strong> ${targetCount || '—'}</li>
       <li><strong>Preflight rows:</strong> ${preflightRows}</li>
@@ -1568,6 +1598,7 @@ function updateCybernetReview() {
       <li><strong>Open ports observed:</strong> ${reachabilityCount > 0 ? openPortsCount : '—'}</li>
       <li><strong>Reachability rows:</strong> ${reachabilityCount > 0 ? reachabilityCount : '—'}</li>
     </ul>
+    ${classificationBlock}
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
   `;
@@ -1588,17 +1619,22 @@ function updateCybernetManifestSummary() {
   const withHostname = rows.filter(r => r.hostname || r.dnsHostName).length;
   const withSerial = rows.filter(r => r.serial).length;
   const withMac = rows.filter(r => r.mac).length;
+  const serialIdRows = rows.filter(r => (r.identifierType || '').toLowerCase() === 'serial').length;
+  const hostIdRows = rows.filter(r => (r.identifierType || '').toLowerCase() === 'hostname').length;
+  const macIdRows = rows.filter(r => (r.identifierType || '').toLowerCase() === 'mac').length;
   const missingDnsHost = rows.filter(r => !r.hostname && !r.dnsHostName).length;
   const missingSerial = rows.filter(r => !r.serial).length;
 
   stats.innerHTML = [
     `<span><strong>${rows.length}</strong> manifest rows</span>`,
+    `<span class="cybernet-id-chip"><strong>${withSerial}</strong> Serial</span>`,
+    `<span class="cybernet-id-chip"><strong>${withHostname}</strong> HostName</span>`,
+    `<span class="cybernet-id-chip"><strong>${withMac}</strong> MAC</span>`,
     `<span><strong>${withHostname}</strong> with hostname/DNS</span>`,
-    `<span><strong>${withSerial}</strong> with serial</span>`,
-    `<span><strong>${withMac}</strong> with MAC</span>`,
     `<span><strong>${missingDnsHost}</strong> missing hostname/DNS</span>`,
     `<span><strong>${missingSerial}</strong> missing serial</span>`,
-  ].join(' · ');
+    serialIdRows || hostIdRows || macIdRows ? `<span>ID lane: ${serialIdRows} Serial / ${hostIdRows} HostName / ${macIdRows} MAC</span>` : '',
+  ].filter(Boolean).join(' · ');
   root.style.display = '';
 }
 

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -398,6 +398,10 @@ function detectFileType(filename, content) {
       fn.includes('ad_missing_dns') || fn.includes('ad_duplicates') || fn.includes('evidence_only')) {
     return 'ad-registered-population';
   }
+  if (fn.includes('dns_infrastructure_classification') || fn.includes('dns_infrastructure') ||
+      fn.includes('cybernet_dns_resolution') || fn.includes('cybernet_master_presence')) {
+    return 'survey-classification';
+  }
   if (fn.includes('wmi_identity') || fn.includes('wmi-identity')) return 'workstation-identity';
 
   // Detect by headers if content is provided
@@ -419,6 +423,8 @@ function detectFileType(filename, content) {
     if (firstLine.includes('populationauthority') && firstLine.includes('reconcilebucket')) return 'ad-registered-population';
     if (firstLine.includes('populationauthority') && firstLine.includes('adstatus')) return 'ad-registered-population';
     if (firstLine.includes('reconcilebucket') && firstLine.includes('hostname')) return 'ad-registered-population';
+    if (firstLine.includes('devicerole') && firstLine.includes('surveylane')) return 'survey-classification';
+    if (firstLine.includes('devicerole') && firstLine.includes('countstowardcybernetpopulation')) return 'survey-classification';
   }
 
   return 'unknown';
@@ -449,6 +455,7 @@ function parseFileContent(type, content, filename) {
     case 'software-superset': return parseSoftwareSuperset(content);
     case 'naabu-reachability': return parseNaabuReachability(content, filename);
     case 'ad-registered-population': return parseAdRegisteredPopulation(content, filename);
+    case 'survey-classification': return parseSurveyClassification(content, filename);
     default: return { type: 'unknown', rows: [], meta: {} };
   }
 }
@@ -511,6 +518,25 @@ function parseNaabuReachability(content, filename) {
   }
 
   return { type: 'naabu-reachability', rows, meta: { count: rows.length, warnings } };
+}
+
+/**
+ * Parse survey classification CSVs (DNS resolution, subnet dns-list, merged evidence).
+ */
+function parseSurveyClassification(content, filename) {
+  const rows = parseCSV(content);
+  const normalized = rows.map(r => ({
+    hostName: r.HostName || r.hostname || r.Target || '',
+    deviceRole: r.DeviceRole || r.devicerole || '',
+    surveyLane: r.SurveyLane || r.surveylane || '',
+    identifierType: r.IdentifierType || r.identifiertype || '',
+    countsToward: r.CountsTowardCybernetPopulation || r.countstowardcybernetpopulation || '',
+    roleSignals: r.RoleSignals || r.rolesignals || '',
+    nextAction: r.NextAction || r.nextaction || '',
+    overallStatus: r.OverallStatus || r.overallstatus || r.Status || '',
+    sourceFile: filename || '',
+  }));
+  return { type: 'survey-classification', rows: normalized, meta: { count: normalized.length } };
 }
 
 /**
@@ -665,6 +691,7 @@ function parseCybernetTargetManifest(content) {
       neuron,
       workstation,
       mac,
+      identifierType,
     };
   }).filter(r =>
     r.hostname || r.dnsHostName || r.ipAddress || r.serial || r.mac || r.neuron || r.workstation
@@ -996,6 +1023,9 @@ function mergeDataStore(existing, incoming) {
       break;
     case 'ad-registered-population':
       store.adRegisteredPopulation = (store.adRegisteredPopulation || []).concat(rows);
+      break;
+    case 'survey-classification':
+      store.surveyClassification = (store.surveyClassification || []).concat(rows);
       break;
   }
 
@@ -4879,6 +4909,7 @@ const TYPE_SECTION_LABELS = {
   'smb-recon': 'Network review',
   'naabu-reachability': 'Reachability evidence',
   'cybernet-target-manifest': 'Target manifest',
+  'survey-classification': 'Survey classification',
   'ad-registered-population': 'AD registered population',
   'remote-task': 'Remote tasks',
   'software-tracker': 'Software tracker',
@@ -5525,7 +5556,7 @@ function addFileChip(name, status, type, countOrData, parsedData = null) {
     'ad-registered-population': '🏢',
     'software-tracker': '📦', 'software-tracker-install-plan': '📋',
     'toolbox-status': '🧰',
-    'cybernet-target-manifest': '🎯', 'unknown': '❓'
+    'cybernet-target-manifest': '🎯', 'survey-classification': '🏷️', 'unknown': '❓'
   };
   const icon = iconMap[type] || '📄';
 
@@ -6378,6 +6409,7 @@ function updateCybernetReview() {
 
   const preflightRows = store.networkPreflight?.length || 0;
   const identityRows = store.workstationIdentity?.length || 0;
+  const classificationRows = store.surveyClassification || [];
   const targetCount = Math.max(_countUniqueTargets(store.networkPreflight), _countUniqueTargets(store.workstationIdentity));
   const reachRows = store.naabuReachability || [];
   const reachabilityCount = reachRows.length;
@@ -6385,8 +6417,8 @@ function updateCybernetReview() {
     const rv = (r.reachability || 'open').toLowerCase();
     return rv === 'open' || rv === '';
   }).length;
-  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachabilityCount > 0 ||
-    loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity' || f.type === 'naabu-reachability');
+  const hasEvidence = preflightRows > 0 || identityRows > 0 || reachabilityCount > 0 || classificationRows.length > 0 ||
+    loadedFiles.some(f => f.type === 'network-preflight' || f.type === 'workstation-identity' || f.type === 'naabu-reachability' || f.type === 'survey-classification');
 
   if (!hasEvidence) {
     section.classList.add('hidden');
@@ -6395,12 +6427,40 @@ function updateCybernetReview() {
 
   section.classList.remove('hidden');
   const guestWarn = _detectGuestNetworkWarning();
+
+  const manifestTargets = classificationRows.filter(r => {
+    const role = (r.deviceRole || '').toLowerCase();
+    const counts = (r.countsToward || '').toLowerCase();
+    return role === 'target_workstation' || counts === 'yes';
+  }).length;
+  const infrastructure = classificationRows.filter(r => {
+    const role = (r.deviceRole || '').toLowerCase();
+    return role.startsWith('infrastructure_');
+  }).length;
+  const needsReview = classificationRows.filter(r => {
+    const role = (r.deviceRole || '').toLowerCase();
+    const status = (r.overallStatus || '').toUpperCase();
+    return status.includes('REVIEW') || status.includes('CONFLICT') || role === 'discovery_only';
+  }).length;
+
   let nextAction = 'Review the summary, then open network evidence details if you need row-level triage.';
   if (!preflightRows) nextAction = 'Load network_preflight.csv to prove network posture.';
   else if (!identityRows) nextAction = 'Load workstation_identity.csv for identity evidence.';
   else if (guestWarn) nextAction = 'Fix network posture (segment/VPN) before running more probes.';
+  else if (infrastructure > 0 && manifestTargets === 0) nextAction = 'Infrastructure hosts found — review subnet lane output; not Cybernet target failures.';
+
+  const laneCallout = `<p class="cybernet-review-lane"><strong>Which survey lane?</strong> Manifest survey (serial-first AD rows) vs subnet discovery (approved CIDRs). See <code>docs/SURVEY_LANES.md</code>.</p>`;
+
+  const classificationBlock = classificationRows.length ? `
+    <ul class="cybernet-review-stats cybernet-review-buckets">
+      <li><strong>Manifest targets:</strong> ${manifestTargets}</li>
+      <li><strong>Infrastructure discovered:</strong> ${infrastructure}</li>
+      <li><strong>Needs review:</strong> ${needsReview}</li>
+    </ul>
+  ` : '';
 
   body.innerHTML = `
+    ${laneCallout}
     <ul class="cybernet-review-stats">
       <li><strong>Targets in evidence:</strong> ${targetCount || '—'}</li>
       <li><strong>Preflight rows:</strong> ${preflightRows}</li>
@@ -6408,6 +6468,7 @@ function updateCybernetReview() {
       <li><strong>Open ports observed:</strong> ${reachabilityCount > 0 ? openPortsCount : '—'}</li>
       <li><strong>Reachability rows:</strong> ${reachabilityCount > 0 ? reachabilityCount : '—'}</li>
     </ul>
+    ${classificationBlock}
     ${guestWarn ? `<p class="cybernet-review-warn">⚠ ${sanitize(guestWarn)}</p>` : ''}
     <p class="cybernet-review-next"><strong>Next:</strong> ${sanitize(nextAction)}</p>
   `;
@@ -6428,17 +6489,22 @@ function updateCybernetManifestSummary() {
   const withHostname = rows.filter(r => r.hostname || r.dnsHostName).length;
   const withSerial = rows.filter(r => r.serial).length;
   const withMac = rows.filter(r => r.mac).length;
+  const serialIdRows = rows.filter(r => (r.identifierType || '').toLowerCase() === 'serial').length;
+  const hostIdRows = rows.filter(r => (r.identifierType || '').toLowerCase() === 'hostname').length;
+  const macIdRows = rows.filter(r => (r.identifierType || '').toLowerCase() === 'mac').length;
   const missingDnsHost = rows.filter(r => !r.hostname && !r.dnsHostName).length;
   const missingSerial = rows.filter(r => !r.serial).length;
 
   stats.innerHTML = [
     `<span><strong>${rows.length}</strong> manifest rows</span>`,
+    `<span class="cybernet-id-chip"><strong>${withSerial}</strong> Serial</span>`,
+    `<span class="cybernet-id-chip"><strong>${withHostname}</strong> HostName</span>`,
+    `<span class="cybernet-id-chip"><strong>${withMac}</strong> MAC</span>`,
     `<span><strong>${withHostname}</strong> with hostname/DNS</span>`,
-    `<span><strong>${withSerial}</strong> with serial</span>`,
-    `<span><strong>${withMac}</strong> with MAC</span>`,
     `<span><strong>${missingDnsHost}</strong> missing hostname/DNS</span>`,
     `<span><strong>${missingSerial}</strong> missing serial</span>`,
-  ].join(' · ');
+    serialIdRows || hostIdRows || macIdRows ? `<span>ID lane: ${serialIdRows} Serial / ${hostIdRows} HostName / ${macIdRows} MAC</span>` : '',
+  ].filter(Boolean).join(' · ');
   root.style.display = '';
 }
 

--- a/dashboard/js/parsers.js
+++ b/dashboard/js/parsers.js
@@ -171,6 +171,10 @@ export function detectFileType(filename, content) {
       fn.includes('ad_missing_dns') || fn.includes('ad_duplicates') || fn.includes('evidence_only')) {
     return 'ad-registered-population';
   }
+  if (fn.includes('dns_infrastructure_classification') || fn.includes('dns_infrastructure') ||
+      fn.includes('cybernet_dns_resolution') || fn.includes('cybernet_master_presence')) {
+    return 'survey-classification';
+  }
   if (fn.includes('wmi_identity') || fn.includes('wmi-identity')) return 'workstation-identity';
 
   // Detect by headers if content is provided
@@ -192,6 +196,8 @@ export function detectFileType(filename, content) {
     if (firstLine.includes('populationauthority') && firstLine.includes('reconcilebucket')) return 'ad-registered-population';
     if (firstLine.includes('populationauthority') && firstLine.includes('adstatus')) return 'ad-registered-population';
     if (firstLine.includes('reconcilebucket') && firstLine.includes('hostname')) return 'ad-registered-population';
+    if (firstLine.includes('devicerole') && firstLine.includes('surveylane')) return 'survey-classification';
+    if (firstLine.includes('devicerole') && firstLine.includes('countstowardcybernetpopulation')) return 'survey-classification';
   }
 
   return 'unknown';
@@ -222,6 +228,7 @@ export function parseFileContent(type, content, filename) {
     case 'software-superset': return parseSoftwareSuperset(content);
     case 'naabu-reachability': return parseNaabuReachability(content, filename);
     case 'ad-registered-population': return parseAdRegisteredPopulation(content, filename);
+    case 'survey-classification': return parseSurveyClassification(content, filename);
     default: return { type: 'unknown', rows: [], meta: {} };
   }
 }
@@ -284,6 +291,25 @@ function parseNaabuReachability(content, filename) {
   }
 
   return { type: 'naabu-reachability', rows, meta: { count: rows.length, warnings } };
+}
+
+/**
+ * Parse survey classification CSVs (DNS resolution, subnet dns-list, merged evidence).
+ */
+function parseSurveyClassification(content, filename) {
+  const rows = parseCSV(content);
+  const normalized = rows.map(r => ({
+    hostName: r.HostName || r.hostname || r.Target || '',
+    deviceRole: r.DeviceRole || r.devicerole || '',
+    surveyLane: r.SurveyLane || r.surveylane || '',
+    identifierType: r.IdentifierType || r.identifiertype || '',
+    countsToward: r.CountsTowardCybernetPopulation || r.countstowardcybernetpopulation || '',
+    roleSignals: r.RoleSignals || r.rolesignals || '',
+    nextAction: r.NextAction || r.nextaction || '',
+    overallStatus: r.OverallStatus || r.overallstatus || r.Status || '',
+    sourceFile: filename || '',
+  }));
+  return { type: 'survey-classification', rows: normalized, meta: { count: normalized.length } };
 }
 
 /**
@@ -438,6 +464,7 @@ function parseCybernetTargetManifest(content) {
       neuron,
       workstation,
       mac,
+      identifierType,
     };
   }).filter(r =>
     r.hostname || r.dnsHostName || r.ipAddress || r.serial || r.mac || r.neuron || r.workstation
@@ -769,6 +796,9 @@ export function mergeDataStore(existing, incoming) {
       break;
     case 'ad-registered-population':
       store.adRegisteredPopulation = (store.adRegisteredPopulation || []).concat(rows);
+      break;
+    case 'survey-classification':
+      store.surveyClassification = (store.surveyClassification || []).concat(rows);
       break;
   }
 

--- a/dashboard/samples/dns_infrastructure_classification.sample.csv
+++ b/dashboard/samples/dns_infrastructure_classification.sample.csv
@@ -1,0 +1,3 @@
+"HostName","IPAddress","Subnet","SurveyLane","IdentifierType","SurveyAuthority","DeviceRole","RoleConfidence","RoleSignals","CountsTowardCybernetPopulation","NextAction","SourceFile"
+"NSUH-AP-FLOOR3","10.10.10.5","10.10.10.0/24","subnet_discovery","HostName","subnet_inference_only","infrastructure_access_point","medium","reverse_dns:ap-pattern","No","Infrastructure AP — informational for subnet review; not a Cybernet workstation target.","nsuh_list_dns.txt"
+"NSUH12WMH01","10.10.10.42","10.10.10.0/24","subnet_discovery","HostName","subnet_inference_only","target_workstation","medium","hostname:cybernet-prefix","No","Possible Windows endpoint — confirm serial identity before treating as confirmed Cybernet target.","nsuh_list_dns.txt"

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -31,6 +31,7 @@ const cases = [
   { file: 'cybernet_targets.sample.csv',           expectedType: 'cybernet-target-manifest', minRows: 2 },
   { file: 'ad_registered_normalized.csv',            expectedType: 'ad-registered-population', minRows: 1 },
   { file: 'ad_registered_population.sample.csv',    expectedType: 'ad-registered-population', minRows: 6 },
+  { file: 'dns_infrastructure_classification.sample.csv', expectedType: 'survey-classification', minRows: 2 },
 ];
 
 // ── Naabu reachability parser cases (synthetic samples only) ────────────────
@@ -165,6 +166,24 @@ if (bomRows.length !== 1 || Object.keys(bomRows[0])[0] !== 'HostName') {
 // available in Node without additional polyfills.  Drop an *.xlsx file onto the
 // dashboard and confirm it appears in the Hardware Inventory or Printer Mapping
 // panel (whichever schema it matches) as a manual verification step.
+
+// Survey classification: infrastructure rows must not count as manifest targets
+{
+  const content = readFileSync(join(samplesDir, 'dns_infrastructure_classification.sample.csv'), 'utf8');
+  const parsed = parseFileContent('survey-classification', content, 'dns_infrastructure_classification.sample.csv');
+  const infra = parsed.rows.filter(r => (r.deviceRole || '').startsWith('infrastructure_'));
+  const targets = parsed.rows.filter(r => (r.countsToward || '').toLowerCase() === 'yes');
+  if (infra.length < 1) {
+    console.error('FAIL [classification]: expected at least one infrastructure row');
+    failed++;
+  } else if (targets.length > 0) {
+    console.error('FAIL [classification]: sample infrastructure CSV should not have counts-toward=yes rows');
+    failed++;
+  } else {
+    console.log('PASS [classification]: infrastructure separated from manifest targets');
+    passed++;
+  }
+}
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/docs/DASHBOARD_ENTRYPOINT.md
+++ b/docs/DASHBOARD_ENTRYPOINT.md
@@ -113,6 +113,7 @@ See [`dashboard/README.md`](../dashboard/README.md) — **Loading experience (Hi
 - [`docs/GUI_HOST_MIGRATION.md`](GUI_HOST_MIGRATION.md) — launcher technical matrix
 - [`docs/DASHBOARD_EXE_FUTURE_SPRINT.md`](DASHBOARD_EXE_FUTURE_SPRINT.md) — planned EXE sprint
 - [`START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md) — advanced CLI path
+- [`SURVEY_LANES.md`](SURVEY_LANES.md) — manifest vs subnet survey lanes; identifier keys
 
 ## Agent guardrails
 

--- a/docs/SURVEY_LANES.md
+++ b/docs/SURVEY_LANES.md
@@ -1,0 +1,92 @@
+# Survey Lanes — Technician Map
+
+This document is the canonical map for **which survey job you are running** and **which identifier key to use at each step**. It complements serial-first and subnet-inference doctrine without changing low-noise survey discipline.
+
+## Two orthogonal axes
+
+| Axis | Question | Values |
+|------|----------|--------|
+| **Survey lane** | What job am I doing? | Cybernet manifest lane · Subnet discovery lane |
+| **Identifier lane** | What key am I using right now? | Serial · HostName · MAC |
+
+DNS and probes may also report a **device role** (workstation vs access point vs network gear vs printer). Infrastructure findings are expected in subnet discovery; they are informational, not product failures.
+
+## When to use each survey lane
+
+### Cybernet manifest lane
+
+Use when you have **AD export or approved manifest rows** and your goal is **serial-confirmed workstation survey**.
+
+| Item | Detail |
+|------|--------|
+| Population authority | AD export / approved manifest |
+| Typical entry | Dashboard **Start Cybernet Survey** or `survey/sas-survey-targets.sh` |
+| Identity proof | **Serial-first** — hostname is a probe transport hint; MAC supports correlation only |
+| Output paths | `survey/output/cybernet_dns_resolution_report.csv`, merged evidence CSVs |
+
+See also: [`CYBERNET_SERIAL_FIRST_SURVEY.md`](CYBERNET_SERIAL_FIRST_SURVEY.md)
+
+### Subnet discovery lane
+
+Use when you have **approved CIDR/subnet lists** and your goal is **find what is on the wire / infer location context**. Access points and other infrastructure are expected.
+
+| Item | Detail |
+|------|--------|
+| Population authority | Approved CIDR/subnet list only — not AD population |
+| Typical entry | `survey/sas-cybernet-subnet-survey.sh` modes (`local-context-only` → `dns-list-only` → `discover` → …) |
+| Identity proof | Hostname/IP/MAC are **location/routing evidence** — never serial proof |
+| Output paths | `survey/output/cybernet_subnet_survey/`, `dns_infrastructure_classification.csv` |
+
+See also: [`CYBERNET_SUBNET_LOCATION_INFERENCE.md`](CYBERNET_SUBNET_LOCATION_INFERENCE.md)
+
+## Identifier choice table
+
+| Key | Use when | Never use for |
+|-----|----------|---------------|
+| **Serial** | Manifest row has known serial; privileged identity collection | Subnet-only discovery proof |
+| **HostName** | DNS resolution, probe transport, manifest hint | Serial proof without privileged identity |
+| **MAC** | DHCP/Nmap correlation, supporting evidence | Serial proof |
+
+## Decision tree
+
+```mermaid
+flowchart TD
+  start["What evidence do you have?"]
+  manifest["AD export or approved manifest rows"]
+  subnet["Approved CIDR/subnet list only"]
+  cybernetLane["Cybernet manifest lane"]
+  subnetLane["Subnet discovery lane"]
+  serialKey["Primary key: Serial when known"]
+  hostKey["DNS/probe key: HostName"]
+  infra["Infrastructure AP/network/print — review only"]
+  target["Manifest workstation target"]
+
+  start --> manifest
+  start --> subnet
+  manifest --> cybernetLane --> serialKey --> target
+  cybernetLane --> hostKey
+  subnet --> subnetLane --> hostKey --> infra
+  subnetLane --> discovery["discovery_only — never serial proof"]
+```
+
+## Device roles (classifier output)
+
+The shared classifier (`survey/sas-survey-device-classify.py`) labels probe findings:
+
+| DeviceRole | Counts toward Cybernet population? |
+|------------|--------------------------------------|
+| `target_workstation` | Yes (manifest lane, in manifest) |
+| `infrastructure_access_point` | No |
+| `infrastructure_network` | No |
+| `infrastructure_print` | No |
+| `discovery_only` | No |
+| `infrastructure_unknown` | No |
+
+Dashboard review separates **manifest targets**, **infrastructure discovered**, and **needs review** buckets.
+
+## Related doctrine
+
+- [`LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md) — reachability validation only; AD defines population
+- [`CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md`](CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md) — bounded hostname variant discovery
+- [`DASHBOARD_ENTRYPOINT.md`](DASHBOARD_ENTRYPOINT.md) — field dashboard front door
+- [`../START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md) — CLI orchestrator path

--- a/survey/README.md
+++ b/survey/README.md
@@ -10,6 +10,7 @@ The current priority tutorial for field technicians is:
 
 - [`../START-HERE-SysAdminSuite.md`](../START-HERE-SysAdminSuite.md) — what to double-click and what opens
 - [`../START-HERE-CYBERNET-NEURON-SURVEY.md`](../START-HERE-CYBERNET-NEURON-SURVEY.md) — advanced CLI orchestrator path
+- [`../docs/SURVEY_LANES.md`](../docs/SURVEY_LANES.md) — manifest lane vs subnet lane; serial vs hostname vs MAC
 - [`../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](../docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md) — full step-by-step runbook
 
 Use the CLI path below only when the dashboard or a lead explicitly asks for Bash orchestration. Start with the workflow diagram in `../START-HERE-CYBERNET-NEURON-SURVEY.md` when you need the one-page field path before the command details. Mermaid source: [`../docs/diagrams/cybernet-neuron-survey-flow.mmd`](../docs/diagrams/cybernet-neuron-survey-flow.mmd). The workflow is:

--- a/survey/sas-classify-dns-list-output.py
+++ b/survey/sas-classify-dns-list-output.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Classify Nmap -sL (dns-list-only) output into infrastructure vs discovery rows.
+
+Read-only local enrichment for subnet discovery lane. Does not scan networks.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+
+def _load_classifier():
+    module_path = Path(__file__).with_name("sas-survey-device-classify.py")
+    spec = importlib.util.spec_from_file_location("sas_survey_device_classify", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"could not load classifier module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CLASSIFY = _load_classifier()
+
+OUTPUT_FIELDS = [
+    "HostName",
+    "IPAddress",
+    "Subnet",
+    "SurveyLane",
+    "IdentifierType",
+    "SurveyAuthority",
+    "DeviceRole",
+    "RoleConfidence",
+    "RoleSignals",
+    "CountsTowardCybernetPopulation",
+    "NextAction",
+    "SourceFile",
+]
+
+REPORT_RE = re.compile(r"^Nmap scan report for\s+(.+)$", re.IGNORECASE)
+IP_PAREN_RE = re.compile(r"^(.*?)\s+\(([^)]+)\)$")
+
+
+def clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def parse_nmap_list_file(path: Path, subnet: str = "") -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        m = REPORT_RE.match(line.strip())
+        if not m:
+            continue
+        raw = clean(m.group(1))
+        hostname = ""
+        ip = raw
+        p = IP_PAREN_RE.match(raw)
+        if p:
+            hostname = clean(p.group(1))
+            ip = clean(p.group(2))
+        host = hostname or ip
+        if not host or host.lower() in {"localhost", "(none)"}:
+            continue
+        cls = _CLASSIFY.classify_device(
+            hostname=host,
+            reverse_dns_names=hostname,
+            survey_lane="subnet_discovery",
+            in_manifest=False,
+        )
+        row = {
+            "HostName": hostname or ip,
+            "IPAddress": ip if ip != hostname else "",
+            "Subnet": subnet,
+            "SourceFile": path.name,
+            **cls.as_dict(),
+        }
+        rows.append(row)
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Classify Nmap -sL dns-list output for subnet discovery lane")
+    parser.add_argument("--input", action="append", required=True, help="Nmap -sL text output; repeatable")
+    parser.add_argument("--subnet", action="append", default=[], help="Subnet label per input file (optional)")
+    parser.add_argument("--output", default="survey/output/dns_infrastructure_classification.csv", help="Classification CSV")
+    args = parser.parse_args()
+
+    inputs = [Path(p) for p in args.input]
+    subnets = list(args.subnet)
+    while len(subnets) < len(inputs):
+        subnets.append("")
+
+    all_rows: list[dict[str, str]] = []
+    for path, subnet in zip(inputs, subnets):
+        if not path.exists():
+            print(f"WARN: input not found: {path}", file=sys.stderr)
+            continue
+        all_rows.extend(parse_nmap_list_file(path, subnet=subnet))
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=OUTPUT_FIELDS, quoting=csv.QUOTE_ALL, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(all_rows)
+
+    infra = sum(1 for r in all_rows if r.get("DeviceRole", "").startswith("infrastructure_"))
+    print(f"Wrote {len(all_rows)} classification row(s) to {out} ({infra} infrastructure)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/survey/sas-cybernet-subnet-location-map.py
+++ b/survey/sas-cybernet-subnet-location-map.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import importlib.util
 import ipaddress
 import json
 import re
@@ -17,6 +18,19 @@ from typing import Iterable
 
 PREFIX_RE = re.compile(r"^([A-Z]{2,4})(\d{2,4})([A-Z]{2,6})(\d*)$")
 EMPTY = {"", "N/A", "NA", "NONE", "NULL", "-", "--", "TBD", "UNKNOWN", "#N/A"}
+
+
+def _load_classifier():
+    module_path = Path(__file__).with_name("sas-survey-device-classify.py")
+    spec = importlib.util.spec_from_file_location("sas_survey_device_classify", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"could not load classifier module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CLASSIFY = _load_classifier()
 
 HOST_FIELDS = [
     "NormalizedHostName",
@@ -44,6 +58,10 @@ HOST_FIELDS = [
     "EvidenceSources",
     "Site",
     "SourceFiles",
+    "DeviceRole",
+    "RoleConfidence",
+    "RoleSignals",
+    "CountsTowardCybernetPopulation",
 ]
 
 MAP_FIELDS = [
@@ -644,6 +662,14 @@ def build_host_rows(
             audit["Blocker"] = "missing_dns_ip"
             audit["NextAction"] = "Resolve hostname or provide approved IP evidence"
 
+        cls = _CLASSIFY.classify_device(
+            hostname=rec.hostname,
+            survey_lane="subnet_discovery",
+            in_manifest=False,
+            identifier_type=audit.get("PrimaryKeyType", ""),
+            serial=rec.serial_value(),
+        )
+
         out.append(
             {
                 "NormalizedHostName": normalized,
@@ -662,6 +688,10 @@ def build_host_rows(
                 "EvidenceSources": ";".join(sorted(rec.sources)),
                 "Site": rec.site,
                 "SourceFiles": ";".join(sorted(rec.source_files)),
+                "DeviceRole": cls.device_role,
+                "RoleConfidence": cls.role_confidence,
+                "RoleSignals": cls.role_signals,
+                "CountsTowardCybernetPopulation": cls.counts_toward_cybernet_population,
             }
         )
     return out

--- a/survey/sas-cybernet-subnet-survey.sh
+++ b/survey/sas-cybernet-subnet-survey.sh
@@ -366,15 +366,26 @@ Network context copy: $ctx_dest"
 mode_dns_list_only() {
   collect_cidrs_for_scan
   ensure_run_dir
-  local nmap c safe out
+  local nmap c safe out py classify_out classify_args
   nmap="$(nmap_bin)"
   [[ -n "$nmap" || "$DRY_RUN" -eq 1 ]] || fail "nmap not found on PATH"
+  classify_out="$RUN_DIR/dns_infrastructure_classification.csv"
+  classify_args=()
   for c in "${CIDRS[@]}"; do
     safe="$(safe_cidr_token "$c")"
     out="$LOGS_ROOT/${SITE}_${safe}_list_dns.txt"
     run_cmd "dns-list $c" "$nmap" -sL "$c" -oN "$out"
     append_summary "$RUN_DIR" "dns-list-only $c -> $out (DNS/list sanity check, not host proof)"
+    if [[ "$DRY_RUN" -eq 0 && -f "$out" ]]; then
+      classify_args+=(--input "$out" --subnet "$c")
+    fi
   done
+  if [[ "$DRY_RUN" -eq 0 && ${#classify_args[@]} -gt 0 ]]; then
+    py="$(find_python)"
+    classify_script="$SCRIPT_DIR/sas-classify-dns-list-output.py"
+    run_cmd "classify dns-list" $py "$classify_script" "${classify_args[@]}" --output "$classify_out"
+    append_summary "$RUN_DIR" "dns-list classification -> $classify_out"
+  fi
   log "dns-list-only complete"
 }
 

--- a/survey/sas-merge-cybernet-evidence.py
+++ b/survey/sas-merge-cybernet-evidence.py
@@ -9,10 +9,24 @@ from __future__ import annotations
 
 import argparse
 import csv
+import importlib.util
 import re
 import sys
 from pathlib import Path
 from typing import Iterable
+
+
+def _load_classifier():
+    module_path = Path(__file__).with_name("sas-survey-device-classify.py")
+    spec = importlib.util.spec_from_file_location("sas_survey_device_classify", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"could not load classifier module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CLASSIFY = _load_classifier()
 
 FIELDS = [
     "OverallStatus",
@@ -36,9 +50,26 @@ FIELDS = [
     "NmapEvidence",
     "EvidenceSources",
     "Source",
+    "SurveyLane",
+    "IdentifierType",
+    "SurveyAuthority",
+    "DeviceRole",
+    "RoleConfidence",
+    "RoleSignals",
+    "CountsTowardCybernetPopulation",
+    "NextAction",
 ]
 
-REVIEW_STATUSES = {"REVIEW_CONFLICT", "MANIFEST_ONLY", "DNS_ONLY", "AD_ONLY"}
+REVIEW_STATUSES = {"REVIEW_CONFLICT", "MANIFEST_ONLY", "DNS_ONLY", "AD_ONLY", "REVIEW_INFRASTRUCTURE_NOT_TARGET"}
+
+INFRASTRUCTURE_ROLES = frozenset(
+    {
+        "infrastructure_access_point",
+        "infrastructure_network",
+        "infrastructure_print",
+        "infrastructure_unknown",
+    }
+)
 
 
 def clean(value: object) -> str:
@@ -320,6 +351,53 @@ def main() -> int:
         nmap_status, nmap_targets, nmap_evidence = summarize_nmap(matched_nmap)
         overall, confidence, review_reason = classify(matched_dns, matched_ad, matched_dhcp, matched_nmap, conflict_reasons)
 
+        # Device role from DNS classification (first matched DNS row with DeviceRole)
+        device_role = ""
+        role_signals = ""
+        counts_toward = ""
+        survey_lane = "cybernet_manifest"
+        identifier_type = ""
+        survey_authority = ""
+        role_confidence = ""
+        next_action = ""
+        for dns_row in matched_dns:
+            role = first(dns_row, ["DeviceRole"])
+            if role:
+                device_role = role
+                role_signals = first(dns_row, ["RoleSignals"])
+                counts_toward = first(dns_row, ["CountsTowardCybernetPopulation"])
+                survey_lane = first(dns_row, ["SurveyLane"]) or survey_lane
+                identifier_type = first(dns_row, ["IdentifierType"])
+                survey_authority = first(dns_row, ["SurveyAuthority"])
+                role_confidence = first(dns_row, ["RoleConfidence"])
+                next_action = first(dns_row, ["NextAction"])
+                break
+
+        if not device_role and host:
+            cls = _CLASSIFY.classify_device(
+                hostname=host,
+                reverse_dns_names=joined(first(r, ["ReverseNames"]) for r in matched_dns),
+                device_type=dtype,
+                serial=serial,
+                mac=mac,
+                survey_lane="cybernet_manifest",
+                in_manifest=True,
+            )
+            device_role = cls.device_role
+            role_signals = cls.role_signals
+            counts_toward = cls.counts_toward_cybernet_population
+            survey_lane = cls.survey_lane
+            identifier_type = cls.identifier_type
+            survey_authority = cls.survey_authority
+            role_confidence = cls.role_confidence
+            next_action = cls.next_action
+
+        if device_role in INFRASTRUCTURE_ROLES:
+            overall = "REVIEW_INFRASTRUCTURE_NOT_TARGET"
+            if confidence == "HIGH":
+                confidence = "MEDIUM"
+            review_reason = f"Manifest row resolves to infrastructure role ({device_role}). {review_reason}"
+
         evidence_sources = []
         if matched_dns:
             evidence_sources.append("DNS")
@@ -353,6 +431,14 @@ def main() -> int:
                 "NmapEvidence": nmap_evidence,
                 "EvidenceSources": joined(evidence_sources),
                 "Source": source,
+                "SurveyLane": survey_lane,
+                "IdentifierType": identifier_type,
+                "SurveyAuthority": survey_authority,
+                "DeviceRole": device_role,
+                "RoleConfidence": role_confidence,
+                "RoleSignals": role_signals,
+                "CountsTowardCybernetPopulation": counts_toward,
+                "NextAction": next_action,
             }
         )
 

--- a/survey/sas-nmap-evidence-export.py
+++ b/survey/sas-nmap-evidence-export.py
@@ -13,10 +13,24 @@ from __future__ import annotations
 
 import argparse
 import csv
+import importlib.util
 import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
+
+
+def _load_classifier():
+    module_path = Path(__file__).with_name("sas-survey-device-classify.py")
+    spec = importlib.util.spec_from_file_location("sas_survey_device_classify", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"could not load classifier module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CLASSIFY = _load_classifier()
 
 FIELDS = [
     "Target",
@@ -28,6 +42,10 @@ FIELDS = [
     "ProbeMethod",
     "EvidenceSource",
     "Notes",
+    "SurveyLane",
+    "DeviceRole",
+    "RoleSignals",
+    "CountsTowardCybernetPopulation",
 ]
 
 
@@ -161,6 +179,12 @@ def main() -> int:
 
     fmt = infer_format(input_path, args.format)
     rows = parse_xml(input_path) if fmt == "xml" else parse_normal_text(input_path)
+    for row in rows:
+        cls = _CLASSIFY.classify_from_nmap_row(row, survey_lane="cybernet_manifest")
+        row["SurveyLane"] = cls.get("SurveyLane", "cybernet_manifest")
+        row["DeviceRole"] = cls.get("DeviceRole", "")
+        row["RoleSignals"] = cls.get("RoleSignals", "")
+        row["CountsTowardCybernetPopulation"] = cls.get("CountsTowardCybernetPopulation", "")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=FIELDS, quoting=csv.QUOTE_ALL, lineterminator="\n")

--- a/survey/sas-resolve-manifest-dns.py
+++ b/survey/sas-resolve-manifest-dns.py
@@ -9,12 +9,28 @@ from __future__ import annotations
 
 import argparse
 import csv
+import importlib.util
 import ipaddress
 import socket
 import sys
 from collections import Counter
 from pathlib import Path
 from typing import Iterable
+
+
+def _load_classifier():
+    module_path = Path(__file__).with_name("sas-survey-device-classify.py")
+    spec = importlib.util.spec_from_file_location("sas_survey_device_classify", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"could not load classifier module: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CLASSIFY = _load_classifier()
+CLASSIFICATION_FIELDS = _CLASSIFY.CLASSIFICATION_FIELDS
+classify_from_dns_row = _CLASSIFY.classify_from_dns_row
 
 OUTPUT_FIELDS = [
     "Status",
@@ -30,6 +46,7 @@ OUTPUT_FIELDS = [
     "ResolvedBy",
     "Error",
     "Source",
+    *CLASSIFICATION_FIELDS,
 ]
 
 
@@ -183,23 +200,23 @@ def build_rows(input_rows: list[dict[str, str]], suffixes: list[str]) -> list[di
         reverse_names = reverse_lookup(ips) if ips else []
         subnets = sorted(set(filter(None, (subnet24(ip) for ip in ips))))
 
-        output.append(
-            {
-                "Status": status,
-                "HostName": host,
-                "Identifier": identifier,
-                "Serial": serial,
-                "MACAddress": mac,
-                "DeviceType": dtype,
-                "FQDN": fqdn,
-                "IPAddresses": ";".join(ips),
-                "ReverseNames": ";".join(reverse_names),
-                "Subnets24": ";".join(subnets),
-                "ResolvedBy": resolved_by,
-                "Error": error,
-                "Source": source,
-            }
-        )
+        row_out = {
+            "Status": status,
+            "HostName": host,
+            "Identifier": identifier,
+            "Serial": serial,
+            "MACAddress": mac,
+            "DeviceType": dtype,
+            "FQDN": fqdn,
+            "IPAddresses": ";".join(ips),
+            "ReverseNames": ";".join(reverse_names),
+            "Subnets24": ";".join(subnets),
+            "ResolvedBy": resolved_by,
+            "Error": error,
+            "Source": source,
+        }
+        row_out.update(classify_from_dns_row(row_out, survey_lane="cybernet_manifest"))
+        output.append(row_out)
 
     return output
 

--- a/survey/sas-survey-device-classify.py
+++ b/survey/sas-survey-device-classify.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Shared device-role classifier for Cybernet manifest and subnet discovery lanes.
+
+Pure offline logic — no network access. Labels DNS/probe findings so technicians
+can separate manifest workstations from infrastructure (APs, switches, printers).
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+CYBERNET_PREFIX_RE = re.compile(r"^([A-Z]{2,4})(\d{2,4})([A-Z]{2,6})(\d*)$")
+
+AP_PATTERNS = (
+    r"\bap[-_]",
+    r"\bwap\b",
+    r"\bwireless\b",
+    r"\bwlc\b",
+    r"\baruba\b",
+    r"\bmeraki\b",
+    r"\bmist[-_]",
+    r"\bunifi\b",
+    r"\baironet\b",
+    r"\baccess[-_]?point\b",
+)
+
+NETWORK_PATTERNS = (
+    r"\bswitch\b",
+    r"\brouter\b",
+    r"\bfw[-_]",
+    r"\bfirewall\b",
+    r"\bcore[-_]",
+    r"\bdist[-_]",
+    r"\bstack\b",
+    r"\bnexus\b",
+    r"\bcatalyst\b",
+)
+
+PRINTER_NAME_PATTERNS = (
+    r"\bprinter\b",
+    r"\bprint[-_]",
+    r"\bmfp\b",
+    r"\bcopier\b",
+    r"\bhp[-_]?laser",
+    r"\bcanon[-_]",
+    r"\bxerox\b",
+    r"\bricoh\b",
+)
+
+AP_VENDORS = frozenset(
+    {
+        "aruba",
+        "cisco",
+        "meraki",
+        "mist",
+        "ruckus",
+        "ubiquiti",
+        "unifi",
+        "aerohive",
+        "extreme",
+    }
+)
+
+PRINTER_VENDORS = frozenset({"hp", "hewlett", "canon", "xerox", "ricoh", "lexmark", "konica", "epson", "brother"})
+
+WIN_WORKSTATION_PORTS = frozenset({"445", "3389", "5985", "5986", "135"})
+PRINTER_PORTS = frozenset({"9100", "515", "631"})
+
+
+def clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def norm_host(value: object) -> str:
+    text = clean(value).upper()
+    return text.split(".", 1)[0] if text else ""
+
+
+def _matches_any(text: str, patterns: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(re.search(p, lowered) for p in patterns)
+
+
+def _parse_ports(open_ports: Iterable[str] | str | None) -> set[str]:
+    if open_ports is None:
+        return set()
+    if isinstance(open_ports, str):
+        parts = re.split(r"[,;|\s]+", open_ports)
+    else:
+        parts = list(open_ports)
+    out: set[str] = set()
+    for part in parts:
+        token = clean(part)
+        if not token:
+            continue
+        m = re.match(r"^(\d+)", token)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def _identifier_type_from_row(
+    identifier_type: str = "",
+    serial: str = "",
+    hostname: str = "",
+    mac: str = "",
+) -> str:
+    itype = clean(identifier_type).lower()
+    if "serial" in itype or itype in {"sn", "s/n", "service_tag", "servicetag"}:
+        return "Serial"
+    if "mac" in itype:
+        return "MAC"
+    if "host" in itype or itype in {"hostname", "dns", "fqdn"}:
+        return "HostName"
+    if clean(serial):
+        return "Serial"
+    if clean(hostname):
+        return "HostName"
+    if clean(mac):
+        return "MAC"
+    return "HostName"
+
+
+def _survey_authority(
+    identifier_type: str,
+    survey_lane: str,
+    in_manifest: bool,
+) -> str:
+    if survey_lane == "subnet_discovery":
+        return "subnet_inference_only"
+    if identifier_type == "Serial":
+        return "serial"
+    if identifier_type == "MAC":
+        return "mac_supporting"
+    if in_manifest:
+        return "hostname_fallback"
+    return "subnet_inference_only"
+
+
+def is_cybernet_hostname(hostname: str) -> bool:
+    host = norm_host(hostname)
+    return bool(host and CYBERNET_PREFIX_RE.match(host))
+
+
+class ClassificationResult:
+    __slots__ = (
+        "survey_lane",
+        "identifier_type",
+        "survey_authority",
+        "device_role",
+        "role_confidence",
+        "role_signals",
+        "counts_toward_cybernet_population",
+        "next_action",
+    )
+
+    def __init__(
+        self,
+        *,
+        survey_lane: str,
+        identifier_type: str,
+        survey_authority: str,
+        device_role: str,
+        role_confidence: str,
+        role_signals: str,
+        counts_toward_cybernet_population: str,
+        next_action: str,
+    ) -> None:
+        self.survey_lane = survey_lane
+        self.identifier_type = identifier_type
+        self.survey_authority = survey_authority
+        self.device_role = device_role
+        self.role_confidence = role_confidence
+        self.role_signals = role_signals
+        self.counts_toward_cybernet_population = counts_toward_cybernet_population
+        self.next_action = next_action
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "SurveyLane": self.survey_lane,
+            "IdentifierType": self.identifier_type,
+            "SurveyAuthority": self.survey_authority,
+            "DeviceRole": self.device_role,
+            "RoleConfidence": self.role_confidence,
+            "RoleSignals": self.role_signals,
+            "CountsTowardCybernetPopulation": self.counts_toward_cybernet_population,
+            "NextAction": self.next_action,
+        }
+
+
+def classify_device(
+    *,
+    hostname: str = "",
+    reverse_dns_names: Iterable[str] | str = (),
+    mac_vendor: str = "",
+    open_ports: Iterable[str] | str | None = None,
+    device_type: str = "",
+    identifier_type: str = "",
+    serial: str = "",
+    mac: str = "",
+    survey_lane: str = "cybernet_manifest",
+    in_manifest: bool = True,
+) -> ClassificationResult:
+    """Classify a device row for survey lane review.
+
+    survey_lane: ``cybernet_manifest`` or ``subnet_discovery``
+    in_manifest: whether the row came from an approved manifest (vs discovery-only)
+    """
+    lane = clean(survey_lane).lower() or "cybernet_manifest"
+    if lane not in {"cybernet_manifest", "subnet_discovery"}:
+        lane = "cybernet_manifest"
+
+    host = norm_host(hostname)
+    if isinstance(reverse_dns_names, str):
+        rev_list = [n.strip() for n in re.split(r"[;,|]+", reverse_dns_names) if n.strip()]
+    else:
+        rev_list = [clean(n) for n in reverse_dns_names if clean(n)]
+
+    names_to_check = " ".join([host, *rev_list]).lower()
+    vendor = clean(mac_vendor).lower()
+    ports = _parse_ports(open_ports)
+    dtype = clean(device_type) or "Cybernet"
+    id_type = _identifier_type_from_row(identifier_type, serial, host, mac)
+    authority = _survey_authority(id_type, lane, in_manifest)
+
+    signals: list[str] = []
+
+    # Infrastructure: access points
+    ap_by_name = _matches_any(names_to_check, AP_PATTERNS)
+    ap_by_vendor = bool(vendor and any(v in vendor for v in AP_VENDORS))
+    if ap_by_name:
+        signals.append("reverse_dns:ap-pattern")
+    if ap_by_vendor:
+        signals.append(f"vendor:{vendor.split()[0]}")
+    if ap_by_name or ap_by_vendor:
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=authority,
+            device_role="infrastructure_access_point",
+            role_confidence="high" if ap_by_name and ap_by_vendor else "medium",
+            role_signals=";".join(signals),
+            counts_toward_cybernet_population="No",
+            next_action="Infrastructure AP — informational for subnet review; not a Cybernet workstation target.",
+        )
+
+    # Infrastructure: network gear
+    if _matches_any(names_to_check, NETWORK_PATTERNS):
+        signals.append("reverse_dns:network-gear")
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=authority,
+            device_role="infrastructure_network",
+            role_confidence="medium",
+            role_signals=";".join(signals),
+            counts_toward_cybernet_population="No",
+            next_action="Network infrastructure — review for subnet/location context only.",
+        )
+
+    # Printers
+    printer_hit = _matches_any(names_to_check, PRINTER_NAME_PATTERNS)
+    if vendor and any(v in vendor for v in PRINTER_VENDORS):
+        signals.append(f"vendor:{vendor.split()[0]}")
+        printer_hit = True
+    if ports & PRINTER_PORTS:
+        for p in sorted(ports & PRINTER_PORTS):
+            signals.append(f"port:{p}")
+        printer_hit = True
+    if printer_hit:
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=authority,
+            device_role="infrastructure_print",
+            role_confidence="high" if ports & PRINTER_PORTS else "medium",
+            role_signals=";".join(signals) or "name:printer-pattern",
+            counts_toward_cybernet_population="No",
+            next_action="Print device — validate queue/driver path; not a Cybernet workstation.",
+        )
+
+    # Workstation signals
+    win_ports = ports & WIN_WORKSTATION_PORTS
+    cybernet_host = dtype.lower() == "cybernet" and is_cybernet_hostname(host)
+    has_win_ports = bool(win_ports)
+    if cybernet_host:
+        signals.append("hostname:cybernet-prefix")
+    if win_ports:
+        for p in sorted(win_ports):
+            signals.append(f"port:{p}")
+
+    if cybernet_host or has_win_ports:
+        counts = "Yes" if lane == "cybernet_manifest" and in_manifest else "No"
+        conf = "high" if cybernet_host and win_ports else "medium" if cybernet_host or win_ports else "low"
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=authority,
+            device_role="target_workstation",
+            role_confidence=conf,
+            role_signals=";".join(signals) or "manifest:cybernet",
+            counts_toward_cybernet_population=counts,
+            next_action="Manifest workstation target — proceed with serial-first identity and reachability probes.",
+        )
+
+    if win_ports:
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=authority,
+            device_role="target_workstation",
+            role_confidence="medium",
+            role_signals=";".join(signals),
+            counts_toward_cybernet_population="Yes" if lane == "cybernet_manifest" and in_manifest else "No",
+            next_action="Possible Windows endpoint — confirm serial identity before treating as confirmed Cybernet target.",
+        )
+
+    # Discovery-only / unknown
+    if lane == "subnet_discovery" or not in_manifest:
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=authority,
+            device_role="discovery_only",
+            role_confidence="low",
+            role_signals=";".join(signals) or "lane:subnet_discovery",
+            counts_toward_cybernet_population="No",
+            next_action="Discovery-only host — use for subnet/location inference; never serial proof.",
+        )
+
+    if lane == "cybernet_manifest" and in_manifest:
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=authority,
+            device_role="target_workstation",
+            role_confidence="low",
+            role_signals=";".join(signals) or "manifest:present",
+            counts_toward_cybernet_population="Yes",
+            next_action="Manifest row — collect serial-first identity evidence.",
+        )
+
+    return ClassificationResult(
+        survey_lane=lane,
+        identifier_type=id_type,
+        survey_authority=authority,
+        device_role="infrastructure_unknown",
+        role_confidence="low",
+        role_signals=";".join(signals) or "role:unknown",
+        counts_toward_cybernet_population="No",
+        next_action="Unknown infrastructure — review before adding to manifest.",
+    )
+
+
+def classify_from_dns_row(row: dict[str, str], survey_lane: str = "cybernet_manifest") -> dict[str, str]:
+    """Classify from a DNS resolution CSV row."""
+    hostname = clean(row.get("HostName") or row.get("Hostname") or row.get("Identifier"))
+    reverse = clean(row.get("ReverseNames") or row.get("ReverseDNS"))
+    result = classify_device(
+        hostname=hostname,
+        reverse_dns_names=reverse,
+        device_type=clean(row.get("DeviceType")),
+        identifier_type=clean(row.get("IdentifierType")),
+        serial=clean(row.get("Serial")),
+        mac=clean(row.get("MACAddress") or row.get("MacAddress")),
+        survey_lane=survey_lane,
+        in_manifest=True,
+    )
+    return result.as_dict()
+
+
+def classify_from_nmap_row(row: dict[str, str], survey_lane: str = "cybernet_manifest") -> dict[str, str]:
+    """Classify from an Nmap evidence export row."""
+    hostname = clean(row.get("observed_hostname") or row.get("HostName") or row.get("Target"))
+    notes = clean(row.get("Notes"))
+    port_match = re.findall(r"(\d+)/tcp", notes)
+    result = classify_device(
+        hostname=hostname,
+        reverse_dns_names=hostname,
+        open_ports=port_match,
+        mac=clean(row.get("observed_mac") or row.get("MACAddress")),
+        survey_lane=survey_lane,
+        in_manifest=True,
+    )
+    return result.as_dict()
+
+
+CLASSIFICATION_FIELDS = [
+    "SurveyLane",
+    "IdentifierType",
+    "SurveyAuthority",
+    "DeviceRole",
+    "RoleConfidence",
+    "RoleSignals",
+    "CountsTowardCybernetPopulation",
+    "NextAction",
+]


### PR DESCRIPTION
## Summary
- Add shared offline classifier (\survey/sas-survey-device-classify.py\) labeling manifest vs subnet lanes, identifier types, and device roles (workstation vs AP/network/print).
- Wire classifier into DNS resolution, evidence merge, Nmap export, subnet dns-list output, and subnet location map.
- Add \docs/SURVEY_LANES.md\ technician map; extend dashboard review with manifest/infrastructure/needs-review buckets and identifier lane chips.

## Test plan
- [x] \python Tests/survey/test_survey_device_classify.py\
- [x] \ash Tests/bash/test_survey_lanes_contracts.sh\
- [x] \ash Tests/bash/test-cybernet-subnet-location-contracts.sh\
- [x] \
ode dashboard/build-bundle.js && node dashboard/smoke-test.js\


Made with [Cursor](https://cursor.com)