### PR TITLE
Fix toolbox status sanity contracts

### DIFF
--- a/Tests/bash/test_toolbox_probe_contracts.sh
+++ b/Tests/bash/test_toolbox_probe_contracts.sh
@@ -13,10 +13,12 @@ probe="$repo_root/scripts/sas-probe-toolbox.sh"
 writer="$repo_root/scripts/sas-write-toolbox-status.sh"
 dotnet_cfg="$repo_root/Config/dotnet-bootstrap.json"
 naabu_profiles="$repo_root/survey/naabu_profiles.json"
+gitignore="$repo_root/.gitignore"
 
 [[ -f "$manifest" ]] || fail "missing toolbox dependency manifest"
 [[ -f "$probe" ]] || fail "missing toolbox probe"
 [[ -f "$writer" ]] || fail "missing toolbox writer"
+[[ -f "$gitignore" ]] || fail "missing .gitignore"
 
 for id in repo git_bash cmd powershell pwsh python dotnet_aspnet dotnet_desktop dotnet_sdk dashboard_host naabu nmap curl unzip; do
   grep -Fq "\"id\": \"$id\"" "$manifest" || fail "manifest missing tool id: $id"
@@ -59,58 +61,15 @@ for key in ("total", "ok", "needsAction", "missing", "outdated", "blocked", "unk
     assert key in summary, key
 PY
 
+bash "$writer" --dry-run --update-state available --update-mode skipped > "$tmp"
+python - "$tmp" <<'PY' || exit 1
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+assert data.get("actionNeeded") is True
+assert data.get("repo", {}).get("updateState") == "available"
+PY
+
+grep -Fq 'dashboard/toolbox-status.json' "$gitignore" || fail ".gitignore must ignore dashboard/toolbox-status.json"
+
 echo "PASS: Toolbox probe contracts"
-#!/usr/bin/env bash
-set -euo pipefail
-
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-manifest="$repo_root/Config/toolbox-dependencies.json"
-probe="$repo_root/scripts/sas-probe-toolbox.sh"
-writer="$repo_root/scripts/sas-write-toolbox-status.sh"
-dotnet_cfg="$repo_root/Config/dotnet-bootstrap.json"
-naabu_cfg="$repo_root/Config/cybernet-naabu-profiles.json"
-
-fail() {
-  echo "FAIL: $*" >&2
-  exit 1
-}
-
-[[ -f "$manifest" ]] || fail "Config/toolbox-dependencies.json is missing"
-[[ -x "$probe" || -f "$probe" ]] || fail "scripts/sas-probe-toolbox.sh is missing"
-[[ -f "$writer" ]] || fail "scripts/sas-write-toolbox-status.sh is missing"
-
-required_ids=(git_bash python pwsh powershell dotnet_aspnet dotnet_desktop naabu nmap)
-for id in "${required_ids[@]}"; do
-  grep -q "\"id\": \"${id}\"" "$manifest" || fail "manifest missing tool id: $id"
-done
-
-grep -qiE 'winget|choco' "$probe" "$writer" "$manifest" && fail "toolbox probe/writer must not reference winget or choco"
-
-probe_json="$(bash "$probe" --dry-run)"
-[[ -n "$probe_json" ]] || fail "probe produced no output"
-
-if command -v python3 >/dev/null 2>&1; then
-  python3 -m json.tool <<< "$probe_json" >/dev/null
-elif command -v python >/dev/null 2>&1; then
-  python -m json.tool <<< "$probe_json" >/dev/null
-else
-  echo "$probe_json" | grep -q '"tools"' || fail "probe JSON missing tools array"
-fi
-
-grep -q '"tools"' <<< "$probe_json" || fail "probe JSON missing tools array"
-
-dotnet_release="$(grep -o '"release"[[:space:]]*:[[:space:]]*"[^"]*"' "$dotnet_cfg" | head -1 | sed 's/.*"\([0-9.]*\)".*/\1/')"
-grep -q "\"pinnedVersion\": \"${dotnet_release}\"" "$manifest" || fail "manifest dotnet pin does not match dotnet-bootstrap release"
-
-naabu_version="$(grep -o '"naabuVersion"[[:space:]]*:[[:space:]]*"[^"]*"' "$naabu_cfg" | head -1 | sed 's/.*"\([0-9.]*\)".*/\1/')"
-grep -q "\"pinnedVersion\": \"${naabu_version}\"" "$manifest" || fail "manifest naabu pin does not match cybernet-naabu-profiles"
-
-tmp_out="$(mktemp)"
-bash "$writer" --dry-run --update-state available --update-mode skipped > "$tmp_out"
-grep -q '"actionNeeded": true' "$tmp_out" || fail "writer should set actionNeeded when update available"
-grep -q '"updateState": "available"' "$tmp_out" || fail "writer should preserve updateState"
-rm -f "$tmp_out"
-
-grep -q 'dashboard/toolbox-status.json' "$repo_root/.gitignore" || fail ".gitignore must ignore dashboard/toolbox-status.json"
-
-echo "OK: toolbox probe contracts"

--- a/dashboard/js/parsers.js
+++ b/dashboard/js/parsers.js
@@ -109,11 +109,6 @@ export function detectFileType(filename, content) {
     return 'software-tracker'; // treat all YAML drops as tracker
   }
 
-  // Naabu reachability JSON / JSONL — filename hint
-  if ((fn.endsWith('.json') || fn.endsWith('.jsonl')) && fn.includes('naabu')) {
-    return 'naabu-reachability';
-  }
-
   // JSON detection — check filename hints first, then probe content
   if (fn.endsWith('.json')) {
     if (fn.includes('toolbox-status') || fn.includes('toolbox_status')) return 'toolbox-status';
@@ -139,6 +134,12 @@ export function detectFileType(filename, content) {
     }
     if (contentLooksLikeNaabuReachability(content)) return 'naabu-reachability';
     return 'status-json'; // fallback: attempt parse as status snapshot
+  }
+
+  // Naabu reachability JSONL — filename hint. JSON is handled above so toolbox
+  // status fixtures with tool names such as "naabu" keep their explicit type.
+  if (fn.endsWith('.jsonl') && fn.includes('naabu')) {
+    return 'naabu-reachability';
   }
 
   if (fn.endsWith('.jsonl')) {

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -41,6 +41,14 @@ const naabuCases = [
   { file: 'cybernet_naabu.invalid.sample.jsonl',  expectedType: 'naabu-reachability', minRows: 1, minWarnings: 1 },
 ];
 
+// Toolbox status fixtures include tool names such as "naabu"; filename hints
+// must keep them on the toolbox parser path before generic reachability rules.
+const toolboxStatusCases = [
+  { file: 'toolbox-status-all-ok.json',             expectedType: 'toolbox-status', minRows: 1, actionNeeded: false },
+  { file: 'toolbox-status-missing-naabu.json',      expectedType: 'toolbox-status', minRows: 1, actionNeeded: true },
+  { file: 'toolbox-status-update-available.json',   expectedType: 'toolbox-status', minRows: 1, actionNeeded: true },
+];
+
 // Generic filenames whose headers resemble manifest columns but must NOT classify as manifest
 const manifestNegativeCases = [
   { file: 'machine_info_negative_manifest.sample.csv',      expectedType: 'machine-info' },
@@ -106,6 +114,34 @@ for (const { file, expectedType, minRows, minWarnings } of naabuCases) {
 
   const warnNote = parsed.meta?.warnings?.length ? `, warnings=${parsed.meta.warnings.length}` : '';
   console.log(`PASS [${file}]: type="${detected}"${parsed.rows ? ', rows=' + parsed.rows.length : ''}${warnNote}`);
+  passed++;
+}
+
+for (const { file, expectedType, minRows, actionNeeded } of toolboxStatusCases) {
+  const content = readFileSync(join(samplesDir, file), 'utf8');
+  const detected = detectFileType(file, content);
+
+  if (detected !== expectedType) {
+    console.error(`FAIL [${file}]: expected type="${expectedType}" got="${detected}"`);
+    failed++;
+    continue;
+  }
+
+  const parsed = parseFileContent(detected, content, file);
+
+  if ((parsed.rows?.length ?? 0) < minRows) {
+    console.error(`FAIL [${file}]: expected >= ${minRows} tools, got ${parsed.rows?.length ?? 0}`);
+    failed++;
+    continue;
+  }
+
+  if (parsed.data?.actionNeeded !== actionNeeded) {
+    console.error(`FAIL [${file}]: expected actionNeeded=${actionNeeded} got=${parsed.data?.actionNeeded}`);
+    failed++;
+    continue;
+  }
+
+  console.log(`PASS [${file}]: type="${detected}", tools=${parsed.rows.length}, actionNeeded=${parsed.data.actionNeeded}`);
   passed++;
 }
 


### PR DESCRIPTION
## Summary
- Preserve toolbox-status fixture parsing before generic naabu JSON filename detection.
- Add smoke coverage for all committed toolbox-status fixtures, including missing-naabu.
- Dedupe the toolbox probe contract while retaining the update-state and runtime-ignore assertions.

## Test plan
- `"C:\\Program Files\\Git\\bin\\bash.exe" Tests/bash/test_toolbox_probe_contracts.sh`
- `"C:\\Program Files\\Git\\bin\\bash.exe" Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh`
- `"C:\\Program Files\\Git\\bin\\bash.exe" Tests/bash/test_dashboard_dependency_bootstrap_contracts.sh`
- `"C:\\Program Files\\Git\\bin\\bash.exe" -lc 'for t in Tests/bash/test_*.sh; do bash "$t"; done'`
- `node dashboard/smoke-test.js`
- `node dashboard/start-button-smoke.js`
- `python -m pytest -q Tests/test_software_tracker_installs.py`