### PR TITLE
fix(ui): add persistent back and stop controls

### DIFF
--- a/Tests/bash/test_dashboard_wizard_exit_contracts.sh
+++ b/Tests/bash/test_dashboard_wizard_exit_contracts.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Contracts for the persistent wizard Back/Exit controls and the real (relay-honored)
+# live-probe Stop. A field user must always be able to leave a wizard and stop a
+# running probe — and Stop must halt server-side network activity, not just the UI.
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+index="$repo_root/dashboard/index.html"
+app="$repo_root/dashboard/js/app.js"
+bundle="$repo_root/dashboard/js/bundle.js"
+panel="$repo_root/dashboard/js/panel-network.js"
+relay_client="$repo_root/dashboard/js/relay-client.js"
+relay_py="$repo_root/dashboard/relay.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+for f in "$index" "$app" "$bundle" "$panel" "$relay_client" "$relay_py"; do
+  [[ -f "$f" ]] || fail "missing required file: $f"
+done
+
+# ── Persistent Back/Exit on every wizard ─────────────────────────────────────
+for id in cybernet-exit repo-setup-exit toolbox-exit sw-exit; do
+  grep -q "id=\"$id\"" "$index" || fail "wizard exit control #$id is missing from index.html"
+done
+grep -q "Back to dashboard" "$index" || fail "no 'Back to dashboard' exit control in index.html"
+
+# Step Back must be a distinct control from the persistent exit (not overloaded).
+grep -q "Previous Step" "$index" || fail "step Back not renamed to 'Previous Step'"
+
+# Shared, state-independent close helper exists and is bundled.
+grep -q "closeWorkflowTutorial" "$app" || fail "app.js does not define closeWorkflowTutorial"
+grep -q "closeWorkflowTutorial" "$bundle" || fail "bundle.js is stale — run: node dashboard/build-bundle.js"
+
+# Each wizard shell wires its exit control to the close helper.
+for id in cybernet-exit repo-setup-exit toolbox-exit sw-exit; do
+  grep -q "$id" "$app" || fail "app.js does not wire the #$id exit control"
+done
+
+# ── Real Stop: relay cancellation protocol ───────────────────────────────────
+grep -q "probe_cancel" "$relay_client" || fail "relay-client.js does not send probe_cancel (UI-only Stop is a defect)"
+grep -q "probeId" "$relay_client" || fail "relay-client.js does not tag probes with a probeId"
+grep -q "probe_cancel" "$relay_py" || fail "relay.py does not handle probe_cancel"
+grep -q "cancel_event" "$relay_py" || fail "relay.py has no cancellation token"
+grep -Eq "def run_probe" "$relay_py" || fail "relay.py missing run_probe orchestrator"
+grep -q "cancelled" "$relay_py" || fail "relay.py does not report a cancelled probe_done"
+
+# ── Persistent Stop on the network panel (not modal-only) ────────────────────
+grep -q "net-stop-probe-btn" "$panel" || fail "no persistent Stop button on the network panel"
+grep -q "net-stop-probe-btn" "$bundle" || fail "bundle.js is stale (missing panel Stop) — run: node dashboard/build-bundle.js"
+grep -q "Partial results preserved" "$panel" || fail "panel-network.js does not report preserved partial results"
+
+# ── Command-gen fallback honesty ─────────────────────────────────────────────
+grep -q "Ctrl+C" "$app" || fail "command-gen modal does not tell the user to stop copied commands with Ctrl+C"
+
+echo "PASS: dashboard wizard exit + probe stop contracts"

--- a/dashboard/css/style.css
+++ b/dashboard/css/style.css
@@ -861,6 +861,30 @@ textarea.paste-area:focus { border-color: var(--accent); }
   font-size: 11px;
 }
 
+/* Persistent Stop control + status shown on the Network panel while a live
+   probe runs, independent of the probe modal. */
+.relay-stop-btn {
+  color: var(--danger, #ef4444);
+  border-color: rgba(239, 68, 68, 0.4);
+  font-weight: 600;
+}
+.relay-stop-btn:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.12);
+  border-color: var(--danger, #ef4444);
+}
+.relay-stop-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.relay-probe-status {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  max-width: 360px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .relay-token-input {
   padding: 4px 8px;
   background: var(--bg3);
@@ -1267,6 +1291,37 @@ textarea.paste-area:focus { border-color: var(--accent); }
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
+}
+
+/* Persistent, state-independent escape control shown at the top of every
+   wizard. Unlike step-level "Previous Step", this never disables and never
+   disappears, so a field user can always return to the dashboard. */
+.workflow-exit-bar {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.workflow-exit-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-dim);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.workflow-exit-btn:hover,
+.workflow-exit-btn:focus-visible {
+  color: var(--text);
+  border-color: var(--info);
+  background: rgba(79, 142, 247, 0.08);
 }
 
 .repo-setup-hero-status,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -132,6 +132,9 @@
   </section>
 
   <section id="toolbox-tutorial" class="workflow-tutorial toolbox-tutorial hidden" aria-label="Toolbox fix wizard">
+    <div class="workflow-exit-bar">
+      <button class="workflow-exit-btn" id="toolbox-exit" type="button" title="Close this wizard and return to the dashboard">← Back to dashboard</button>
+    </div>
     <div class="workflow-step-kicker" id="toolbox-step-kicker">Step 1</div>
     <div class="workflow-step-card">
       <div class="workflow-step-content">
@@ -157,7 +160,7 @@
     </div>
     <p class="wizard-run-note">These wizards never run commands for you. Next only moves to the next step. When a step shows a command, copy it and run it yourself.</p>
     <div class="workflow-tutorial-nav">
-      <button class="btn-secondary" id="toolbox-prev" type="button">← Back</button>
+      <button class="btn-secondary" id="toolbox-prev" type="button">← Previous Step</button>
       <button class="btn-secondary hidden" id="toolbox-copy" type="button">Copy Command</button>
       <button class="btn-primary" id="toolbox-next" type="button">Next →</button>
     </div>
@@ -186,6 +189,9 @@
   </section>
 
   <section id="repo-setup-tutorial" class="workflow-tutorial repo-setup-tutorial hidden" aria-label="Repo setup wizard">
+    <div class="workflow-exit-bar">
+      <button class="workflow-exit-btn" id="repo-setup-exit" type="button" title="Close this wizard and return to the dashboard">← Back to dashboard</button>
+    </div>
     <div class="workflow-step-kicker" id="repo-setup-step-kicker">Step 1 of 5</div>
     <div class="workflow-step-card">
       <div class="workflow-step-content">
@@ -211,7 +217,7 @@
     </div>
     <p class="wizard-run-note">These wizards never run commands for you. Next only moves to the next step. When a step shows a command, copy it and run it yourself.</p>
     <div class="workflow-tutorial-nav">
-      <button class="btn-secondary" id="repo-setup-prev" type="button">← Back</button>
+      <button class="btn-secondary" id="repo-setup-prev" type="button">← Previous Step</button>
       <button class="btn-secondary hidden" id="repo-setup-copy" type="button">Copy Command</button>
       <button class="btn-primary" id="repo-setup-next" type="button">Next →</button>
     </div>
@@ -241,6 +247,9 @@
   </section>
 
   <section id="cybernet-tutorial" class="workflow-tutorial cybernet-tutorial hidden" aria-label="Cybernet survey wizard">
+    <div class="workflow-exit-bar">
+      <button class="workflow-exit-btn" id="cybernet-exit" type="button" title="Close this wizard and return to the dashboard">← Back to dashboard</button>
+    </div>
     <div class="workflow-step-kicker" id="cybernet-step-kicker">Step 1 of 6</div>
     <div class="cybernet-step-progress" id="cybernet-step-progress" aria-hidden="true"></div>
     <div class="workflow-step-card cybernet-step-card">
@@ -270,7 +279,7 @@
     </div>
     <p class="wizard-run-note">These wizards never run commands for you. Next only moves to the next step. When a step shows a command, copy it and run it yourself.</p>
     <div class="workflow-tutorial-nav cybernet-tutorial-nav">
-      <button class="btn-secondary" id="cybernet-prev" type="button">← Back</button>
+      <button class="btn-secondary" id="cybernet-prev" type="button">← Previous Step</button>
       <button class="btn-secondary hidden" id="cybernet-copy" type="button">Copy Command</button>
       <button class="btn-primary" id="cybernet-next" type="button">Next →</button>
     </div>
@@ -305,6 +314,9 @@
   </section>
 
   <section id="software-tracker-tutorial" class="workflow-tutorial software-tracker-tutorial hidden" aria-label="Software Tracker install wizard">
+    <div class="workflow-exit-bar">
+      <button class="workflow-exit-btn" id="sw-exit" type="button" title="Close this wizard and return to the dashboard">← Back to dashboard</button>
+    </div>
     <div class="workflow-step-kicker" id="sw-step-kicker">Step 1 of 7</div>
     <div class="workflow-step-card">
       <div class="workflow-step-content">
@@ -341,7 +353,7 @@
     </div>
     <p class="wizard-run-note">These wizards never run commands for you. Next only moves to the next step. When a step shows a command, copy it and run it yourself.</p>
     <div class="workflow-tutorial-nav">
-      <button class="btn-secondary" id="sw-prev" type="button">← Back</button>
+      <button class="btn-secondary" id="sw-prev" type="button">← Previous Step</button>
       <button class="btn-secondary hidden" id="sw-copy" type="button">Copy Command</button>
       <button class="btn-primary" id="sw-next" type="button">Next →</button>
     </div>

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -147,6 +147,36 @@ function switchTab(tab) {
   if (content) content.classList.remove('hidden');
 }
 
+// ── Shared workflow exit control ─────────────────────────────────────────────
+// A durable, state-independent way to leave any open wizard and return to its
+// hero/start action. This never depends on step index or probe state, so a field
+// user is never trapped inside a tutorial. It does NOT clear loaded evidence,
+// manifests, or live rows — only the visible wizard chrome is closed.
+function closeWorkflowTutorial(opts) {
+  if (!opts) return;
+  const tutorial = opts.tutorialId ? document.getElementById(opts.tutorialId) : null;
+  if (tutorial) {
+    tutorial.classList.add('hidden');
+    tutorial.style.display = ''; // drop any stale inline display so .hidden wins
+  }
+  const startBtn = opts.startBtnId ? document.getElementById(opts.startBtnId) : null;
+  if (startBtn) {
+    if (opts.startLabel) startBtn.textContent = opts.startLabel;
+    startBtn.removeAttribute('aria-label');
+  }
+  const statusEl = opts.heroStatusId ? document.getElementById(opts.heroStatusId) : null;
+  if (statusEl) {
+    statusEl.textContent = opts.neutralStatus || '';
+    statusEl.classList.remove('is-busy', 'is-open', 'is-error');
+    statusEl.classList.toggle('hidden', !opts.neutralStatus);
+  }
+  const hero = opts.heroId ? document.getElementById(opts.heroId) : null;
+  if (hero && opts.scroll !== false) {
+    try { hero.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (_) { /* non-fatal */ }
+  }
+}
+window.closeWorkflowTutorial = closeWorkflowTutorial;
+
 // ── Cybernet-first shell ─────────────────────────────────────────────────────
 function initRepoSetupShell() {
   const startBtn = document.getElementById('hero-start-setup');
@@ -202,6 +232,13 @@ function initRepoSetupShell() {
   };
 
   startBtn?.addEventListener('click', () => startRepoSetupTutorial({ source: 'manual' }));
+  document.getElementById('repo-setup-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'repo-setup-tutorial', heroId: 'repo-setup-hero',
+      startBtnId: 'hero-start-setup', startLabel: 'Start Repo Setup',
+      heroStatusId: 'repo-setup-hero-status',
+    });
+  });
   document.getElementById('hero-open-cybernet')?.addEventListener('click', () => {
     if (typeof window.startCybernetTutorial === 'function') window.startCybernetTutorial({ source: 'manual' });
     else document.getElementById('hero-start-survey')?.click();
@@ -266,6 +303,13 @@ function initToolboxShell() {
   };
 
   startBtn?.addEventListener('click', () => startToolboxTutorial({ source: 'manual', status: window.__sasLastToolboxStatus }));
+  document.getElementById('toolbox-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'toolbox-tutorial', heroId: 'toolbox-hero',
+      startBtnId: 'hero-start-toolbox', startLabel: 'Start Toolbox Check',
+      heroStatusId: 'toolbox-hero-status',
+    });
+  });
   window.startToolboxTutorial = startToolboxTutorial;
   window.renderToolboxChecklist = renderToolboxChecklist;
   window.updateToolboxBanner = updateToolboxBanner;
