### PR TITLE
feat(survey): complete classification export fields

### DIFF
--- a/START-HERE-SysAdminSuite.md
+++ b/START-HERE-SysAdminSuite.md
@@ -117,6 +117,17 @@ Only when the dashboard tells you to copy a command, or a runbook explicitly ask
 
 Live target CSVs, scan output, packaged ZIPs, serials, MACs, and site evidence. Keep them on your admin workstation only.
 
+### Where to put local Cybernet sources
+
+Keep live operational files out of git. Use ignored local paths only:
+
+| Path | Use |
+|------|-----|
+| `targets/local/` | Approved manifest CSVs, AD exports, and other intake files you load into the dashboard |
+| `logs/targets/` | Local target-store copies the dashboard or survey scripts reference during a run |
+
+Policy and naming rules: [`docs/TARGETS_FOLDER_POLICY.md`](docs/TARGETS_FOLDER_POLICY.md). Survey lane map: [`docs/SURVEY_LANES.md`](docs/SURVEY_LANES.md).
+
 ## More help
 
 - Agent/IT canonical reference: [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md)

--- a/Tests/bash/test_survey_lanes_contracts.sh
+++ b/Tests/bash/test_survey_lanes_contracts.sh
@@ -28,6 +28,14 @@ grep -q 'humanizeClassificationWhy' dashboard/js/app.js || fail "dashboard missi
 grep -q 'cybernet-classification-drilldown' dashboard/js/app.js || fail "dashboard missing classification drilldown rendering"
 grep -q 'roleConfidence' dashboard/js/parsers.js || fail "parser missing roleConfidence field"
 
+grep -q 'classify_from_unresolved_manifest_row' survey/sas-resolve-manifest-dns.py || fail "DNS resolver missing unresolved manifest classifier wiring"
+grep -q 'CLASSIFICATION_FIELDS' survey/sas-nmap-evidence-export.py || fail "Nmap exporter missing full classification column wiring"
+grep -q 'SourceFile' survey/sas-nmap-evidence-export.py || fail "Nmap exporter missing SourceFile column"
+grep -q 'targets/local/' START-HERE-SysAdminSuite.md || fail "START-HERE missing targets/local local intake guidance"
+grep -q 'logs/targets/' START-HERE-SysAdminSuite.md || fail "START-HERE missing logs/targets local store guidance"
+grep -q 'TARGETS_FOLDER_POLICY.md' START-HERE-SysAdminSuite.md || fail "START-HERE missing targets folder policy link"
+
 python tests/survey/test_survey_device_classify.py
+python tests/survey/test_nmap_evidence_export.py
 
 pass "survey lanes contracts"

