### PR TITLE
docs(ad): AD probe resilience and ambiguity doctrine

### DIFF
--- a/.cursor/rules/ad-probe-resilience.mdc
+++ b/.cursor/rules/ad-probe-resilience.mdc
@@ -1,0 +1,45 @@
+---
+alwaysApply: true
+---
+
+# Active Directory Probe Resilience and Ambiguity Doctrine
+
+AD probes are resilient, read-only discovery paths. AD registration is not proof a device is
+live, reachable, correctly subnetted, physically present, or serial-matched. Do not treat one AD
+method as authoritative by itself.
+
+When a sprint touches AD discovery, subnet discovery, Cybernet targeting, registered-device
+inventory, hostname matching, or AD-derived manifests, implement or verify this fallback ladder:
+
+1. RSAT / ActiveDirectory module (`Get-ADComputer`-style lookup).
+2. LDAP / DirectorySearcher / ADSI read-only lookup when RSAT is missing.
+3. Domain/DC discovery before blaming the query; failure is environment-blocked, not "not found".
+4. DNS enrichment (forward; reverse only when in scope); DNS mismatch is classified separately.
+5. Approved manifest fallback (exported AD list / CSV) marked imported/static, not live AD proof.
+6. No-AD fallback: emit a clear operator instruction naming the exact missing evidence/file.
+
+Classify ambiguity instead of collapsing to pass/fail. Use these states:
+
+```text
+AD_CONFIRMED  AD_OBJECT_FOUND_DNS_FOUND  AD_OBJECT_FOUND_DNS_MISSING  AD_OBJECT_FOUND_DNS_MISMATCH
+AD_OBJECT_FOUND_STALE  AD_OBJECT_FOUND_DISABLED  AD_OBJECT_FOUND_WRONG_OU  AD_DUPLICATE_CANDIDATES
+AD_NOT_FOUND  AD_QUERY_BLOCKED  DOMAIN_CONTEXT_UNKNOWN  DOMAIN_CONTROLLER_UNREACHABLE
+PERMISSION_BLOCKED  IMPORTED_STATIC_EVIDENCE  NOT_AD_VERIFIED  NEEDS_OPERATOR_REVIEW
+```
+
+Grey-area rules: AD presence is not reachability; a reachable IP is not AD registration; a DNS
+match is not serial identity; serial proof needs a separate privileged inventory source; stale
+objects are not active targets without review; duplicates/aliases surface as
+`NEEDS_OPERATOR_REVIEW`; "not found" must be distinguished from blocked/domain-unavailable/permission.
+
+Private logging means local, repo-ignored operator evidence for clarity and reproducibility. It
+never means hiding activity, suppressing telemetry, clearing logs, or evading monitoring. Write
+diagnostics only to ignored paths (`logs/`, `tmp/`, `survey/output/`, `evidence/`). Never commit
+live AD exports, host/serial lists, credentials, or tokens. Final reports summarize counts and
+classifications, not live directory contents, and must emit an `AD PROBE STATE SUMMARY`.
+
+If no real domain runtime is available, do not pretend AD validation ran: use fixtures/mocks,
+classify live validation as blocked by runtime access, and emit the exact operator command or
+evidence file needed for future authorized validation.
+
+Canonical reference: `docs/AD_PROBE_RESILIENCE.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ data/updated/*
 !survey/fixtures/ad_evidence_manifest.sample.csv
 !survey/fixtures/ad_network_evidence.sample.csv
 !survey/fixtures/ad_live_serial.sample.csv
+!survey/fixtures/ad_probe_states.sample.csv
 !dashboard/samples/*.csv
 *.zip
 !**/.gitkeep

--- a/Tests/survey/test_ad_probe_resilience_contracts.py
+++ b/Tests/survey/test_ad_probe_resilience_contracts.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Offline contract tests for the AD probe resilience and ambiguity doctrine.
+
+These tests are network-free and domain-free. They validate the doctrine
+artifacts (rule, canonical doc, synthetic fixture) rather than executing a live
+AD query. Live AD validation requires an authorized domain runtime and is
+classified as blocked-by-runtime-access; see docs/AD_PROBE_RESILIENCE.md.
+
+The tests prove:
+- the required AD state taxonomy is fully documented and fully exercised by the
+  synthetic fixture (ambiguous states are classified, not silently dropped),
+- the documented fallback ladder and AD PROBE STATE SUMMARY template exist,
+- the synthetic fixture contains no obvious live/private values (no committed
+  live evidence, no credentials/tokens).
+"""
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "docs" / "AD_PROBE_RESILIENCE.md"
+RULE = REPO_ROOT / ".cursor" / "rules" / "ad-probe-resilience.mdc"
+FIXTURE = REPO_ROOT / "survey" / "fixtures" / "ad_probe_states.sample.csv"
+
+REQUIRED_STATES = [
+    "AD_CONFIRMED",
+    "AD_OBJECT_FOUND_DNS_FOUND",
+    "AD_OBJECT_FOUND_DNS_MISSING",
+    "AD_OBJECT_FOUND_DNS_MISMATCH",
+    "AD_OBJECT_FOUND_STALE",
+    "AD_OBJECT_FOUND_DISABLED",
+    "AD_OBJECT_FOUND_WRONG_OU",
+    "AD_DUPLICATE_CANDIDATES",
+    "AD_NOT_FOUND",
+    "AD_QUERY_BLOCKED",
+    "DOMAIN_CONTEXT_UNKNOWN",
+    "DOMAIN_CONTROLLER_UNREACHABLE",
+    "PERMISSION_BLOCKED",
+    "IMPORTED_STATIC_EVIDENCE",
+    "NOT_AD_VERIFIED",
+    "NEEDS_OPERATOR_REVIEW",
+]
+
+REQUIRED_SUMMARY_FIELDS = [
+    "Query mode used:",
+    "Fallback mode used:",
+    "Domain context:",
+    "Domain controller status:",
+    "Permission status:",
+    "Input target count:",
+    "AD objects found:",
+    "DNS enriched:",
+    "Stale objects:",
+    "Disabled objects:",
+    "Duplicate candidates:",
+    "Not found:",
+    "Blocked / unknown:",
+    "Needs operator review:",
+    "Local ignored log path:",
+    "Evidence committed:",
+]
+
+REQUIRED_LADDER_TERMS = [
+    "RSAT",
+    "LDAP",
+    "Domain",
+    "DNS enrichment",
+    "manifest fallback",
+    "No-AD fallback",
+]
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"Missing required artifact: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_doc_and_rule_exist() -> None:
+    assert DOC.exists(), "docs/AD_PROBE_RESILIENCE.md must exist"
+    assert RULE.exists(), ".cursor/rules/ad-probe-resilience.mdc must exist"
+    rule_text = _read(RULE)
+    assert "alwaysApply: true" in rule_text, "Rule must be always-applied"
+    assert "docs/AD_PROBE_RESILIENCE.md" in rule_text, "Rule must cite canonical doc"
+
+
+def test_doc_documents_every_required_state() -> None:
+    doc = _read(DOC)
+    missing = [s for s in REQUIRED_STATES if s not in doc]
+    assert not missing, f"Doc missing required AD states: {missing}"
+
+
+def test_doc_documents_fallback_ladder_and_summary() -> None:
+    doc = _read(DOC)
+    missing_terms = [t for t in REQUIRED_LADDER_TERMS if t not in doc]
+    assert not missing_terms, f"Doc missing fallback ladder terms: {missing_terms}"
+    assert "AD PROBE STATE SUMMARY:" in doc, "Doc must include the state summary template"
+    missing_fields = [f for f in REQUIRED_SUMMARY_FIELDS if f not in doc]
+    assert not missing_fields, f"Doc missing summary fields: {missing_fields}"
+
+
+def test_doc_states_live_validation_is_blocked_by_runtime() -> None:
+    doc = _read(DOC)
+    assert "blocked by runtime access" in doc, (
+        "Doc must classify live AD validation as blocked by runtime access, "
+        "not pretend a domain run occurred"
+    )
+    assert "sas-ad-identity-export.ps1" in doc, (
+        "Doc must name the exact operator command/file for future authorized validation"
+    )
+
+
+def test_fixture_exercises_every_required_state() -> None:
+    with FIXTURE.open(newline="", encoding="utf-8-sig") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows, "Fixture must contain rows"
+    assert "ADState" in rows[0], "Fixture must have an ADState column"
+    seen = {row["ADState"].strip() for row in rows}
+    missing = [s for s in REQUIRED_STATES if s not in seen]
+    assert not missing, f"Fixture does not exercise states: {missing}"
+    unknown = [s for s in seen if s not in REQUIRED_STATES]
+    assert not unknown, f"Fixture has undocumented states: {unknown}"
+
+
+def test_fixture_uses_only_synthetic_identifiers() -> None:
+    """Guard against committing live evidence, credentials, or tokens."""
+    text = _read(FIXTURE)
+    with FIXTURE.open(newline="", encoding="utf-8-sig") as handle:
+        rows = list(csv.DictReader(handle))
+
+    for row in rows:
+        target = row["Target"].strip()
+        assert re.fullmatch(r"(CYBTEST|WNH000TEST)\d+", target), (
+            f"Non-synthetic target identifier in fixture: {target!r}"
+        )
+
+    # DNS hostnames must stay inside the synthetic sample domain.
+    for row in rows:
+        dns = row.get("DNSHostName", "").strip()
+        if dns:
+            for name in re.split(r"[;\s]+", dns):
+                if name:
+                    assert name.endswith(".sample.local"), (
+                        f"Non-synthetic DNS name in fixture: {name!r}"
+                    )
+
+    lowered = text.lower()
+    forbidden = ["password", "secret", "token", "apikey", "api_key", "bearer", "northwell"]
+    hits = [needle for needle in forbidden if needle in lowered]
+    assert not hits, f"Fixture appears to contain sensitive values: {hits}"
+
+
+if __name__ == "__main__":
+    test_doc_and_rule_exist()
+    test_doc_documents_every_required_state()
+    test_doc_documents_fallback_ladder_and_summary()
+    test_doc_states_live_validation_is_blocked_by_runtime()
+    test_fixture_exercises_every_required_state()
+    test_fixture_uses_only_synthetic_identifiers()
+    print("offline AD probe resilience contract tests passed")

--- a/docs/AD_CYBERNET_EXPORT_CONTRACT.md
+++ b/docs/AD_CYBERNET_EXPORT_CONTRACT.md
@@ -88,3 +88,8 @@ When AD and supplemental evidence disagree:
 ## Dashboard ingestion
 
 Drop `ad_registered_normalized.csv`, `ad_evidence_matches.csv`, or bucket CSVs into the dashboard. Files are detected as parser type `ad-registered-population`.
+
+## Related documents
+
+- [AD_PROBE_RESILIENCE.md](AD_PROBE_RESILIENCE.md) — resilient AD probe fallback ladder, ambiguity classifications, and the imported/static evidence rules that govern how this export contract is consumed when live AD is blocked.
+- [AD_REGISTERED_POPULATION.md](AD_REGISTERED_POPULATION.md) — AD as population authority.

--- a/docs/AD_PROBE_RESILIENCE.md
+++ b/docs/AD_PROBE_RESILIENCE.md
@@ -1,0 +1,201 @@
+# Active Directory Probe Resilience and Ambiguity Doctrine
+
+Active Directory probes in SysAdminSuite are **resilient, read-only discovery paths** with explicit
+fallback mechanisms, local operator-side evidence, and clear state classification.
+
+AD is a **registration and directory source**. It is not proof that a device is currently live,
+reachable, correctly subnetted, physically present, or matched to a serial number. No single AD
+method is authoritative by itself.
+
+This doctrine gives the AD side the same operator-clarity guarantee as the dashboard Back/Stop
+controls: the operator must never be trapped in confusion. AD results must say whether a machine is
+**registered, reachable, stale, blocked, ambiguous, imported, or simply not proven**.
+
+## When this applies
+
+Any sprint that touches:
+
+- AD discovery or live AD queries
+- subnet discovery or Cybernet targeting
+- registered-device inventory
+- hostname matching or bounded hostname-variant expansion
+- AD-derived manifests
+
+must implement or verify the fallback ladder and the state classifications below.
+
+## Required fallback ladder
+
+```mermaid
+flowchart TD
+  rsat["1. RSAT / ActiveDirectory module"]
+  ldap["2. LDAP / DirectorySearcher / ADSI (read-only)"]
+  domain["3. Domain / DC discovery"]
+  dns["4. DNS enrichment (forward; reverse if in scope)"]
+  manifest["5. Approved manifest fallback (imported/static)"]
+  noad["6. No-AD fallback (operator instruction)"]
+  rsat -->|module missing| ldap
+  ldap -->|no directory context| domain
+  domain -->|"context ok"| dns
+  domain -->|"context fails"| noad
+  dns --> manifest
+  manifest -->|no approved list| noad
+```
+
+1. **Preferred AD query path** — RSAT / ActiveDirectory module when available
+   (`Get-ADComputer`-style computer-object lookup).
+2. **Secondary AD query path** — LDAP / DirectorySearcher / ADSI lookup when RSAT is missing. Must
+   remain read-only.
+3. **Domain/controller discovery path** — detect domain context and a reachable domain controller
+   before blaming the query. If domain discovery fails, classify as **environment-blocked**, not
+   "no devices found".
+4. **DNS enrichment path** — forward DNS lookup for AD hostnames when authorized; reverse lookup
+   only when needed and in scope. A DNS mismatch is classified **separately** from AD absence.
+5. **Approved manifest fallback** — if live AD access is blocked, accept an approved exported AD
+   list, CSV, or operator-provided target manifest. Mark it **imported/static evidence**, not live
+   AD proof.
+6. **No-AD fallback** — if AD access is unavailable, generate a clear operator instruction
+   describing exactly what evidence is missing and what file/output would unblock the workflow.
+
+## Required AD state classifications
+
+AD probe outputs classify ambiguity instead of collapsing it into pass/fail:
+
+| State | Meaning |
+|---|---|
+| `AD_CONFIRMED` | AD object found and corroborated (e.g. DNS + reachability/identity agree) |
+| `AD_OBJECT_FOUND_DNS_FOUND` | AD object found, forward DNS resolves |
+| `AD_OBJECT_FOUND_DNS_MISSING` | AD object found, no DNS record |
+| `AD_OBJECT_FOUND_DNS_MISMATCH` | AD object found, DNS resolves to a conflicting name/address |
+| `AD_OBJECT_FOUND_STALE` | AD object found but last-logon/password age exceeds staleness threshold |
+| `AD_OBJECT_FOUND_DISABLED` | AD object found but the computer account is disabled |
+| `AD_OBJECT_FOUND_WRONG_OU` | AD object found in an unexpected / forbidden OU |
+| `AD_DUPLICATE_CANDIDATES` | Multiple candidate objects match; no single authoritative record |
+| `AD_NOT_FOUND` | Query ran successfully, no matching object |
+| `AD_QUERY_BLOCKED` | Query path failed (module/tooling error), distinct from "not found" |
+| `DOMAIN_CONTEXT_UNKNOWN` | Domain context could not be determined |
+| `DOMAIN_CONTROLLER_UNREACHABLE` | Domain known, no DC reachable |
+| `PERMISSION_BLOCKED` | Access denied / insufficient rights |
+| `IMPORTED_STATIC_EVIDENCE` | Result came from an approved exported list, not live AD |
+| `NOT_AD_VERIFIED` | Reachability/identity exists but AD registration is unproven |
+| `NEEDS_OPERATOR_REVIEW` | Ambiguous/duplicate/conflicting; requires human reconciliation |
+
+## Grey-area handling
+
+- A hostname found in AD is **not** proof of reachability.
+- A reachable IP is **not** proof of AD registration.
+- A DNS match is **not** proof of serial identity.
+- A serial match usually requires a **separate** inventory source: endpoint WMI/CIM, SCCM, MDM,
+  vendor inventory, or operator evidence.
+- A stale AD object must **not** be treated as an active deployment target without review.
+- Multiple matching names, prefixes, aliases, or duplicate candidates surface as
+  `NEEDS_OPERATOR_REVIEW`.
+- Missing AD results must distinguish `AD_NOT_FOUND` from `AD_QUERY_BLOCKED`,
+  `DOMAIN_CONTROLLER_UNREACHABLE` / `DOMAIN_CONTEXT_UNKNOWN`, and `PERMISSION_BLOCKED`.
+
+## Private / local logging behavior
+
+Private logging means **local, operator-side, repo-ignored** diagnostic evidence for clarity and
+reproducibility. It must **not** mean hiding activity, suppressing telemetry, clearing logs,
+bypassing endpoint tools, or evading organizational monitoring.
+
+- Write local diagnostic logs only to approved ignored paths (`logs/`, `tmp/`, `survey/output/`,
+  `evidence/`, or another repo-ignored evidence folder).
+- Never commit live AD exports, domain inventory, host lists, serial lists, credentials, tokens, or
+  operational evidence.
+- Include timestamps, query mode used, fallback path used, domain/DC discovery status, record
+  counts, and classification counts.
+- Redact or minimize sensitive values in summaries where possible.
+- Preserve enough local detail for the operator to understand why a device is classified as found,
+  missing, stale, blocked, ambiguous, or imported.
+- Final reports summarize counts and classifications, not live directory contents.
+
+## Required confusion-reduction output
+
+Every AD probe run emits this summary (counts only; no live directory dump):
+
+```text
+AD PROBE STATE SUMMARY:
+- Query mode used:
+- Fallback mode used:
+- Domain context:
+- Domain controller status:
+- Permission status:
+- Input target count:
+- AD objects found:
+- DNS enriched:
+- Stale objects:
+- Disabled objects:
+- Duplicate candidates:
+- Not found:
+- Blocked / unknown:
+- Needs operator review:
+- Local ignored log path:
+- Evidence committed: none, or sanitized fixture only
+```
+
+## Validation contracts
+
+When validating AD probe logic, contracts must prove:
+
+- read-only behavior
+- fallback path selection
+- clear blocked-state classification
+- no committed live evidence
+- no credential capture
+- no scan broadening beyond approved manifests
+- useful local ignored logs are produced or documented
+- ambiguous states are classified instead of silently dropped
+
+If the agent cannot access a real domain runtime, it must **not** pretend AD validation ran. Use
+fixtures/mocks for contract validation, classify live AD validation as **blocked by runtime
+access**, and produce the exact operator command or evidence file needed for a future authorized
+validation.
+
+### Offline contract coverage (this repo)
+
+- Fixture: [`survey/fixtures/ad_probe_states.sample.csv`](../survey/fixtures/ad_probe_states.sample.csv)
+  — synthetic `CYBTEST*` / `WNH000TEST*` rows enumerating every required state.
+- Test: [`tests/survey/test_ad_probe_resilience_contracts.py`](../tests/survey/test_ad_probe_resilience_contracts.py)
+  — asserts taxonomy coverage, the documented fallback ladder, the `AD PROBE STATE SUMMARY`
+  template, and the absence of obvious live/private values.
+- Runner: [`tests/survey/run_offline_survey_tests.sh`](../tests/survey/run_offline_survey_tests.sh).
+
+### Live validation boundary
+
+Live AD validation requires an authorized domain runtime and is **out of scope for offline CI**.
+The exact future operator command for authorized validation:
+
+```bash
+pwsh survey/sas-ad-identity-export.ps1 \
+  -Manifest logs/targets/approved_manifest.csv \
+  -Output survey/output/ad_identity_evidence.csv
+```
+
+That command, run on a domain-joined or RSAT-equipped operator workstation against an approved
+manifest, produces the live evidence CSV. Until then, live AD validation is classified
+`blocked by runtime access`.
+
+## Code migration checklist (future authorized sprint)
+
+The live helper [`survey/sas-ad-identity-export.ps1`](../survey/sas-ad-identity-export.ps1) is the
+integration point. It currently emits a smaller status set (`ad_object_found`, `ad_no_match`,
+`ad_multiple_matches`, `ad_query_failed`, `ad_probe_limited`, `ad_probe_unavailable`). A future
+authorized sprint should:
+
+1. Add explicit domain/DC discovery before query, emitting `DOMAIN_CONTEXT_UNKNOWN` /
+   `DOMAIN_CONTROLLER_UNREACHABLE` instead of generic failure.
+2. Replace broad wildcard LDAP (`name=*$id*`) with bounded candidate lookups per
+   [`CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md`](CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md).
+3. Map internal statuses to the classification table above (DNS missing/mismatch, stale, disabled,
+   wrong OU, permission blocked, duplicate candidates).
+4. Add a DNS enrichment pass that classifies `AD_OBJECT_FOUND_DNS_MISSING` /
+   `AD_OBJECT_FOUND_DNS_MISMATCH` separately from AD absence.
+5. Accept an approved exported list and tag rows `IMPORTED_STATIC_EVIDENCE`.
+6. Emit the `AD PROBE STATE SUMMARY` and write diagnostics only to ignored paths.
+
+## Related documents
+
+- [AD_REGISTERED_POPULATION.md](AD_REGISTERED_POPULATION.md) — AD as population authority
+- [AD_CYBERNET_EXPORT_CONTRACT.md](AD_CYBERNET_EXPORT_CONTRACT.md) — offline export CSV contract
+- [CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md](CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md) — bounded variant discovery
+- [CYBERNET_EVIDENCE_CORRELATION.md](CYBERNET_EVIDENCE_CORRELATION.md) — multi-source evidence merge

--- a/docs/AD_REGISTERED_POPULATION.md
+++ b/docs/AD_REGISTERED_POPULATION.md
@@ -84,6 +84,7 @@ Do not invert this order. Build manifests from AD reconciliation first, then att
 
 ## Related documents
 
+- [AD_PROBE_RESILIENCE.md](AD_PROBE_RESILIENCE.md) — resilient AD probe fallback ladder and ambiguity classifications
 - [AD_CYBERNET_EXPORT_CONTRACT.md](AD_CYBERNET_EXPORT_CONTRACT.md) — CSV export contract for AD computer inventory
 - [CYBERNET_EVIDENCE_CORRELATION.md](CYBERNET_EVIDENCE_CORRELATION.md) — multi-source evidence merge (downstream)
 - [START-HERE-CYBERNET-NEURON-SURVEY.md](../START-HERE-CYBERNET-NEURON-SURVEY.md) — field workflow entry point

--- a/docs/CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md
+++ b/docs/CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md
@@ -219,6 +219,10 @@ Hostname variant expansion and subnet location inference are complementary read-
 - AD remains the registered population authority per
   [`AD_REGISTERED_POPULATION.md`](AD_REGISTERED_POPULATION.md). Variant matches are candidate
   discovery, not population membership.
+- AD probe resilience, the fallback ladder, and the ambiguity state classifications that bounded
+  variant discovery feeds into are governed by
+  [`AD_PROBE_RESILIENCE.md`](AD_PROBE_RESILIENCE.md). A variant match is never serial-confirmed and
+  must be classified (e.g. `NEEDS_OPERATOR_REVIEW`) rather than collapsed to pass/fail.
 - Reachability validation stays governed by
   [`LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md) and the Naabu/Nmap profiles.
 - Manifest ingestion and identity transport context live in