@@ -337,6 +381,13 @@ function initCybernetShell() {
   };
 
   startBtn?.addEventListener('click', () => startCybernetTutorial({ source: 'manual' }));
+  document.getElementById('cybernet-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'cybernet-tutorial', heroId: 'cybernet-hero',
+      startBtnId: 'hero-start-survey', startLabel: 'Start Cybernet Survey',
+      heroStatusId: 'cybernet-hero-status',
+    });
+  });
 
   // Expose the same verified transition for the ?tutorial=cybernet auto-launch
   // path so it cannot diverge from the manual click behavior.
@@ -416,6 +467,13 @@ function initSoftwareTrackerShell() {
   };
 
   startBtn?.addEventListener('click', () => startSoftwareTrackerTutorial({ source: 'manual' }));
+  document.getElementById('sw-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'software-tracker-tutorial', heroId: 'software-tracker-hero',
+      startBtnId: 'hero-start-install', startLabel: 'Start Software Tracker Install',
+      heroStatusId: 'software-tracker-hero-status',
+    });
+  });
   window.startSoftwareTrackerTutorial = startSoftwareTrackerTutorial;
 
   document.getElementById('hero-start-install-evidence')?.addEventListener('click', () => {
@@ -1297,6 +1355,8 @@ function showCommandModal(targetCount, bashCmds, psCmds, linuxCmds) {
         <div style="padding:8px 12px;background:rgba(245,158,11,0.1);border:1px solid rgba(245,158,11,0.3);border-radius:6px;font-size:11px;color:var(--warning)">
           ⚠ Browser security prevents direct network probing from a web page.
           Copy the commands below, run them from an admin machine, then drag the resulting CSV files back into the dashboard.
+          <br><strong>To stop a copied command, use Ctrl+C in the terminal where it is running.</strong>
+          The dashboard cannot stop a command already running in an external shell, and it does not hide or evade normal OS, network, or security telemetry.
         </div>
         ${section('bash-cmds', '1 — BASH  (primary — suite scripts + optional low-noise reachability)', '220px')}
         ${section('ps-cmds',   '2 — POWERSHELL  (Windows WMI / printer mapping)', '150px')}

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -1477,6 +1477,20 @@ const RELAY_PORT = 7823;
 const RELAY_HOST = 'localhost';
 const RELAY_TOKEN_KEY = 'sas_relay_token';
 const RECONNECT_DELAY = 5000;
+// How long to wait for the relay to acknowledge a cancel before the client
+// falls back to a local cancelled state (so Start re-enables even if the relay
+// is slow to answer). The relay normally answers within one step boundary.
+const CANCEL_ACK_TIMEOUT = 6000;
+
+/** Generate a per-probe id so cancel requests target the right probe. */
+function _genProbeId() {
+  try {
+    if (typeof crypto !== 'undefined' && crypto && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch (e) { /* fall through to manual id */ }
+  return 'probe-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
+}
 
 let _ws = null;
 let _connected = false;
@@ -1595,7 +1609,7 @@ function initRelayConnection() {
  * @param {function} onMessage — called with each parsed JSON message
  * @param {function} onDone    — called when probe_done received or WS closes mid-probe
  * @param {function} onError   — called with an error string
- * @returns {function} cancel  — call to abort early
+ * @returns {function} cancel  — call to stop the probe; sends a real cancel to the relay
  */
 function sendRelayProbe(req, onMessage, onDone, onError) {
   if (!_connected || !_ws) {
@@ -1604,45 +1618,69 @@ function sendRelayProbe(req, onMessage, onDone, onError) {
   }
 
   let active = true;
+  let cancelTimer = null;
   const ws = _ws;
+  const probeId = _genProbeId();
+
+  function cleanup() {
+    active = false;
+    ws.removeEventListener('message', listener);
+    ws.removeEventListener('close', closeListener);
+    if (cancelTimer) { clearTimeout(cancelTimer); cancelTimer = null; }
+  }
 
   function listener(event) {
     if (!active) return;
     let msg;
     try { msg = JSON.parse(event.data); } catch (e) { return; }
+    // If the relay tags messages with a probeId, ignore ones for other probes.
+    if (msg.probeId && msg.probeId !== probeId) return;
     if (onMessage) onMessage(msg);
     if (msg.type === 'probe_done' || msg.type === 'error') {
-      active = false;
-      ws.removeEventListener('message', listener);
-      ws.removeEventListener('close', closeListener);
+      cleanup();
       if (onDone) onDone(msg);
     }
   }
 
   function closeListener() {
     if (!active) return;
-    active = false;
-    ws.removeEventListener('message', listener);
-    if (onDone) onDone({ type: 'probe_done', aborted: true });
+    cleanup();
+    // The relay socket dropped mid-probe: classify as aborted/disconnected,
+    // never as a successful completion.
+    if (onDone) onDone({ type: 'probe_done', probeId, aborted: true });
   }
 
   ws.addEventListener('message', listener);
   ws.addEventListener('close', closeListener);
 
   try {
-    ws.send(JSON.stringify(Object.assign({ type: 'probe' }, req)));
+    ws.send(JSON.stringify(Object.assign({ type: 'probe', probeId }, req)));
   } catch (e) {
-    active = false;
-    ws.removeEventListener('message', listener);
-    ws.removeEventListener('close', closeListener);
+    cleanup();
     if (onError) onError(String(e));
   }
 
   return function cancel() {
-    active = false;
-    ws.removeEventListener('message', listener);
-    ws.removeEventListener('close', closeListener);
-    if (onDone) onDone({ type: 'probe_done', cancelled: true });
+    if (!active) return;
+    // Tell the relay to stop issuing network checks. UI-only cancellation is not
+    // enough — without this message the relay keeps probing every target.
+    try {
+      ws.send(JSON.stringify({ type: 'probe_cancel', probeId }));
+    } catch (e) {
+      // Socket is already gone — classify as aborted/disconnected, not success.
+      cleanup();
+      if (onDone) onDone({ type: 'probe_done', probeId, aborted: true });
+      return;
+    }
+    // Wait for the relay's authoritative probe_done (cancelled:true). If it does
+    // not arrive in time, fall back to a local cancelled state so the UI re-enables.
+    if (!cancelTimer) {
+      cancelTimer = setTimeout(() => {
+        if (!active) return;
+        cleanup();
+        if (onDone) onDone({ type: 'probe_done', probeId, cancelled: true, ackTimeout: true });
+      }, CANCEL_ACK_TIMEOUT);
+    }
   };
 }
 
@@ -2259,6 +2297,7 @@ let sortDir = 'asc';
 let liveRows = {};       // keyed by target — accumulated step results
 let probeCancel = null;  // cancel function returned by sendRelayProbe
 let probeRunning = false;
+let probeStopping = false; // true between a Stop request and the relay's ack
 
 const PROTOCOL_STEPS = [
   { key: 'DNS',  label: 'DNS',     port: null },
@@ -2386,6 +2425,33 @@ function initNetworkPanel() {
   // Live probe button
   const probeBtn = document.getElementById('net-live-probe-btn');
   if (probeBtn) probeBtn.addEventListener('click', openProbeModal);
+
+  // Persistent Stop control on the panel header — always available while a probe
+  // runs, even if the probe modal was closed. This stops real network activity
+  // (it sends a cancel to the relay), not just the browser view.
+  const stopBtn = document.getElementById('net-stop-probe-btn');
+  if (stopBtn) stopBtn.addEventListener('click', () => stopLiveProbe());
+}
+
+// Update the probe status line on the panel (and mirror it into the modal
+// progress line when the modal is open).
+function _setProbeStatus(text) {
+  const panelStatus = document.getElementById('net-probe-status');
+  if (panelStatus) {
+    panelStatus.textContent = text || '';
+    panelStatus.classList.toggle('hidden', !text);
+  }
+  const modalProgress = document.getElementById('probe-progress');
+  if (modalProgress && text) modalProgress.textContent = text;
+}
+
+// Shared Stop path used by both the panel Stop button and the modal Stop button.
+// Sends a real cancellation to the relay so server-side probing halts.
+function stopLiveProbe() {
+  if (!probeRunning || !probeCancel) return;
+  probeStopping = true;
+  _setProbeStatus('Stopping probe…');
+  probeCancel();
 }
 
 // ── Relay indicator ───────────────────────────────────────────────────────────
@@ -2394,6 +2460,7 @@ function updateRelayIndicator() {
   const dot = document.getElementById('relay-dot');
   const label = document.getElementById('relay-label');
   const probeBtn = document.getElementById('net-live-probe-btn');
+  const stopBtn = document.getElementById('net-stop-probe-btn');
   const tokenInput = document.getElementById('relay-token-input');
   const connectBtn = document.getElementById('relay-connect-btn');
 
@@ -2417,6 +2484,13 @@ function updateRelayIndicator() {
     probeBtn.title = connected
       ? 'Run live network probe via local relay'
       : 'Relay offline — shows setup instructions and command-gen fallback';
+  }
+  if (stopBtn) {
+    // Visible only while a probe is running, regardless of whether the modal is
+    // open — so closing the modal never strands the user without a Stop control.
+    stopBtn.classList.toggle('hidden', !probeRunning);
+    stopBtn.disabled = probeStopping;
+    stopBtn.textContent = probeStopping ? '■ Stopping…' : '■ Stop Probe';
   }
   // Hide token input once connected (token is saved); show when disconnected
   if (tokenInput) tokenInput.style.display = connected ? 'none' : '';
@@ -2495,7 +2569,7 @@ function openProbeModal() {
     <div class="modal" style="width:560px;max-width:98vw">
       <div class="modal-header">
         <span class="modal-title">📡 Live Network Probe</span>
-        <p class="modal-subtitle">Targets are probed via the local relay. Results stream into the Network panel in real time.</p>
+        <p class="modal-subtitle">Targets are probed via the local relay. Results stream into the Network panel in real time. A running probe can be stopped here or from the Stop button on the Network panel — closing this window does not stop the probe.</p>
         <button class="modal-close" id="probe-modal-close">×</button>
       </div>
       <div class="modal-body" style="gap:12px">
@@ -2523,17 +2597,28 @@ function openProbeModal() {
         <div id="probe-progress" style="display:none;font-size:11px;color:var(--text-dim);font-family:var(--mono)"></div>
       </div>
       <div class="modal-footer">
-        <button class="btn-secondary" id="probe-modal-cancel">Cancel</button>
-        <button class="btn-primary" id="probe-modal-start">▶ Start Probe</button>
+        <button class="btn-secondary" id="probe-modal-back" type="button">← Back to dashboard</button>
+        <button class="btn-secondary" id="probe-modal-cancel" type="button">Cancel</button>
+        <button class="btn-primary" id="probe-modal-start" type="button">▶ Start Probe</button>
       </div>
     </div>`;
 
   document.body.appendChild(modal);
 
+  // Closing the modal only dismisses the window. If a probe is running it keeps
+  // running and the panel Stop button remains available, so the user is never
+  // stranded without a way to stop it.
   const close = () => modal.remove();
   modal.querySelector('#probe-modal-close').addEventListener('click', close);
-  modal.querySelector('#probe-modal-cancel').addEventListener('click', close);
+  modal.querySelector('#probe-modal-back').addEventListener('click', close);
   modal.addEventListener('click', e => { if (e.target === modal) close(); });
+
+  // Single persistent handler: before a probe starts this Cancels (closes the
+  // window); once a probe is running it Stops the probe (real relay cancel).
+  modal.querySelector('#probe-modal-cancel').addEventListener('click', () => {
+    if (probeRunning) stopLiveProbe();
+    else close();
+  });
 
   modal.querySelector('#probe-modal-start').addEventListener('click', () => {
     const targetsRaw = modal.querySelector('#probe-targets-input').value;
@@ -2560,21 +2645,54 @@ function openProbeModal() {
   });
 }
 
+// Re-enable controls and report the final probe outcome. Works whether or not
+// the modal is still open: the panel status always reflects the result, and any
+// captured (possibly detached) modal buttons are updated harmlessly.
+function _finishProbe(doneMsg, totalTargets, modalEls) {
+  probeRunning = false;
+  probeStopping = false;
+  probeCancel = null;
+  updateRelayIndicator();
+
+  let label;
+  if (doneMsg && doneMsg.aborted) {
+    label = 'Relay disconnected — probe aborted. Partial results preserved.';
+  } else if (doneMsg && doneMsg.cancelled) {
+    const completed = typeof doneMsg.completed === 'number' ? doneMsg.completed : null;
+    const total = typeof doneMsg.total === 'number' ? doneMsg.total : totalTargets;
+    label = completed !== null
+      ? `Probe stopped. Partial results preserved (${completed} of ${total} target(s) completed).`
+      : 'Probe stopped. Partial results preserved.';
+  } else {
+    label = `Probe complete — ${totalTargets} target(s) done.`;
+  }
+  _setProbeStatus(label);
+
+  const startBtn = modalEls && modalEls.startBtn;
+  const cancelBtn = modalEls && modalEls.cancelBtn;
+  if (startBtn) { startBtn.disabled = false; startBtn.textContent = '▶ Start Probe'; }
+  if (cancelBtn) cancelBtn.textContent = 'Close';
+  _refreshLive();
+}
+
 function startLiveProbe(targets, ports, community, timeout, modal) {
   if (!getRelayConnected()) return;
   if (probeRunning && probeCancel) probeCancel();
 
   liveRows = {};
   probeRunning = true;
+  probeStopping = false;
   updateRelayIndicator();
 
-  const startBtn = modal.querySelector('#probe-modal-start');
-  const cancelBtn = modal.querySelector('#probe-modal-cancel');
-  const progress = modal.querySelector('#probe-progress');
+  const startBtn = modal ? modal.querySelector('#probe-modal-start') : null;
+  const cancelBtn = modal ? modal.querySelector('#probe-modal-cancel') : null;
+  const progress = modal ? modal.querySelector('#probe-progress') : null;
+  const modalEls = { startBtn, cancelBtn };
 
   if (startBtn) { startBtn.disabled = true; startBtn.textContent = '⏳ Probing…'; }
   if (cancelBtn) cancelBtn.textContent = 'Stop';
-  if (progress) { progress.style.display = ''; progress.textContent = `Probing ${targets.length} target(s)…`; }
+  if (progress) progress.style.display = '';
+  _setProbeStatus(`Probing ${targets.length} target(s)…`);
 
   // Initialise live rows for each target so they appear immediately
   for (const t of targets) {
@@ -2587,46 +2705,24 @@ function startLiveProbe(targets, ports, community, timeout, modal) {
     (msg) => {
       if (msg.type === 'step_result') {
         _applyStepResult(msg);
-        if (progress) {
-          progress.textContent = `Probing ${targets.length} target(s) — ${msg.target} / ${msg.step}`;
+        if (!probeStopping) {
+          _setProbeStatus(`Probing ${targets.length} target(s) — ${msg.target} / ${msg.step}`);
         }
         _refreshLive();
       } else if (msg.type === 'probe_start') {
-        if (progress) progress.textContent = `Probing ${msg.total} target(s)…`;
+        _setProbeStatus(`Probing ${msg.total} target(s)…`);
       }
     },
-    (doneMsg) => {
-      probeRunning = false;
-      probeCancel = null;
-      updateRelayIndicator();
-      if (progress) {
-        const label = doneMsg.cancelled ? 'Probe cancelled.' : doneMsg.aborted ? 'Relay disconnected.' : `Probe complete — ${targets.length} target(s) done.`;
-        progress.textContent = label;
-      }
-      if (startBtn) { startBtn.disabled = false; startBtn.textContent = '▶ Start Probe'; }
-      if (cancelBtn) cancelBtn.textContent = 'Close';
-      _refreshLive();
-    },
+    (doneMsg) => { _finishProbe(doneMsg, targets.length, modalEls); },
     (err) => {
       probeRunning = false;
+      probeStopping = false;
       probeCancel = null;
       updateRelayIndicator();
-      if (progress) progress.textContent = `Error: ${err}`;
+      _setProbeStatus(`Error: ${err}`);
       if (startBtn) { startBtn.disabled = false; startBtn.textContent = '▶ Start Probe'; }
     },
   );
-
-  if (cancelBtn) {
-    cancelBtn.addEventListener('click', () => {
-      if (probeRunning && probeCancel) {
-        probeCancel();
-        probeRunning = false;
-        probeCancel = null;
-        updateRelayIndicator();
-      }
-      modal.remove();
-    }, { once: true });
-  }
 }
 
 function _makeLiveRow(target) {
@@ -2897,6 +2993,8 @@ function getNetworkHTML() {
         title="Paste the token printed by: python3 dashboard/relay.py">
       <button class="icon-btn relay-connect-btn" id="relay-connect-btn" title="Connect to relay with this token">Connect</button>
       <button class="icon-btn relay-probe-btn" id="net-live-probe-btn" title="Run live probe or get setup instructions">📡 Probe / Commands</button>
+      <button class="icon-btn relay-stop-btn hidden" id="net-stop-probe-btn" title="Stop the running probe — halts further network checks on the relay">■ Stop Probe</button>
+      <span class="relay-probe-status hidden" id="net-probe-status" role="status" aria-live="polite"></span>
     </div>
     <div class="table-wrapper" id="net-accordion"></div>`;
 }
@@ -5260,6 +5358,36 @@ function switchTab(tab) {
   if (content) content.classList.remove('hidden');
 }
 
+// ── Shared workflow exit control ─────────────────────────────────────────────
+// A durable, state-independent way to leave any open wizard and return to its
+// hero/start action. This never depends on step index or probe state, so a field
+// user is never trapped inside a tutorial. It does NOT clear loaded evidence,
+// manifests, or live rows — only the visible wizard chrome is closed.
+function closeWorkflowTutorial(opts) {
+  if (!opts) return;
+  const tutorial = opts.tutorialId ? document.getElementById(opts.tutorialId) : null;
+  if (tutorial) {
+    tutorial.classList.add('hidden');
+    tutorial.style.display = ''; // drop any stale inline display so .hidden wins
+  }
+  const startBtn = opts.startBtnId ? document.getElementById(opts.startBtnId) : null;
+  if (startBtn) {
+    if (opts.startLabel) startBtn.textContent = opts.startLabel;
+    startBtn.removeAttribute('aria-label');
+  }
+  const statusEl = opts.heroStatusId ? document.getElementById(opts.heroStatusId) : null;
+  if (statusEl) {
+    statusEl.textContent = opts.neutralStatus || '';
+    statusEl.classList.remove('is-busy', 'is-open', 'is-error');
+    statusEl.classList.toggle('hidden', !opts.neutralStatus);
+  }
+  const hero = opts.heroId ? document.getElementById(opts.heroId) : null;
+  if (hero && opts.scroll !== false) {
+    try { hero.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (_) { /* non-fatal */ }
+  }
+}
+window.closeWorkflowTutorial = closeWorkflowTutorial;
+
 // ── Cybernet-first shell ─────────────────────────────────────────────────────
 function initRepoSetupShell() {
   const startBtn = document.getElementById('hero-start-setup');
@@ -5315,6 +5443,13 @@ function initRepoSetupShell() {
   };
 
   startBtn?.addEventListener('click', () => startRepoSetupTutorial({ source: 'manual' }));
+  document.getElementById('repo-setup-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'repo-setup-tutorial', heroId: 'repo-setup-hero',
+      startBtnId: 'hero-start-setup', startLabel: 'Start Repo Setup',
+      heroStatusId: 'repo-setup-hero-status',
+    });
+  });
   document.getElementById('hero-open-cybernet')?.addEventListener('click', () => {
     if (typeof window.startCybernetTutorial === 'function') window.startCybernetTutorial({ source: 'manual' });
     else document.getElementById('hero-start-survey')?.click();
@@ -5379,6 +5514,13 @@ function initToolboxShell() {
   };
 
   startBtn?.addEventListener('click', () => startToolboxTutorial({ source: 'manual', status: window.__sasLastToolboxStatus }));
+  document.getElementById('toolbox-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'toolbox-tutorial', heroId: 'toolbox-hero',
+      startBtnId: 'hero-start-toolbox', startLabel: 'Start Toolbox Check',
+      heroStatusId: 'toolbox-hero-status',
+    });
+  });
   window.startToolboxTutorial = startToolboxTutorial;
   window.renderToolboxChecklist = renderToolboxChecklist;
   window.updateToolboxBanner = updateToolboxBanner;
@@ -5450,6 +5592,13 @@ function initCybernetShell() {
   };
 
   startBtn?.addEventListener('click', () => startCybernetTutorial({ source: 'manual' }));
+  document.getElementById('cybernet-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'cybernet-tutorial', heroId: 'cybernet-hero',
+      startBtnId: 'hero-start-survey', startLabel: 'Start Cybernet Survey',
+      heroStatusId: 'cybernet-hero-status',
+    });
+  });
 
   // Expose the same verified transition for the ?tutorial=cybernet auto-launch
   // path so it cannot diverge from the manual click behavior.
@@ -5529,6 +5678,13 @@ function initSoftwareTrackerShell() {
   };
 
   startBtn?.addEventListener('click', () => startSoftwareTrackerTutorial({ source: 'manual' }));
+  document.getElementById('sw-exit')?.addEventListener('click', () => {
+    closeWorkflowTutorial({
+      tutorialId: 'software-tracker-tutorial', heroId: 'software-tracker-hero',
+      startBtnId: 'hero-start-install', startLabel: 'Start Software Tracker Install',
+      heroStatusId: 'software-tracker-hero-status',
+    });
+  });
   window.startSoftwareTrackerTutorial = startSoftwareTrackerTutorial;
 
   document.getElementById('hero-start-install-evidence')?.addEventListener('click', () => {
@@ -6410,6 +6566,8 @@ function showCommandModal(targetCount, bashCmds, psCmds, linuxCmds) {
         <div style="padding:8px 12px;background:rgba(245,158,11,0.1);border:1px solid rgba(245,158,11,0.3);border-radius:6px;font-size:11px;color:var(--warning)">
           ⚠ Browser security prevents direct network probing from a web page.
           Copy the commands below, run them from an admin machine, then drag the resulting CSV files back into the dashboard.
+          <br><strong>To stop a copied command, use Ctrl+C in the terminal where it is running.</strong>
+          The dashboard cannot stop a command already running in an external shell, and it does not hide or evade normal OS, network, or security telemetry.
         </div>
         ${section('bash-cmds', '1 — BASH  (primary — suite scripts + optional low-noise reachability)', '220px')}
         ${section('ps-cmds',   '2 — POWERSHELL  (Windows WMI / printer mapping)', '150px')}

--- a/dashboard/js/panel-network.js
+++ b/dashboard/js/panel-network.js
@@ -16,6 +16,7 @@ let sortDir = 'asc';
 let liveRows = {};       // keyed by target — accumulated step results
 let probeCancel = null;  // cancel function returned by sendRelayProbe
 let probeRunning = false;
+let probeStopping = false; // true between a Stop request and the relay's ack
 
 const PROTOCOL_STEPS = [
   { key: 'DNS',  label: 'DNS',     port: null },
@@ -143,6 +144,33 @@ export function initNetworkPanel() {
   // Live probe button
   const probeBtn = document.getElementById('net-live-probe-btn');
   if (probeBtn) probeBtn.addEventListener('click', openProbeModal);
+
+  // Persistent Stop control on the panel header — always available while a probe
+  // runs, even if the probe modal was closed. This stops real network activity
+  // (it sends a cancel to the relay), not just the browser view.
+  const stopBtn = document.getElementById('net-stop-probe-btn');
+  if (stopBtn) stopBtn.addEventListener('click', () => stopLiveProbe());
+}
+
+// Update the probe status line on the panel (and mirror it into the modal
+// progress line when the modal is open).
+function _setProbeStatus(text) {
+  const panelStatus = document.getElementById('net-probe-status');
+  if (panelStatus) {
+    panelStatus.textContent = text || '';
+    panelStatus.classList.toggle('hidden', !text);
+  }
+  const modalProgress = document.getElementById('probe-progress');
+  if (modalProgress && text) modalProgress.textContent = text;
+}
+
+// Shared Stop path used by both the panel Stop button and the modal Stop button.
+// Sends a real cancellation to the relay so server-side probing halts.
+function stopLiveProbe() {
+  if (!probeRunning || !probeCancel) return;
+  probeStopping = true;
+  _setProbeStatus('Stopping probe…');
+  probeCancel();
 }
 
 // ── Relay indicator ───────────────────────────────────────────────────────────
@@ -151,6 +179,7 @@ function updateRelayIndicator() {
   const dot = document.getElementById('relay-dot');
   const label = document.getElementById('relay-label');
   const probeBtn = document.getElementById('net-live-probe-btn');
+  const stopBtn = document.getElementById('net-stop-probe-btn');
   const tokenInput = document.getElementById('relay-token-input');
   const connectBtn = document.getElementById('relay-connect-btn');
 
@@ -174,6 +203,13 @@ function updateRelayIndicator() {
     probeBtn.title = connected
       ? 'Run live network probe via local relay'
       : 'Relay offline — shows setup instructions and command-gen fallback';
+  }
+  if (stopBtn) {
+    // Visible only while a probe is running, regardless of whether the modal is
+    // open — so closing the modal never strands the user without a Stop control.
+    stopBtn.classList.toggle('hidden', !probeRunning);
+    stopBtn.disabled = probeStopping;
+    stopBtn.textContent = probeStopping ? '■ Stopping…' : '■ Stop Probe';
   }
   // Hide token input once connected (token is saved); show when disconnected
   if (tokenInput) tokenInput.style.display = connected ? 'none' : '';
@@ -252,7 +288,7 @@ function openProbeModal() {
     <div class="modal" style="width:560px;max-width:98vw">
       <div class="modal-header">
         <span class="modal-title">📡 Live Network Probe</span>
-        <p class="modal-subtitle">Targets are probed via the local relay. Results stream into the Network panel in real time.</p>
+        <p class="modal-subtitle">Targets are probed via the local relay. Results stream into the Network panel in real time. A running probe can be stopped here or from the Stop button on the Network panel — closing this window does not stop the probe.</p>
         <button class="modal-close" id="probe-modal-close">×</button>
       </div>
       <div class="modal-body" style="gap:12px">
@@ -280,17 +316,28 @@ function openProbeModal() {
         <div id="probe-progress" style="display:none;font-size:11px;color:var(--text-dim);font-family:var(--mono)"></div>
       </div>
       <div class="modal-footer">
-        <button class="btn-secondary" id="probe-modal-cancel">Cancel</button>
-        <button class="btn-primary" id="probe-modal-start">▶ Start Probe</button>
+        <button class="btn-secondary" id="probe-modal-back" type="button">← Back to dashboard</button>
+        <button class="btn-secondary" id="probe-modal-cancel" type="button">Cancel</button>
+        <button class="btn-primary" id="probe-modal-start" type="button">▶ Start Probe</button>
       </div>
     </div>`;
 
   document.body.appendChild(modal);
 
+  // Closing the modal only dismisses the window. If a probe is running it keeps
+  // running and the panel Stop button remains available, so the user is never
+  // stranded without a way to stop it.
   const close = () => modal.remove();
   modal.querySelector('#probe-modal-close').addEventListener('click', close);
-  modal.querySelector('#probe-modal-cancel').addEventListener('click', close);
+  modal.querySelector('#probe-modal-back').addEventListener('click', close);
   modal.addEventListener('click', e => { if (e.target === modal) close(); });
+
+  // Single persistent handler: before a probe starts this Cancels (closes the
+  // window); once a probe is running it Stops the probe (real relay cancel).
+  modal.querySelector('#probe-modal-cancel').addEventListener('click', () => {
+    if (probeRunning) stopLiveProbe();
+    else close();
+  });
 
   modal.querySelector('#probe-modal-start').addEventListener('click', () => {
     const targetsRaw = modal.querySelector('#probe-targets-input').value;
@@ -317,21 +364,54 @@ function openProbeModal() {
   });
 }
 
+// Re-enable controls and report the final probe outcome. Works whether or not
+// the modal is still open: the panel status always reflects the result, and any
+// captured (possibly detached) modal buttons are updated harmlessly.
+function _finishProbe(doneMsg, totalTargets, modalEls) {
+  probeRunning = false;
+  probeStopping = false;
+  probeCancel = null;
+  updateRelayIndicator();
+
+  let label;
+  if (doneMsg && doneMsg.aborted) {
+    label = 'Relay disconnected — probe aborted. Partial results preserved.';
+  } else if (doneMsg && doneMsg.cancelled) {
+    const completed = typeof doneMsg.completed === 'number' ? doneMsg.completed : null;
+    const total = typeof doneMsg.total === 'number' ? doneMsg.total : totalTargets;
+    label = completed !== null
+      ? `Probe stopped. Partial results preserved (${completed} of ${total} target(s) completed).`
+      : 'Probe stopped. Partial results preserved.';
+  } else {
+    label = `Probe complete — ${totalTargets} target(s) done.`;
+  }
+  _setProbeStatus(label);
+
+  const startBtn = modalEls && modalEls.startBtn;
+  const cancelBtn = modalEls && modalEls.cancelBtn;
+  if (startBtn) { startBtn.disabled = false; startBtn.textContent = '▶ Start Probe'; }
+  if (cancelBtn) cancelBtn.textContent = 'Close';
+  _refreshLive();
+}
+
 function startLiveProbe(targets, ports, community, timeout, modal) {
   if (!getRelayConnected()) return;
   if (probeRunning && probeCancel) probeCancel();
 
   liveRows = {};
   probeRunning = true;
+  probeStopping = false;
   updateRelayIndicator();
 
-  const startBtn = modal.querySelector('#probe-modal-start');
-  const cancelBtn = modal.querySelector('#probe-modal-cancel');
-  const progress = modal.querySelector('#probe-progress');
+  const startBtn = modal ? modal.querySelector('#probe-modal-start') : null;
+  const cancelBtn = modal ? modal.querySelector('#probe-modal-cancel') : null;
+  const progress = modal ? modal.querySelector('#probe-progress') : null;
+  const modalEls = { startBtn, cancelBtn };
 
   if (startBtn) { startBtn.disabled = true; startBtn.textContent = '⏳ Probing…'; }
   if (cancelBtn) cancelBtn.textContent = 'Stop';
-  if (progress) { progress.style.display = ''; progress.textContent = `Probing ${targets.length} target(s)…`; }
+  if (progress) progress.style.display = '';
+  _setProbeStatus(`Probing ${targets.length} target(s)…`);
 
   // Initialise live rows for each target so they appear immediately
   for (const t of targets) {
@@ -344,46 +424,24 @@ function startLiveProbe(targets, ports, community, timeout, modal) {
     (msg) => {
       if (msg.type === 'step_result') {
         _applyStepResult(msg);
-        if (progress) {
-          progress.textContent = `Probing ${targets.length} target(s) — ${msg.target} / ${msg.step}`;
+        if (!probeStopping) {
+          _setProbeStatus(`Probing ${targets.length} target(s) — ${msg.target} / ${msg.step}`);
         }
         _refreshLive();
       } else if (msg.type === 'probe_start') {
-        if (progress) progress.textContent = `Probing ${msg.total} target(s)…`;
+        _setProbeStatus(`Probing ${msg.total} target(s)…`);
       }
     },
-    (doneMsg) => {
-      probeRunning = false;
-      probeCancel = null;
-      updateRelayIndicator();
-      if (progress) {
-        const label = doneMsg.cancelled ? 'Probe cancelled.' : doneMsg.aborted ? 'Relay disconnected.' : `Probe complete — ${targets.length} target(s) done.`;
-        progress.textContent = label;
-      }
-      if (startBtn) { startBtn.disabled = false; startBtn.textContent = '▶ Start Probe'; }
-      if (cancelBtn) cancelBtn.textContent = 'Close';
-      _refreshLive();
-    },
+    (doneMsg) => { _finishProbe(doneMsg, targets.length, modalEls); },
     (err) => {
       probeRunning = false;
+      probeStopping = false;
       probeCancel = null;
       updateRelayIndicator();
-      if (progress) progress.textContent = `Error: ${err}`;
+      _setProbeStatus(`Error: ${err}`);
       if (startBtn) { startBtn.disabled = false; startBtn.textContent = '▶ Start Probe'; }
     },
   );
-
-  if (cancelBtn) {
-    cancelBtn.addEventListener('click', () => {
-      if (probeRunning && probeCancel) {
-        probeCancel();
-        probeRunning = false;
-        probeCancel = null;
-        updateRelayIndicator();
-      }
-      modal.remove();
-    }, { once: true });
-  }
 }
 
 function _makeLiveRow(target) {
@@ -654,6 +712,8 @@ export function getNetworkHTML() {
         title="Paste the token printed by: python3 dashboard/relay.py">
       <button class="icon-btn relay-connect-btn" id="relay-connect-btn" title="Connect to relay with this token">Connect</button>
       <button class="icon-btn relay-probe-btn" id="net-live-probe-btn" title="Run live probe or get setup instructions">📡 Probe / Commands</button>
+      <button class="icon-btn relay-stop-btn hidden" id="net-stop-probe-btn" title="Stop the running probe — halts further network checks on the relay">■ Stop Probe</button>
+      <span class="relay-probe-status hidden" id="net-probe-status" role="status" aria-live="polite"></span>
     </div>
     <div class="table-wrapper" id="net-accordion"></div>`;
 }

--- a/dashboard/js/relay-client.js
+++ b/dashboard/js/relay-client.js
@@ -6,6 +6,20 @@ export const RELAY_PORT = 7823;
 export const RELAY_HOST = 'localhost';
 const RELAY_TOKEN_KEY = 'sas_relay_token';
 const RECONNECT_DELAY = 5000;
+// How long to wait for the relay to acknowledge a cancel before the client
+// falls back to a local cancelled state (so Start re-enables even if the relay
+// is slow to answer). The relay normally answers within one step boundary.
+const CANCEL_ACK_TIMEOUT = 6000;
+
+/** Generate a per-probe id so cancel requests target the right probe. */
+function _genProbeId() {
+  try {
+    if (typeof crypto !== 'undefined' && crypto && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch (e) { /* fall through to manual id */ }
+  return 'probe-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
+}
 
 let _ws = null;
 let _connected = false;
@@ -124,7 +138,7 @@ export function initRelayConnection() {
  * @param {function} onMessage — called with each parsed JSON message
  * @param {function} onDone    — called when probe_done received or WS closes mid-probe
  * @param {function} onError   — called with an error string
- * @returns {function} cancel  — call to abort early
+ * @returns {function} cancel  — call to stop the probe; sends a real cancel to the relay
  */
 export function sendRelayProbe(req, onMessage, onDone, onError) {
   if (!_connected || !_ws) {
@@ -133,44 +147,68 @@ export function sendRelayProbe(req, onMessage, onDone, onError) {
   }
 
   let active = true;
+  let cancelTimer = null;
   const ws = _ws;
+  const probeId = _genProbeId();
+
+  function cleanup() {
+    active = false;
+    ws.removeEventListener('message', listener);
+    ws.removeEventListener('close', closeListener);
+    if (cancelTimer) { clearTimeout(cancelTimer); cancelTimer = null; }
+  }
 
   function listener(event) {
     if (!active) return;
     let msg;
     try { msg = JSON.parse(event.data); } catch (e) { return; }
+    // If the relay tags messages with a probeId, ignore ones for other probes.
+    if (msg.probeId && msg.probeId !== probeId) return;
     if (onMessage) onMessage(msg);
     if (msg.type === 'probe_done' || msg.type === 'error') {
-      active = false;
-      ws.removeEventListener('message', listener);
-      ws.removeEventListener('close', closeListener);
+      cleanup();
       if (onDone) onDone(msg);
     }
   }
 
   function closeListener() {
     if (!active) return;
-    active = false;
-    ws.removeEventListener('message', listener);
-    if (onDone) onDone({ type: 'probe_done', aborted: true });
+    cleanup();
+    // The relay socket dropped mid-probe: classify as aborted/disconnected,
+    // never as a successful completion.
+    if (onDone) onDone({ type: 'probe_done', probeId, aborted: true });
   }
 
   ws.addEventListener('message', listener);
   ws.addEventListener('close', closeListener);
 
   try {
-    ws.send(JSON.stringify(Object.assign({ type: 'probe' }, req)));
+    ws.send(JSON.stringify(Object.assign({ type: 'probe', probeId }, req)));
   } catch (e) {
-    active = false;
-    ws.removeEventListener('message', listener);
-    ws.removeEventListener('close', closeListener);
+    cleanup();
     if (onError) onError(String(e));
   }
 
   return function cancel() {
-    active = false;
-    ws.removeEventListener('message', listener);
-    ws.removeEventListener('close', closeListener);
-    if (onDone) onDone({ type: 'probe_done', cancelled: true });
+    if (!active) return;
+    // Tell the relay to stop issuing network checks. UI-only cancellation is not
+    // enough — without this message the relay keeps probing every target.
+    try {
+      ws.send(JSON.stringify({ type: 'probe_cancel', probeId }));
+    } catch (e) {
+      // Socket is already gone — classify as aborted/disconnected, not success.
+      cleanup();
+      if (onDone) onDone({ type: 'probe_done', probeId, aborted: true });
+      return;
+    }
+    // Wait for the relay's authoritative probe_done (cancelled:true). If it does
+    // not arrive in time, fall back to a local cancelled state so the UI re-enables.
+    if (!cancelTimer) {
+      cancelTimer = setTimeout(() => {
+        if (!active) return;
+        cleanup();
+        if (onDone) onDone({ type: 'probe_done', probeId, cancelled: true, ackTimeout: true });
+      }, CANCEL_ACK_TIMEOUT);
+    }
   };
 }

--- a/dashboard/probe-stop-smoke.js
+++ b/dashboard/probe-stop-smoke.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// dashboard/probe-stop-smoke.js — runtime proof that Stop sends a real cancel.
+// Run: node dashboard/probe-stop-smoke.js
+//
+// Loads the real relay-client.js module under a mock WebSocket and proves the
+// critical safety contract: a probe Stop sends a `probe_cancel` (with the same
+// probeId as the probe) to the relay — it is NOT a UI-only listener teardown.
+// Also proves disconnect mid-probe is classified as aborted, never success.
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+let passed = 0;
+let failed = 0;
+function assert(ok, label, detail) {
+  if (ok) { console.log(`PASS [probe-stop:${label}]`); passed++; }
+  else { console.error(`FAIL [probe-stop:${label}]${detail ? ': ' + detail : ''}`); failed++; }
+}
+
+// ── Mock WebSocket ──────────────────────────────────────────────────────────
+let lastSocket = null;
+class MockWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.sent = [];
+    this._listeners = {};
+    this.readyState = 1; // OPEN
+    lastSocket = this;
+  }
+  addEventListener(type, fn) { (this._listeners[type] = this._listeners[type] || []).push(fn); }
+  removeEventListener(type, fn) {
+    if (this._listeners[type]) this._listeners[type] = this._listeners[type].filter(f => f !== fn);
+  }
+  send(data) { this.sent.push(JSON.parse(data)); }
+  close() { this.readyState = 3; this._fire('close', { code: 1000 }); }
+  _fire(type, ev) { (this._listeners[type] || []).slice().forEach(fn => fn(ev)); }
+  sentOfType(t) { return this.sent.filter(m => m.type === t); }
+}
+MockWebSocket.CONNECTING = 0;
+MockWebSocket.OPEN = 1;
+MockWebSocket.CLOSING = 2;
+MockWebSocket.CLOSED = 3;
+
+global.WebSocket = MockWebSocket;
+const _store = new Map();
+global.localStorage = {
+  getItem: k => (_store.has(k) ? _store.get(k) : null),
+  setItem: (k, v) => _store.set(k, String(v)),
+  removeItem: k => _store.delete(k),
+};
+
+// Load the real module (Node resolves the ESM file directly).
+const relayClientUrl = 'file://' + join(__dir, 'js', 'relay-client.js').replace(/\\/g, '/');
+const { setRelayToken, getRelayConnected, sendRelayProbe } = await import(relayClientUrl);
+
+// Connect: setting a token triggers _connect() which creates a MockWebSocket.
+setRelayToken('test-token-123');
+assert(lastSocket !== null, 'socket-created', 'no WebSocket created on token set');
+lastSocket._fire('open');
+assert(getRelayConnected() === true, 'relay-connected', 'relay did not report connected after open');
+
+// ── Probe 1: Stop must send probe_cancel with the matching probeId ───────────
+let doneMsg1 = null;
+const cancel1 = sendRelayProbe(
+  { targets: ['t1', 't2'], ports: [80], snmp_community: 'public', timeout: 1 },
+  () => {},
+  (d) => { doneMsg1 = d; },
+  (e) => { assert(false, 'probe1-no-error', e); },
+);
+
+const probeMsgs = lastSocket.sentOfType('probe');
+assert(probeMsgs.length === 1, 'probe-sent', `expected 1 probe message, got ${probeMsgs.length}`);
+const probeId = probeMsgs[0].probeId;
+assert(typeof probeId === 'string' && probeId.length > 0, 'probe-has-id', 'probe message missing probeId');
+
+// Trigger Stop.
+cancel1();
+const cancelMsgs = lastSocket.sentOfType('probe_cancel');
+assert(cancelMsgs.length === 1, 'cancel-sent-to-relay',
+  'Stop did not send a probe_cancel to the relay (UI-only cancel is a defect)');
+assert(cancelMsgs[0].probeId === probeId, 'cancel-matches-probe-id',
+  `cancel probeId ${cancelMsgs[0].probeId} != probe ${probeId}`);
+
+// Relay acknowledges with an authoritative cancelled probe_done.
+lastSocket._fire('message', { data: JSON.stringify({ type: 'probe_done', probeId, total: 2, completed: 1, cancelled: true }) });
+assert(doneMsg1 && doneMsg1.cancelled === true, 'cancel-ack-honored',
+  'client did not surface the relay cancelled probe_done');
+assert(doneMsg1 && doneMsg1.completed === 1, 'partial-count-preserved',
+  'client lost the partial completion count');
+
+// ── Probe 2: mid-probe disconnect is classified as aborted, not success ──────
+let doneMsg2 = null;
+sendRelayProbe(
+  { targets: ['t3'], ports: [80], snmp_community: 'public', timeout: 1 },
+  () => {},
+  (d) => { doneMsg2 = d; },
+  () => {},
+);
+lastSocket.close();
+assert(doneMsg2 && doneMsg2.aborted === true, 'disconnect-classified-aborted',
+  'mid-probe disconnect was not classified as aborted/disconnected');
+assert(!(doneMsg2 && doneMsg2.cancelled), 'disconnect-not-success',
+  'aborted probe must not also be reported as a clean cancel/success');
+
+console.log(`\nProbe stop: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/dashboard/relay.py
+++ b/dashboard/relay.py
@@ -29,22 +29,35 @@ Protocol
 
   Client  → Server  (JSON):
     { "type": "probe",
+      "probeId":        "abc123",            # optional; relay generates one if absent
       "targets":        ["192.168.1.1", "printer.local"],
       "ports":          [135, 139, 445, 515, 631, 3389, 9100],
       "snmp_community": "public",
       "timeout":        2 }
 
+    { "type": "probe_cancel", "probeId": "abc123" }   # stop the running probe
+
+  Cancellation
+  ------------
+  A probe runs as a background task while the connection keeps reading messages,
+  so a "probe_cancel" can interrupt it. The relay checks the cancel flag before
+  each target and before each major step (DNS, ping, TCP batch, SNMP), so in-flight
+  network activity stops promptly and remaining targets are never probed. Partial
+  results already streamed to the client are preserved. This is scope control, not
+  log evasion — normal OS/network telemetry is unaffected.
+
   Server  → Client  (JSON, streaming, one message per event):
-    { "type": "probe_start",  "total": N }
-    { "type": "step_result",  "target": "...", "step": "dns",
+    { "type": "probe_start",  "probeId": "...", "total": N }
+    { "type": "step_result",  "probeId": "...", "target": "...", "step": "dns",
       "status": "ok|failed|skipped", "value": "..." }
-    { "type": "step_result",  "target": "...", "step": "ping",
+    { "type": "step_result",  "probeId": "...", "target": "...", "step": "ping",
       "status": "ok|failed",  "value": "Reachable|NoPing" }
-    { "type": "step_result",  "target": "...", "step": "tcp_PORT",
+    { "type": "step_result",  "probeId": "...", "target": "...", "step": "tcp_PORT",
       "status": "ok|failed",  "value": "open|closed|filtered" }
-    { "type": "step_result",  "target": "...", "step": "snmp",
+    { "type": "step_result",  "probeId": "...", "target": "...", "step": "snmp",
       "status": "ok|failed|skipped", "value": "..." }
-    { "type": "probe_done",   "total": N }
+    { "type": "probe_done",   "probeId": "...", "total": N, "completed": M,
+      "cancelled": true|false }
     { "type": "error",        "message": "..." }
 """
 
@@ -271,17 +284,30 @@ async def probe_snmp(target: str, community: str, timeout: int) -> dict:
 
 # ── Per-target probe orchestrator ─────────────────────────────────────────────
 
-async def probe_target(ws, target: str, ports: list, snmp_community: str, timeout: int):
-    """Run all probe steps for one target and stream results over ws."""
+async def probe_target(ws, target: str, ports: list, snmp_community: str, timeout: int,
+                       cancel_event=None, probe_id=None):
+    """Run all probe steps for one target and stream results over ws.
+
+    If ``cancel_event`` is set at any checkpoint (before ping, before the TCP
+    batch, before SNMP) the probe stops early and no further network activity is
+    issued for this target. Results already sent are preserved by the client.
+    """
+
+    def cancelled():
+        return cancel_event is not None and cancel_event.is_set()
 
     async def send(step, status, value):
         await ws.send(json.dumps({
             "type": "step_result",
+            "probeId": probe_id,
             "target": target,
             "step": step,
             "status": status,
             "value": value,
         }))
+
+    if cancelled():
+        return
 
     # DNS
     dns = await probe_dns(target, timeout)
@@ -289,9 +315,15 @@ async def probe_target(ws, target: str, ports: list, snmp_community: str, timeou
     # Use resolved IP for lower-level probes to avoid repeated DNS lookups
     probe_addr = dns["value"] if dns["status"] == "ok" else target
 
+    if cancelled():
+        return
+
     # Ping
     ping = await probe_ping(probe_addr, timeout)
     await send("ping", ping["status"], ping["value"])
+
+    if cancelled():
+        return
 
     # TCP ports (run concurrently for speed)
     port_coros = {str(p): probe_tcp(probe_addr, p, timeout) for p in ports}
@@ -302,9 +334,57 @@ async def probe_target(ws, target: str, ports: list, snmp_community: str, timeou
         else:
             await send(f"tcp_{port_str}", result["status"], result["value"])
 
+    if cancelled():
+        return
+
     # SNMP
     snmp = await probe_snmp(probe_addr, snmp_community, timeout)
     await send("snmp", snmp["status"], snmp["value"])
+
+
+# ── Probe orchestration (cancellable) ─────────────────────────────────────────
+
+async def run_probe(ws, probe_id, targets, ports, community, timeout, cancel_event):
+    """Probe every target sequentially while honoring ``cancel_event``.
+
+    Checks for cancellation before each target so a Stop request halts further
+    network activity instead of merely hiding the browser UI. Streams a
+    ``probe_done`` with ``cancelled`` and ``completed`` counts. Returns the
+    ``(completed, cancelled)`` tuple so callers/tests can assert behavior.
+    """
+    await ws.send(json.dumps({
+        "type": "probe_start", "probeId": probe_id, "total": len(targets),
+    }))
+
+    completed = 0
+    for target in targets:
+        if cancel_event.is_set():
+            break
+        try:
+            await probe_target(ws, target, ports, community, timeout, cancel_event, probe_id)
+        except Exception as exc:
+            log.warning("Error probing %s: %s", target, exc)
+            await ws.send(json.dumps({
+                "type": "step_result", "probeId": probe_id, "target": target,
+                "step": "error", "status": "failed", "value": str(exc),
+            }))
+        # If cancellation arrived during this target, treat it as not completed
+        # (partial results already streamed are preserved on the client).
+        if cancel_event.is_set():
+            break
+        completed += 1
+
+    cancelled = cancel_event.is_set()
+    await ws.send(json.dumps({
+        "type": "probe_done", "probeId": probe_id,
+        "total": len(targets), "completed": completed, "cancelled": cancelled,
+    }))
+    if cancelled:
+        log.info("Probe %s cancelled — %d of %d target(s) completed",
+                 probe_id, completed, len(targets))
+    else:
+        log.info("Probe %s complete — %d target(s)", probe_id, len(targets))
+    return completed, cancelled
 
 
 # ── WebSocket connection handler ──────────────────────────────────────────────
@@ -342,6 +422,21 @@ async def handle_connection(ws, secret_token: str):
     remote = getattr(ws, "remote_address", ("?", "?"))
     log.info("Authenticated client connected from %s:%s", *remote)
 
+    # Per-connection probe state. The probe runs as a background task so the
+    # connection keeps reading messages and can honor a "probe_cancel".
+    state = {"probe_id": None, "task": None, "cancel_event": None}
+
+    async def cancel_current():
+        ev = state["cancel_event"]
+        task = state["task"]
+        if ev is not None:
+            ev.set()
+        if task is not None and not task.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=15)
+            except Exception:
+                pass
+
     try:
         async for raw in ws:
             try:
@@ -350,10 +445,22 @@ async def handle_connection(ws, secret_token: str):
                 await ws.send(json.dumps({"type": "error", "message": "Invalid JSON"}))
                 continue
 
-            if msg.get("type") != "probe":
+            mtype = msg.get("type")
+
+            # Cancellation request — stop the running probe (if the id matches or
+            # no id was supplied). Safe to receive at any time.
+            if mtype == "probe_cancel":
+                pid = msg.get("probeId")
+                if state["probe_id"] and (pid is None or pid == state["probe_id"]):
+                    log.info("Cancellation requested for probe %s", state["probe_id"])
+                    if state["cancel_event"] is not None:
+                        state["cancel_event"].set()
+                continue
+
+            if mtype != "probe":
                 await ws.send(json.dumps({
                     "type": "error",
-                    "message": f"Unknown message type: {msg.get('type')}",
+                    "message": f"Unknown message type: {mtype}",
                 }))
                 continue
 
@@ -379,25 +486,35 @@ async def handle_connection(ws, secret_token: str):
                 ports = ports[:MAX_PORTS]
                 log.warning("Port list truncated to %d (max %d)", MAX_PORTS, MAX_PORTS)
 
-            log.info("Probing %d target(s): %s", len(targets), ", ".join(targets[:5]))
-            await ws.send(json.dumps({"type": "probe_start", "total": len(targets)}))
+            # If a probe is already running, cancel it before starting a new one.
+            await cancel_current()
 
-            for target in targets:
+            probe_id = str(msg.get("probeId") or secrets.token_hex(8))
+            cancel_event = asyncio.Event()
+            state["probe_id"] = probe_id
+            state["cancel_event"] = cancel_event
+            log.info("Probing %d target(s) [probe %s]: %s",
+                     len(targets), probe_id, ", ".join(targets[:5]))
+
+            async def _runner(pid=probe_id, t=targets, p=ports, c=community,
+                              to=timeout, ev=cancel_event):
                 try:
-                    await probe_target(ws, target, ports, community, timeout)
+                    await run_probe(ws, pid, t, p, c, to, ev)
                 except Exception as exc:
-                    log.warning("Error probing %s: %s", target, exc)
-                    await ws.send(json.dumps({
-                        "type": "step_result", "target": target,
-                        "step": "error", "status": "failed", "value": str(exc),
-                    }))
+                    log.warning("Probe %s ended unexpectedly: %s", pid, exc)
+                finally:
+                    if state["probe_id"] == pid:
+                        state["probe_id"] = None
+                        state["task"] = None
+                        state["cancel_event"] = None
 
-            await ws.send(json.dumps({"type": "probe_done", "total": len(targets)}))
-            log.info("Probe complete — %d target(s)", len(targets))
+            state["task"] = asyncio.create_task(_runner())
 
     except Exception as exc:
         log.warning("Connection closed unexpectedly: %s", exc)
     finally:
+        # Never leave a probe task running after the connection ends.
+        await cancel_current()
         log.info("Client disconnected from %s:%s", *remote)
 
 

--- a/dashboard/smoke-test.js
+++ b/dashboard/smoke-test.js
@@ -527,3 +527,48 @@ startAssert(bundleJs.includes('startCybernetTutorial'), 'bundle-not-stale',
 
 console.log(`\nStart button: ${startPassed} passed, ${startFailed} failed`);
 if (startFailed > 0) process.exit(1);
+
+// ── Persistent Back/Exit + real Stop contracts ───────────────────────────────
+// Source-level guards that every wizard has a state-independent exit and that
+// the live probe Stop is a real relay cancellation, not a UI-only teardown.
+
+const relayClientJs = readFileSync(join(__dir, 'js', 'relay-client.js'), 'utf8');
+const panelNetworkJs = readFileSync(join(__dir, 'js', 'panel-network.js'), 'utf8');
+const relayPy = readFileSync(join(__dir, 'relay.py'), 'utf8');
+
+let bsPassed = 0;
+let bsFailed = 0;
+function bsAssert(ok, label, detail) {
+  if (ok) { console.log(`PASS [back-stop:${label}]`); bsPassed++; }
+  else { console.error(`FAIL [back-stop:${label}]${detail ? ': ' + detail : ''}`); bsFailed++; }
+}
+
+// Persistent Back/Exit control on every wizard (independent of step index).
+for (const id of ['cybernet-exit', 'repo-setup-exit', 'toolbox-exit', 'sw-exit']) {
+  bsAssert(indexHtml.includes(`id="${id}"`), `exit-control:${id}`, `index.html missing #${id}`);
+}
+bsAssert(indexHtml.includes('Back to dashboard'), 'exit-label', 'no "Back to dashboard" control in index.html');
+// Step Back is renamed so exit and previous-step are not the same overloaded button.
+bsAssert(indexHtml.includes('Previous Step'), 'step-back-renamed', 'step Back not renamed to Previous Step');
+bsAssert(appJs.includes('closeWorkflowTutorial'), 'close-helper', 'app.js missing closeWorkflowTutorial');
+bsAssert(bundleJs.includes('closeWorkflowTutorial'), 'close-helper-bundled',
+  'bundle.js stale — missing closeWorkflowTutorial; rebuild with: node dashboard/build-bundle.js');
+
+// Real Stop: client sends probe_cancel; relay honors it; panel has a Stop button.
+bsAssert(relayClientJs.includes('probe_cancel'), 'client-sends-cancel',
+  'relay-client.js does not send a probe_cancel (UI-only Stop is a defect)');
+bsAssert(relayClientJs.includes('probeId'), 'client-probe-id', 'relay-client.js missing probeId');
+bsAssert(relayPy.includes('probe_cancel'), 'relay-handles-cancel', 'relay.py does not handle probe_cancel');
+bsAssert(relayPy.includes('cancel_event'), 'relay-cancel-event', 'relay.py has no cancellation token');
+bsAssert(/def run_probe/.test(relayPy), 'relay-run-probe', 'relay.py missing run_probe orchestrator');
+bsAssert(indexHtml.includes('id="net-stop-probe-btn"') || panelNetworkJs.includes('net-stop-probe-btn'),
+  'panel-stop-button', 'no persistent Stop button on the network panel');
+bsAssert(panelNetworkJs.includes('Partial results preserved'), 'partial-results-msg',
+  'panel-network.js does not report preserved partial results');
+bsAssert(bundleJs.includes('net-stop-probe-btn'), 'panel-stop-bundled',
+  'bundle.js stale — missing panel Stop button; rebuild with: node dashboard/build-bundle.js');
+// Command-gen fallback must tell the user how to stop a copied command.
+bsAssert(appJs.includes('Ctrl+C'), 'cmdgen-ctrl-c', 'command-gen modal missing Ctrl+C stop guidance');
+
+console.log(`\nBack/Stop controls: ${bsPassed} passed, ${bsFailed} failed`);
+if (bsFailed > 0) process.exit(1);

--- a/dashboard/start-button-smoke.js
+++ b/dashboard/start-button-smoke.js
@@ -239,5 +239,24 @@ assert(isVisible(setupTutorial), 'setup-auto-start-opens-wizard', 'setup auto-st
 assert(/restart/i.test(setupStartBtn.textContent), 'setup-auto-start-transforms-start',
   `setup auto-start did not transform Start (was "${setupStartBtn.textContent}")`);
 
+// State 6: the persistent "Back to dashboard" exit closes the wizard, keeps the
+// hero/start action visible, and restores the Start label — the user is never
+// trapped inside an open wizard.
+tutorial.classList.add('hidden');
+tutorial.style.display = '';
+startBtn.textContent = 'Start Cybernet Survey';
+window.location.search = '';
+startBtn.click();
+assert(isVisible(tutorial), 'exit-precondition-open', 'wizard not open before exit test');
+const cybernetExit = document.getElementById('cybernet-exit');
+assert(typeof window.closeWorkflowTutorial === 'function', 'exit-helper-exposed',
+  'window.closeWorkflowTutorial missing');
+cybernetExit.click();
+assert(!isVisible(tutorial), 'exit-closes-wizard', 'exit control did not hide the wizard');
+assert(isVisible(document.getElementById('cybernet-hero-actions')), 'exit-keeps-hero-actions',
+  'hero actions hidden after exit, stranding the user');
+assert(startBtn.textContent === 'Start Cybernet Survey', 'exit-restores-start-label',
+  `Start label not restored on exit (was "${startBtn.textContent}")`);
+
 console.log(`\nStart button: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/dashboard/test_relay_cancel.py
+++ b/dashboard/test_relay_cancel.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Unit tests for the relay probe cancellation path (dashboard/relay.py).
+
+These tests prove that a Stop request actually halts server-side probing:
+the relay must stop before remaining targets and report a cancelled probe with
+partial-completion counts. No real network probing is performed — probe_target
+is replaced with a fake so the loop logic is tested in isolation.
+
+Run: python dashboard/test_relay_cancel.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import relay  # noqa: E402
+
+
+class FakeWS:
+    """Minimal async WebSocket stand-in that records JSON messages sent."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, data):
+        self.sent.append(json.loads(data))
+
+    def messages_of_type(self, mtype):
+        return [m for m in self.sent if m.get("type") == mtype]
+
+    def first(self, mtype):
+        msgs = self.messages_of_type(mtype)
+        return msgs[0] if msgs else None
+
+
+class RunProbeCancelTests(unittest.TestCase):
+    def _patch_probe_target(self, fake):
+        original = relay.probe_target
+        relay.probe_target = fake
+        self.addCleanup(lambda: setattr(relay, "probe_target", original))
+
+    def test_cancel_before_start_probes_no_targets(self):
+        ws = FakeWS()
+        cancel_event = asyncio.Event()
+        cancel_event.set()  # cancelled before the loop even begins
+
+        calls = []
+
+        async def fake_probe_target(ws_, target, ports, community, timeout,
+                                    cancel_event=None, probe_id=None):
+            calls.append(target)
+
+        self._patch_probe_target(fake_probe_target)
+
+        completed, cancelled = asyncio.run(
+            relay.run_probe(ws, "p1", ["t1", "t2", "t3"], [80], "public", 1, cancel_event)
+        )
+
+        self.assertEqual(calls, [], "no targets should be probed when cancelled up front")
+        self.assertEqual(completed, 0)
+        self.assertTrue(cancelled)
+        done = ws.first("probe_done")
+        self.assertIsNotNone(done)
+        self.assertTrue(done["cancelled"])
+        self.assertEqual(done["completed"], 0)
+        self.assertEqual(done["total"], 3)
+        self.assertEqual(done["probeId"], "p1")
+
+    def test_cancel_midway_stops_remaining_targets(self):
+        ws = FakeWS()
+        cancel_event = asyncio.Event()
+        calls = []
+
+        async def fake_probe_target(ws_, target, ports, community, timeout,
+                                    cancel_event=None, probe_id=None):
+            calls.append(target)
+            # Simulate a Stop arriving while the first target is being probed.
+            if len(calls) == 1:
+                cancel_event.set()
+
+        self._patch_probe_target(fake_probe_target)
+
+        completed, cancelled = asyncio.run(
+            relay.run_probe(ws, "p2", ["t1", "t2", "t3"], [80], "public", 1, cancel_event)
+        )
+
+        self.assertEqual(calls, ["t1"], "relay must not probe targets after cancellation")
+        self.assertTrue(cancelled)
+        done = ws.first("probe_done")
+        self.assertTrue(done["cancelled"])
+        self.assertEqual(done["total"], 3)
+
+    def test_no_cancel_completes_all_targets(self):
+        ws = FakeWS()
+        cancel_event = asyncio.Event()
+        calls = []
+
+        async def fake_probe_target(ws_, target, ports, community, timeout,
+                                    cancel_event=None, probe_id=None):
+            calls.append(target)
+
+        self._patch_probe_target(fake_probe_target)
+
+        completed, cancelled = asyncio.run(
+            relay.run_probe(ws, "p3", ["t1", "t2"], [80], "public", 1, cancel_event)
+        )
+
+        self.assertEqual(calls, ["t1", "t2"])
+        self.assertEqual(completed, 2)
+        self.assertFalse(cancelled)
+        done = ws.first("probe_done")
+        self.assertFalse(done["cancelled"])
+        self.assertEqual(done["completed"], 2)
+
+    def test_probe_target_short_circuits_when_cancelled(self):
+        """probe_target must issue no network steps when cancel is already set."""
+        ws = FakeWS()
+        cancel_event = asyncio.Event()
+        cancel_event.set()
+
+        asyncio.run(
+            relay.probe_target(ws, "t1", [80], "public", 1, cancel_event, "p4")
+        )
+
+        self.assertEqual(ws.sent, [], "no step_result should be sent for a cancelled target")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/docs/DASHBOARD_TOOLBOX_TUTORIAL.md
+++ b/docs/DASHBOARD_TOOLBOX_TUTORIAL.md
@@ -30,6 +30,16 @@ tool is missing, outdated, blocked, or requires update review.
 4. `dashboard/js/launch-toolbox-tutorial.js` fetches that JSON. If
    `actionNeeded` is true, the Toolbox wizard opens before Repo Setup.
 
+## Leaving a wizard
+
+Every dashboard wizard (Toolbox Check, Repo Setup, Cybernet Survey, Software
+Tracker Install) carries a persistent **← Back to dashboard** control at the top
+of the wizard. It is always visible and never depends on the current step, so a
+field user can always close the wizard and return to its hero/start action. The
+step-level **← Previous Step** button is a separate control and may be disabled
+on the first step; the Back to dashboard control is not. Closing a wizard hides
+only the wizard chrome and does not clear loaded evidence.
+
 ## Probe Contract
 
 The committed manifest is

--- a/docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md
+++ b/docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md
@@ -333,3 +333,30 @@ Stop and escalate when:
 7. Package local artifacts under survey/artifacts/.
 8. Do not commit live data.
 ```
+
+## Dashboard controls: Back and Stop
+
+Every dashboard wizard (Cybernet Survey, Repo Setup, Toolbox Check, Software
+Tracker Install) shows a persistent **← Back to dashboard** control at the top.
+It is always available and never depends on the step you are on or whether a
+probe is running, so you can always leave a wizard. The step-level **← Previous
+Step** button is separate and may be disabled on the first step; the Back to
+dashboard control is not. Closing a wizard keeps your loaded evidence — it only
+hides the wizard chrome.
+
+Live relay probes can be stopped from the dashboard. While a live probe is
+running, a **■ Stop Probe** button appears on the Network panel (and in the live
+probe window). Stop sends a real cancellation to the local relay, which stops
+issuing further network checks — it is not a browser-only action. Stopping
+preserves partial results: rows already collected stay in the Network panel, and
+the status line reads `Probe stopped. Partial results preserved.` Closing the
+probe window does not stop the probe; use Stop. If the relay disconnects mid
+probe, the result is classified as aborted/disconnected, never as success.
+
+Command-generation scripts (the relay-offline fallback) run in your own
+terminal, so the dashboard cannot stop them. Command-generation scripts must be
+stopped in the terminal with **Ctrl+C** in the window where they are running.
+
+The dashboard does not hide or evade normal OS, network, or security telemetry;
+Stop is scope control, not log suppression. Keep probes scoped to approved
+target manifests.


### PR DESCRIPTION
## Summary

Blocker-level dashboard UX + safety sprint. Makes **Back** and **Stop** first-class, always-visible, state-independent controls so a field user can never start a probe and then lose the ability to back out or stop it.

### Back / Exit
- Every wizard (Cybernet Survey, Repo Setup, Toolbox Check, Software Tracker Install) now has a persistent **← Back to dashboard** control at the top, wired through a shared `closeWorkflowTutorial` helper. It never depends on step index or probe state.
- Step-level **← Back** renamed to **← Previous Step** so exit and previous-step are not one overloaded button (Previous Step may still disable at step 0; Back to dashboard never disappears).
- Closing a wizard hides only the wizard chrome, restores the hero Start action and a neutral status, and preserves loaded evidence.

### Stop (real, relay-honored — not UI-only)
- `relay.py`: new `probeId` + `probe_cancel` protocol and a per-connection `cancel_event`. Probes run as a cancellable background task; `run_probe` checks cancellation before each target and `probe_target` before each major step (DNS, ping, TCP batch, SNMP), then sends `probe_done` with `cancelled` + `completed` counts. The connection keeps reading messages while a probe runs so a cancel can interrupt it.
- `relay-client.js`: `cancel()` now sends `{type:"probe_cancel", probeId}` to the relay and waits for the relay's authoritative ack (with a fallback timeout), instead of only removing listeners. Mid-probe disconnect is classified as **aborted**, never success.
- `panel-network.js`: persistent **■ Stop Probe** button on the Network panel, visible whenever a probe runs even if the modal is closed; shared `stopLiveProbe` path used by both modal and panel; status messages `Stopping probe…` / `Probe stopped. Partial results preserved.`; fixed the double-bound modal cancel handler. Partial results are preserved.
- Command-generation fallback documents **Ctrl+C** to stop copied commands and states the dashboard does not hide/evade normal OS/network/security telemetry.

## Test plan
- [x] `node dashboard/build-bundle.js`
- [x] `node dashboard/smoke-test.js` (165 assertions, incl. 17 new Back/Stop contracts)
- [x] `node dashboard/start-button-smoke.js` (18, incl. 5 new wizard-exit runtime assertions)
- [x] `node dashboard/probe-stop-smoke.js` (10 — proves Stop sends `probe_cancel` with matching `probeId`, ack honored, partial count preserved, disconnect=aborted)
- [x] `python dashboard/test_relay_cancel.py` (4 — relay stops before remaining targets, reports cancelled + partial)
- [x] `bash Tests/bash/test_dashboard_wizard_exit_contracts.sh` (new)
- [x] `bash Tests/bash/test_dashboard_tutorial_launcher_contracts.sh`
- [x] `bash Tests/bash/test_dashboard_entrypoint_contracts.sh`
- [x] `bash Tests/bash/test_dashboard_toolbox_tutorial_contracts.sh`

## Scope notes
- Additive: no wizard code rewritten wholesale; legacy behavior preserved.
- No scan broadening, no concurrency increase, no credentials, no telemetry suppression, no live evidence committed.