--- a/Tests/survey/test_nmap_evidence_export.py
+++ b/Tests/survey/test_nmap_evidence_export.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Offline contract tests for Nmap evidence export classification columns."""
+from __future__ import annotations
+
+import csv
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPORTER = REPO_ROOT / "survey" / "sas-nmap-evidence-export.py"
+FIXTURE = REPO_ROOT / "survey" / "fixtures" / "nmap_sample_output.txt"
+
+REQUIRED_CLASSIFICATION_COLUMNS = [
+    "RoleConfidence",
+    "NextAction",
+    "IdentifierType",
+    "SurveyAuthority",
+    "CountsTowardCybernetPopulation",
+    "SurveyLane",
+    "DeviceRole",
+    "RoleSignals",
+]
+
+
+def run_export(output_path: Path) -> None:
+    proc = subprocess.run(
+        [sys.executable, str(EXPORTER), "--input", str(FIXTURE), "--output", str(output_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"exporter failed: {proc.stderr or proc.stdout}")
+
+
+def test_nmap_export_includes_classification_columns() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "nmap_evidence.csv"
+        run_export(out)
+        with out.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            header = reader.fieldnames or []
+            for column in REQUIRED_CLASSIFICATION_COLUMNS:
+                assert column in header, f"missing column {column} in export header"
+            rows = list(reader)
+        assert len(rows) >= 2, "fixture should produce hostname and IP-only rows"
+
+        hostname_row = next(r for r in rows if r.get("observed_hostname"))
+        assert hostname_row.get("DeviceRole") == "target_workstation"
+        assert hostname_row.get("NextAction")
+        assert hostname_row.get("RoleConfidence")
+        assert hostname_row.get("SourceFile") == FIXTURE.name
+
+        ip_only_row = next(r for r in rows if not r.get("observed_hostname"))
+        assert ip_only_row.get("RoleConfidence") == "needs_review"
+        assert "nmap:no-hostname" in (ip_only_row.get("RoleSignals") or "")
+        assert ip_only_row.get("NextAction")
+
+
+def main() -> int:
+    tests = [test_nmap_export_includes_classification_columns]
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            print(f"PASS {test.__name__}")
+        except Exception as exc:
+            failed += 1
+            print(f"FAIL {test.__name__}: {exc}", file=sys.stderr)
+    if failed:
+        print(f"{failed} test(s) failed", file=sys.stderr)
+        return 1
+    print(f"All {len(tests)} Nmap export test(s) passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/survey/test_survey_device_classify.py
+++ b/Tests/survey/test_survey_device_classify.py
@@ -146,6 +146,77 @@ def test_classify_from_dns_row():
     assert "DeviceRole" in out
 
 
+def test_classify_from_nmap_row_with_hostname():
+    row = {
+        "Target": "SAMPLEHOST001",
+        "observed_hostname": "SAMPLEHOST001",
+        "observed_mac": "AA:BB:CC:DD:EE:10",
+        "Notes": "ip=192.0.2.10",
+    }
+    out = MOD.classify_from_nmap_row(row)
+    assert out["DeviceRole"] == "target_workstation"
+    assert out["RoleConfidence"] in {"low", "medium", "high"}
+    assert out["NextAction"]
+    assert out["IdentifierType"] == "HostName"
+
+
+def test_classify_from_nmap_row_ip_only():
+    row = {
+        "Target": "192.0.2.11",
+        "observed_hostname": "",
+        "observed_mac": "AA:BB:CC:DD:EE:11",
+        "Notes": "ip=192.0.2.11",
+    }
+    out = MOD.classify_from_nmap_row(row)
+    assert out["RoleConfidence"] == "needs_review"
+    assert "nmap:no-hostname" in out["RoleSignals"]
+    assert out["NextAction"]
+    assert out["IdentifierType"] == "MAC"
+
+
+def test_unresolved_serial_no_hostname():
+    row = {
+        "Serial": "CYB-SERIAL-999",
+        "Identifier": "CYB-SERIAL-999",
+        "MACAddress": "",
+        "DeviceType": "Cybernet",
+    }
+    out = MOD.classify_from_unresolved_manifest_row(row)
+    assert out["DeviceRole"] == "target_workstation"
+    assert out["RoleConfidence"] == "needs_review"
+    assert out["IdentifierType"] == "Serial"
+    assert out["CountsTowardCybernetPopulation"] == "Yes"
+    assert "serial-first" in out["NextAction"].lower() or "identity" in out["NextAction"].lower()
+
+
+def test_unresolved_mac_no_hostname():
+    row = {
+        "Serial": "",
+        "Identifier": "02:00:00:00:00:01",
+        "MACAddress": "02:00:00:00:00:01",
+        "IdentifierType": "MAC",
+        "DeviceType": "Cybernet",
+    }
+    out = MOD.classify_from_unresolved_manifest_row(row)
+    assert out["RoleConfidence"] == "needs_review"
+    assert out["CountsTowardCybernetPopulation"] == "No"
+    assert out["IdentifierType"] == "MAC"
+
+
+def test_unresolved_ambiguous_identifier():
+    row = {
+        "Serial": "",
+        "Identifier": "UNKNOWN-REF",
+        "MACAddress": "",
+        "IdentifierType": "Other",
+        "DeviceType": "Cybernet",
+    }
+    out = MOD.classify_from_unresolved_manifest_row(row)
+    assert out["DeviceRole"] == "discovery_only"
+    assert out["RoleConfidence"] == "needs_review"
+    assert out["CountsTowardCybernetPopulation"] == "No"
+
+
 def main() -> int:
     tests = [
         test_ap_reverse_dns,
@@ -158,6 +229,11 @@ def main() -> int:
         test_discovery_only_subnet_lane,
         test_aruba_vendor_ap,
         test_classify_from_dns_row,
+        test_classify_from_nmap_row_with_hostname,
+        test_classify_from_nmap_row_ip_only,
+        test_unresolved_serial_no_hostname,
+        test_unresolved_mac_no_hostname,
+        test_unresolved_ambiguous_identifier,
     ]
     failed = 0
     for test in tests:

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -1591,7 +1591,16 @@ function _countsTowardCybernet(row) {
 function _isNeedsReviewClassification(row) {
   const role = _classificationRole(row);
   const status = String(row?.overallStatus || '').toUpperCase();
-  return status.includes('REVIEW') || status.includes('CONFLICT') || role === 'discovery_only' || role === 'infrastructure_unknown';
+  const confidence = String(row?.roleConfidence || '').toLowerCase();
+  return (
+    status.includes('REVIEW') ||
+    status.includes('CONFLICT') ||
+    status === 'NO_HOSTNAME' ||
+    status === 'DNS_NOT_FOUND' ||
+    confidence === 'needs_review' ||
+    role === 'discovery_only' ||
+    role === 'infrastructure_unknown'
+  );
 }
 
 function bucketClassificationRows(rows) {

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -6704,7 +6704,16 @@ function _countsTowardCybernet(row) {
 function _isNeedsReviewClassification(row) {
   const role = _classificationRole(row);
   const status = String(row?.overallStatus || '').toUpperCase();
-  return status.includes('REVIEW') || status.includes('CONFLICT') || role === 'discovery_only' || role === 'infrastructure_unknown';
+  const confidence = String(row?.roleConfidence || '').toLowerCase();
+  return (
+    status.includes('REVIEW') ||
+    status.includes('CONFLICT') ||
+    status === 'NO_HOSTNAME' ||
+    status === 'DNS_NOT_FOUND' ||
+    confidence === 'needs_review' ||
+    role === 'discovery_only' ||
+    role === 'infrastructure_unknown'
+  );
 }
 
 function bucketClassificationRows(rows) {

--- a/docs/SURVEY_LANES.md
+++ b/docs/SURVEY_LANES.md
@@ -100,6 +100,34 @@ Each drill-down row exposes `SurveyLane`, `IdentifierType`, `DeviceRole`, `Count
 
 Infrastructure is separated because DNS and subnet discovery can legitimately surface access points, switches, routers, printers, and appliances. These findings are useful for location review but are not serial-confirmed Cybernet workstations.
 
+## Export column set (classification completeness)
+
+DNS resolution (`survey/sas-resolve-manifest-dns.py`), DNS-list classification (`survey/sas-classify-dns-list-output.py`), and Nmap evidence export (`survey/sas-nmap-evidence-export.py`) all emit the shared classifier columns:
+
+| Column | Meaning |
+|--------|---------|
+| `SurveyLane` | `cybernet_manifest` or `subnet_discovery` |
+| `IdentifierType` | `Serial`, `HostName`, or `MAC` — which key drove this row |
+| `SurveyAuthority` | Whether serial, MAC, hostname fallback, or subnet inference is authoritative |
+| `DeviceRole` | Workstation vs infrastructure vs discovery-only |
+| `RoleConfidence` | `high`, `medium`, `low`, or `needs_review` for unresolved/ambiguous rows |
+| `RoleSignals` | Semicolon-separated classifier signals (for example `nmap:no-hostname`, `manifest:no-hostname`) |
+| `CountsTowardCybernetPopulation` | `Yes` only for confirmed manifest workstation targets |
+| `NextAction` | Field-readable next step for the technician |
+
+Nmap export also includes probe evidence columns (`Target`, `observed_hostname`, `observed_serial`, `observed_mac`, reachability/probe fields, `Notes`, `EvidenceSource`, `SourceFile`).
+
+### Unresolved manifest rows (`NO_HOSTNAME`)
+
+When a manifest row has serial, MAC, or identifier values but no hostname-like value, the DNS resolver emits `Status=NO_HOSTNAME` and classifies the row via `classify_from_unresolved_manifest_row()`:
+
+- Serial-only rows → `target_workstation`, `RoleConfidence=needs_review`, population `Yes`
+- MAC-only rows → `target_workstation`, `RoleConfidence=needs_review`, population `No` until hostname is confirmed
+- Ambiguous identifier-only rows → `discovery_only`, `needs_review`, population `No`
+- Empty identifier rows → `infrastructure_unknown`, `needs_review`, population `No`
+
+IP-only Nmap rows (no reverse DNS hostname) receive `RoleConfidence=needs_review` and a `nmap:no-hostname` signal. Infrastructure rows (AP, network gear, printer) always keep `CountsTowardCybernetPopulation=No`.
+
 ## Field validation safety
 
 Use approved target manifests or approved narrow subnet lists only. Keep survey scope narrow and transparent. Normal operating-system, network, endpoint-protection, or application telemetry may occur during local verification; do not attempt to suppress it. Do not broaden scans beyond approved scope. Do not use credentials unless explicitly authorized and appropriate for the identity check. Do not commit live operational evidence; keep outputs in ignored local paths such as `targets/local/`, `logs/targets/`, `survey/output/`, `survey/artifacts/`, or `logs/nmap/`.

--- a/survey/sas-nmap-evidence-export.py
+++ b/survey/sas-nmap-evidence-export.py
@@ -31,8 +31,9 @@ def _load_classifier():
 
 
 _CLASSIFY = _load_classifier()
+CLASSIFICATION_FIELDS = _CLASSIFY.CLASSIFICATION_FIELDS
 
-FIELDS = [
+EVIDENCE_FIELDS = [
     "Target",
     "observed_hostname",
     "observed_serial",
@@ -42,11 +43,10 @@ FIELDS = [
     "ProbeMethod",
     "EvidenceSource",
     "Notes",
-    "SurveyLane",
-    "DeviceRole",
-    "RoleSignals",
-    "CountsTowardCybernetPopulation",
+    "SourceFile",
 ]
+
+FIELDS = EVIDENCE_FIELDS + CLASSIFICATION_FIELDS
 
 
 def clean(value: object) -> str:
@@ -198,12 +198,11 @@ def main() -> int:
 
     fmt = infer_format(input_path, args.format)
     rows = parse_xml(input_path) if fmt == "xml" else parse_normal_text(input_path)
+    source_file = input_path.name
     for row in rows:
         cls = _CLASSIFY.classify_from_nmap_row(row, survey_lane="cybernet_manifest")
-        row["SurveyLane"] = cls.get("SurveyLane", "cybernet_manifest")
-        row["DeviceRole"] = cls.get("DeviceRole", "")
-        row["RoleSignals"] = cls.get("RoleSignals", "")
-        row["CountsTowardCybernetPopulation"] = cls.get("CountsTowardCybernetPopulation", "")
+        row.update({field: cls.get(field, "") for field in CLASSIFICATION_FIELDS})
+        row["SourceFile"] = source_file
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=FIELDS, quoting=csv.QUOTE_ALL, lineterminator="\n")

--- a/survey/sas-resolve-manifest-dns.py
+++ b/survey/sas-resolve-manifest-dns.py
@@ -31,6 +31,7 @@ def _load_classifier():
 _CLASSIFY = _load_classifier()
 CLASSIFICATION_FIELDS = _CLASSIFY.CLASSIFICATION_FIELDS
 classify_from_dns_row = _CLASSIFY.classify_from_dns_row
+classify_from_unresolved_manifest_row = _CLASSIFY.classify_from_unresolved_manifest_row
 
 OUTPUT_FIELDS = [
     "Status",
@@ -177,23 +178,24 @@ def build_rows(input_rows: list[dict[str, str]], suffixes: list[str]) -> list[di
         seen.add(key)
 
         if not host:
-            output.append(
-                {
-                    "Status": "NO_HOSTNAME",
-                    "HostName": "",
-                    "Identifier": identifier,
-                    "Serial": serial,
-                    "MACAddress": mac,
-                    "DeviceType": dtype,
-                    "FQDN": "",
-                    "IPAddresses": "",
-                    "ReverseNames": "",
-                    "Subnets24": "",
-                    "ResolvedBy": "",
-                    "Error": "No hostname-like value was present in the manifest row.",
-                    "Source": source,
-                }
-            )
+            row_out = {
+                "Status": "NO_HOSTNAME",
+                "HostName": "",
+                "Identifier": identifier,
+                "Serial": serial,
+                "MACAddress": mac,
+                "DeviceType": dtype,
+                "IdentifierType": identifier_type,
+                "FQDN": "",
+                "IPAddresses": "",
+                "ReverseNames": "",
+                "Subnets24": "",
+                "ResolvedBy": "",
+                "Error": "No hostname-like value was present in the manifest row.",
+                "Source": source,
+            }
+            row_out.update(classify_from_unresolved_manifest_row(row_out, survey_lane="cybernet_manifest"))
+            output.append(row_out)
             continue
 
         status, fqdn, ips, resolved_by, error = resolve_host(host, suffixes)

--- a/survey/sas-survey-device-classify.py
+++ b/survey/sas-survey-device-classify.py
@@ -369,20 +369,102 @@ def classify_from_dns_row(row: dict[str, str], survey_lane: str = "cybernet_mani
     return result.as_dict()
 
 
+def classify_from_unresolved_manifest_row(row: dict[str, str], survey_lane: str = "cybernet_manifest") -> dict[str, str]:
+    """Classify manifest rows with no resolvable hostname (NO_HOSTNAME path)."""
+    lane = clean(survey_lane).lower() or "cybernet_manifest"
+    if lane not in {"cybernet_manifest", "subnet_discovery"}:
+        lane = "cybernet_manifest"
+
+    serial = clean(row.get("Serial") or row.get("SerialNumber"))
+    mac = clean(row.get("MACAddress") or row.get("MacAddress") or row.get("MAC"))
+    identifier = clean(row.get("Identifier") or row.get("Target"))
+    identifier_type = clean(row.get("IdentifierType") or row.get("Type"))
+
+    if serial:
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type="Serial",
+            survey_authority="serial",
+            device_role="target_workstation",
+            role_confidence="needs_review",
+            role_signals="manifest:no-hostname;identifier:serial",
+            counts_toward_cybernet_population="Yes",
+            next_action="Manifest serial without hostname — verify hostname against AD and collect serial-first identity evidence.",
+        ).as_dict()
+
+    if mac or identifier_type.lower() == "mac":
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type="MAC",
+            survey_authority="mac_supporting",
+            device_role="target_workstation",
+            role_confidence="needs_review",
+            role_signals="manifest:no-hostname;identifier:mac",
+            counts_toward_cybernet_population="No",
+            next_action="Manifest MAC without hostname — resolve hostname via DHCP or AD before treating as confirmed target.",
+        ).as_dict()
+
+    if identifier:
+        id_type = _identifier_type_from_row(identifier_type, "", identifier, mac)
+        return ClassificationResult(
+            survey_lane=lane,
+            identifier_type=id_type,
+            survey_authority=_survey_authority(id_type, lane, True),
+            device_role="discovery_only",
+            role_confidence="needs_review",
+            role_signals="manifest:no-hostname;identifier:ambiguous",
+            counts_toward_cybernet_population="No",
+            next_action="Unresolved manifest identifier — confirm serial or hostname before adding to probe list.",
+        ).as_dict()
+
+    return ClassificationResult(
+        survey_lane=lane,
+        identifier_type="HostName",
+        survey_authority="hostname_fallback",
+        device_role="infrastructure_unknown",
+        role_confidence="needs_review",
+        role_signals="manifest:no-hostname;identifier:none",
+        counts_toward_cybernet_population="No",
+        next_action="Manifest row lacks hostname and usable identifier — review source file and fix manifest row.",
+    ).as_dict()
+
+
 def classify_from_nmap_row(row: dict[str, str], survey_lane: str = "cybernet_manifest") -> dict[str, str]:
     """Classify from an Nmap evidence export row."""
-    hostname = clean(row.get("observed_hostname") or row.get("HostName") or row.get("Target"))
+    observed_hostname = clean(row.get("observed_hostname") or row.get("HostName"))
+    target = clean(row.get("Target"))
+    hostname = observed_hostname or (target if observed_hostname == "" and target and not re.match(r"^\d+\.\d+\.\d+\.\d+$", target) else "")
     notes = clean(row.get("Notes"))
     port_match = re.findall(r"(\d+)/tcp", notes)
+    mac = clean(row.get("observed_mac") or row.get("MACAddress"))
+    serial = clean(row.get("observed_serial") or row.get("Serial"))
+    id_type = _identifier_type_from_row("", serial, hostname, mac)
+
     result = classify_device(
         hostname=hostname,
         reverse_dns_names=hostname,
         open_ports=port_match,
-        mac=clean(row.get("observed_mac") or row.get("MACAddress")),
+        mac=mac,
+        serial=serial,
+        identifier_type=id_type,
         survey_lane=survey_lane,
         in_manifest=True,
     )
-    return result.as_dict()
+    out = result.as_dict()
+
+    if not observed_hostname:
+        signals = [s for s in out.get("RoleSignals", "").split(";") if s]
+        signals.append("nmap:no-hostname")
+        out["RoleSignals"] = ";".join(signals)
+        if result.device_role == "target_workstation":
+            out["RoleConfidence"] = "needs_review"
+            out["NextAction"] = (
+                "Nmap observed IP or MAC without hostname — confirm hostname via AD or DHCP before serial proof."
+            )
+        elif result.device_role in {"discovery_only", "infrastructure_unknown"}:
+            out["RoleConfidence"] = "needs_review"
+
+    return out
 
 
 CLASSIFICATION_FIELDS = [


### PR DESCRIPTION
## Summary
- Emit full `CLASSIFICATION_FIELDS` from Nmap evidence export and classify `NO_HOSTNAME` DNS manifest rows via a new unresolved-manifest helper.
- Tighten IP/MAC-only Nmap classification with `needs_review` confidence and `nmap:no-hostname` signals; extend dashboard needs-review bucketing.
- Add export/classifier tests, START-HERE targets placement guidance, and SURVEY_LANES export column documentation.

## Test plan
- [x] `python Tests/survey/test_survey_device_classify.py`
- [x] `python Tests/survey/test_nmap_evidence_export.py`
- [x] `bash Tests/bash/test_survey_lanes_contracts.sh`
- [x] `bash Tests/bash/test-cybernet-subnet-location-contracts.sh`
- [x] `python scripts/validate-targets-folder-policy.py`
- [x] `bash Tests/bash/test-targets-folder-policy-contracts.sh`
- [x] `node dashboard/build-bundle.js` + `node dashboard/smoke-test.js`