--- a/survey/fixtures/ad_probe_states.sample.csv
+++ b/survey/fixtures/ad_probe_states.sample.csv
@@ -1,0 +1,17 @@
+Target,ADState,QueryMode,FallbackMode,DNSHostName,Enabled,LastLogonDate,ComputerOU,EvidenceSource,NextAction,Notes
+CYBTEST001,AD_CONFIRMED,active_directory_module,none,CYBTEST001.sample.local,True,2026-06-20,OU=Cybernet;Managed_Shared,live_ad,proceed,Synthetic confirmed object with DNS and recent logon
+CYBTEST002,AD_OBJECT_FOUND_DNS_FOUND,active_directory_module,none,CYBTEST002.sample.local,True,2026-06-18,OU=Cybernet;Managed_Shared,live_ad,enrich_reachability,Found with forward DNS
+CYBTEST003,AD_OBJECT_FOUND_DNS_MISSING,active_directory_module,none,,True,2026-06-17,OU=Cybernet;Managed_Shared,live_ad,needs_dns_review,Object found but no DNS record
+CYBTEST004,AD_OBJECT_FOUND_DNS_MISMATCH,ldap_directorysearcher,rsat_missing,CYBTEST004-alt.sample.local,True,2026-06-16,OU=Cybernet;Managed_Shared,live_ad,needs_operator_review,DNS resolves to conflicting name
+WNH000TEST001,AD_OBJECT_FOUND_STALE,active_directory_module,none,WNH000TEST001.sample.local,True,2024-01-01,OU=Neuron;Managed_Shared,live_ad,hold_for_review,Last logon exceeds staleness threshold
+CYBTEST005,AD_OBJECT_FOUND_DISABLED,active_directory_module,none,CYBTEST005.sample.local,False,2025-02-02,OU=Cybernet;Managed_Shared,live_ad,hold_for_review,Computer account disabled
+CYBTEST006,AD_OBJECT_FOUND_WRONG_OU,active_directory_module,none,CYBTEST006.sample.local,True,2026-06-10,OU=Workstations;Legacy,live_ad,needs_operator_review,Object in forbidden legacy OU
+CYBTEST007,AD_DUPLICATE_CANDIDATES,ldap_directorysearcher,rsat_missing,CYBTEST007-a.sample.local;CYBTEST007-b.sample.local,True,2026-06-09,OU=Cybernet;Managed_Shared,live_ad,needs_operator_review,Multiple candidate objects matched
+CYBTEST008,AD_NOT_FOUND,active_directory_module,none,,,,,live_ad,manifest_data_review,Query ran successfully no matching object
+CYBTEST009,AD_QUERY_BLOCKED,active_directory_module,none,,,,,live_ad,retry_or_secondary_path,Query path raised an error distinct from not found
+CYBTEST010,DOMAIN_CONTEXT_UNKNOWN,domain_discovery,environment_check,,,,,environment,classify_environment_blocked,Domain context could not be determined
+CYBTEST011,DOMAIN_CONTROLLER_UNREACHABLE,domain_discovery,environment_check,,,,,environment,classify_environment_blocked,Domain known but no DC reachable
+CYBTEST012,PERMISSION_BLOCKED,ldap_directorysearcher,rsat_missing,,,,,live_ad,escalate_permissions,Access denied insufficient rights
+CYBTEST013,IMPORTED_STATIC_EVIDENCE,imported_manifest,live_ad_blocked,CYBTEST013.sample.local,True,2026-05-01,OU=Cybernet;Managed_Shared,approved_export,treat_as_static,From approved exported list not live AD
+CYBTEST014,NOT_AD_VERIFIED,none,no_ad_access,CYBTEST014.sample.local,,,,reachability_only,needs_ad_lookup,Reachable but AD registration unproven
+CYBTEST015,NEEDS_OPERATOR_REVIEW,ldap_directorysearcher,rsat_missing,CYBTEST015.sample.local,True,2026-06-05,OU=Cybernet;Managed_Shared,live_ad,route_to_operator,Ambiguous alias requires human reconciliation

--- a/tests/survey/run_offline_survey_tests.sh
+++ b/tests/survey/run_offline_survey_tests.sh
@@ -3,3 +3,4 @@ set -euo pipefail
 
 python3 tests/survey/test_serial_first_identity.py
 python3 tests/survey/test_cybernet_cleanup_report.py
+python3 tests/survey/test_ad_probe_resilience_contracts.py


### PR DESCRIPTION
## Summary

Adds the **Active Directory probe resilience and ambiguity doctrine** so AD discovery work is guided by a resilient, read-only fallback ladder with explicit state classification, instead of collapsing ambiguous directory results into pass/fail.

- New always-applied rule `.cursor/rules/ad-probe-resilience.mdc` and canonical doc `docs/AD_PROBE_RESILIENCE.md` covering the six-step fallback ladder (RSAT -> LDAP/ADSI -> domain/DC discovery -> DNS enrichment -> approved manifest -> no-AD operator instruction), the required AD state taxonomy, local repo-ignored evidence rules, and the `AD PROBE STATE SUMMARY` output.
- Cross-links from `AD_REGISTERED_POPULATION.md`, `AD_CYBERNET_EXPORT_CONTRACT.md`, and `CYBERNET_HOSTNAME_VARIANT_DOCTRINE.md`.
- Synthetic fixture `survey/fixtures/ad_probe_states.sample.csv` exercising every required state (CYBTEST/WNH000TEST identifiers only).
- Offline contract test `Tests/survey/test_ad_probe_resilience_contracts.py` wired into `tests/survey/run_offline_survey_tests.sh`.

This is doctrine + fixtures + contracts only. It does not migrate the live AD helper `survey/sas-ad-identity-export.ps1`; that is documented as a future authorized sprint. Live AD validation requires a domain runtime and is classified blocked-by-runtime-access, with the exact future operator command recorded.

## Test plan

- [x] `python3 Tests/survey/test_ad_probe_resilience_contracts.py`
- [x] `bash tests/survey/run_offline_survey_tests.sh` (all three offline suites pass)
- [ ] Live AD validation: blocked by runtime access (no authorized domain runtime); future command documented in `docs/AD_PROBE_RESILIENCE.md`.
