### PR TITLE
feat(posture): unify low-noise discipline and legacy deployment gates

### DIFF
--- a/.cursor/rules/operational-posture.mdc
+++ b/.cursor/rules/operational-posture.mdc
@@ -1,0 +1,23 @@
+# Operational Posture
+
+SysAdminSuite applies low-waste posture across survey, dashboard, deployment, and
+cleanup work.
+
+- `Config/operational-posture.json` is the cross-lane posture manifest.
+- `docs/OPERATIONAL_POSTURE.md` is the human/agent entry point.
+- Survey and dashboard lanes do not write to target boxes. Evidence stays local
+  in ignored paths.
+- Deployment/mapping lanes may mutate targets only when explicitly authorized.
+  They must be legacy-gated and teardown-aware.
+- Preserved PowerShell tools are not deleted. For Northwell Bash-first field
+  work, legacy deployment/mapping tools must require `--allow-legacy`,
+  `-AllowLegacy`, or `SAS_ALLOW_LEGACY_TOOLS=1`.
+- Cleanup means reducing residual operational clutter. Do not frame it as log
+  bypass, stealth, evasion, or hiding activity.
+
+Canonical references:
+
+- `Config/operational-posture.json`
+- `docs/OPERATIONAL_POSTURE.md`
+- `docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md`
+- `docs/LOW_NOISE_SURVEY_DOCTRINE.md`

--- a/.github/workflows/operational-posture.yml
+++ b/.github/workflows/operational-posture.yml
@@ -1,0 +1,59 @@
+name: Operational posture
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths:
+      - 'AGENTS.md'
+      - '.cursor/rules/operational-posture.mdc'
+      - 'Config/operational-posture.json'
+      - 'docs/OPERATIONAL_POSTURE.md'
+      - 'docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md'
+      - 'docs/DEPENDENCIES.md'
+      - 'scripts/sas-legacy-gate.sh'
+      - 'scripts/Invoke-SasLegacyGate.ps1'
+      - 'bash/apps/sas-install-apps.sh'
+      - 'bash/apps/sas-stage-fileshare.sh'
+      - 'mapping/Controllers/Map-Run-Controller.ps1'
+      - 'EnvSetup/Deploy-Shortcuts.ps1'
+      - 'survey/sas-run-naabu-pipeline.sh'
+      - 'survey/sas-cybernet-subnet-survey.sh'
+      - 'Tests/bash/test_operational_posture_contracts.sh'
+      - 'Tests/bash/test_naabu_pipeline_contracts.sh'
+      - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
+      - '.github/workflows/operational-posture.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'AGENTS.md'
+      - '.cursor/rules/operational-posture.mdc'
+      - 'Config/operational-posture.json'
+      - 'docs/OPERATIONAL_POSTURE.md'
+      - 'docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md'
+      - 'docs/DEPENDENCIES.md'
+      - 'scripts/sas-legacy-gate.sh'
+      - 'scripts/Invoke-SasLegacyGate.ps1'
+      - 'bash/apps/sas-install-apps.sh'
+      - 'bash/apps/sas-stage-fileshare.sh'
+      - 'mapping/Controllers/Map-Run-Controller.ps1'
+      - 'EnvSetup/Deploy-Shortcuts.ps1'
+      - 'survey/sas-run-naabu-pipeline.sh'
+      - 'survey/sas-cybernet-subnet-survey.sh'
+      - 'Tests/bash/test_operational_posture_contracts.sh'
+      - 'Tests/bash/test_naabu_pipeline_contracts.sh'
+      - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
+      - '.github/workflows/operational-posture.yml'
+
+jobs:
+  posture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Operational posture contracts
+        shell: bash
+        run: bash Tests/bash/test_operational_posture_contracts.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,30 @@ Agents MUST preserve these rules across docs, scripts, dashboards, generated com
 - Treat `feature/naabu-docs-consolidation` as superseded by current `main` doctrine. Do not
   revive or merge it without explicit user authorization.
 
+## Operational Posture / Legacy Gates
+
+`Config/operational-posture.json` and `docs/OPERATIONAL_POSTURE.md` are the cross-lane posture
+authority for low-waste SysAdminSuite work.
+
+Agents MUST preserve these boundaries:
+
+- Survey and dashboard probes are read-only toward target machines. They write evidence locally only.
+- Deployment, mapping, staging, and shortcut tools are authorized mutation lanes, not survey lanes.
+- Preserved legacy deployment/mapping tools must be disabled by default and require an explicit
+  legacy gate such as `--allow-legacy`, `-AllowLegacy`, or `SAS_ALLOW_LEGACY_TOOLS=1`.
+- Legacy enablement does not expand target scope, grant credentials, or remove the need for
+  approved deployment intent.
+- Deployment payload scripts, launchers, stop/status files, scheduled tasks, and transient staging
+  folders require teardown unless they are documented as intentional retained payloads.
+- Cleanup means reducing residual operational clutter. Do not describe cleanup as bypassing logs,
+  suppressing telemetry, hiding activity, stealth, or evasion.
+
+Canonical references:
+
+- `Config/operational-posture.json`
+- `docs/OPERATIONAL_POSTURE.md`
+- `docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md`
+
 ## WAB Test Evidence Guardrail
 
 When the user reports that SysAdminSuite is `running` on the WAB path, do not treat that as full validation.

--- a/Config/operational-posture.json
+++ b/Config/operational-posture.json
@@ -1,0 +1,110 @@
+{
+  "schema": 1,
+  "doctrine": "Low-waste, low-noise operation: scoped inputs, transparent operator intent, local-only evidence, no target-side artifacts for survey lanes, and teardown-required payloads for authorized deployment lanes.",
+  "defaults": {
+    "legacyToolsEnabled": false,
+    "legacyEnableEnv": "SAS_ALLOW_LEGACY_TOOLS",
+    "legacyEnableFlag": "--allow-legacy",
+    "legacyDisabledClassification": "LEGACY_TOOLS_DISABLED",
+    "naabuMaxRate": 3000
+  },
+  "lanes": [
+    {
+      "id": "survey",
+      "description": "Read-only survey and reachability validation from approved manifests.",
+      "targetMutation": "never",
+      "evidenceLocalOnly": true,
+      "teardownRequired": false,
+      "defaultEnabled": true,
+      "outputRoots": ["logs/nmap/", "logs/targets/", "survey/output/", "survey/artifacts/"]
+    },
+    {
+      "id": "dashboard",
+      "description": "Local dashboard and relay probes run from the operator machine.",
+      "targetMutation": "never",
+      "evidenceLocalOnly": true,
+      "teardownRequired": false,
+      "defaultEnabled": true,
+      "outputRoots": ["dashboard/toolbox-status.json", "survey/output/", "logs/nmap/"]
+    },
+    {
+      "id": "deployment",
+      "description": "Authorized deployment, mapping, and staging workflows that may mutate targets.",
+      "targetMutation": "authorized-only",
+      "evidenceLocalOnly": true,
+      "teardownRequired": true,
+      "defaultEnabled": false,
+      "legacyGateRequired": true,
+      "outputRoots": ["bash/apps/output/", "SysAdminSuite-Session-*"]
+    }
+  ],
+  "principles": [
+    {
+      "id": "low_noise_survey",
+      "summary": "Use approved target manifests, key ports, -silent, -ec, and JSON for parser-facing evidence."
+    },
+    {
+      "id": "no_target_evidence",
+      "summary": "Survey evidence is written only to local ignored paths; target workstations receive no logs, scripts, or agents."
+    },
+    {
+      "id": "cdn_exclude",
+      "summary": "Use Naabu -ec on reachability profiles to avoid wasting probes on CDN/cloud firewall edges."
+    },
+    {
+      "id": "silent_output",
+      "summary": "Use silent machine-readable tool output in pipelines to avoid logos and banner noise."
+    },
+    {
+      "id": "ad_population_first",
+      "summary": "AD-derived or approved manifests define population; packet probes validate reachability only."
+    },
+    {
+      "id": "deployment_teardown",
+      "summary": "Authorized deployment payloads, scheduled tasks, and transient staging must be removed or explicitly documented as retained."
+    },
+    {
+      "id": "legacy_gate",
+      "summary": "Legacy deployment/mapping tools are preserved but disabled by default until the operator opts in."
+    }
+  ],
+  "legacyTools": [
+    {
+      "id": "map_run_controller",
+      "path": "mapping/Controllers/Map-Run-Controller.ps1",
+      "lane": "deployment",
+      "gate": "powershell",
+      "teardownRequired": true
+    },
+    {
+      "id": "app_install_remote",
+      "path": "bash/apps/sas-install-apps.sh",
+      "lane": "deployment",
+      "gate": "bash",
+      "teardownRequired": true
+    },
+    {
+      "id": "app_stage_fileshare",
+      "path": "bash/apps/sas-stage-fileshare.sh",
+      "lane": "deployment",
+      "gate": "bash",
+      "teardownRequired": true,
+      "retentionMode": "operator-selected"
+    },
+    {
+      "id": "deploy_shortcuts",
+      "path": "EnvSetup/Deploy-Shortcuts.ps1",
+      "lane": "deployment",
+      "gate": "powershell",
+      "teardownRequired": false,
+      "retentionMode": "intentional-shortcut-deployment"
+    },
+    {
+      "id": "mapping_archive",
+      "path": "mapping/Archive",
+      "lane": "deployment",
+      "gate": "archive-block",
+      "teardownRequired": true
+    }
+  ]
+}

--- a/EnvSetup/Deploy-Shortcuts.ps1
+++ b/EnvSetup/Deploy-Shortcuts.ps1
@@ -26,10 +26,19 @@ param(
   [int]   $EndNum    = 164,
   [string[]]$ComputerList,  # optional explicit list; overrides prefix/range
   [string]$SmbUser    = '',   # optional; else config, env DEPLOY_SHORTCUTS_SMB_USER, or legacy default
-  [switch]$WhatIf
+  [switch]$WhatIf,
+  [switch]$AllowLegacy
 )
 
 Set-StrictMode -Version Latest
+$legacyGatePath = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\Invoke-SasLegacyGate.ps1'
+if (-not (Test-Path -LiteralPath $legacyGatePath)) {
+  throw "Legacy gate helper not found: $legacyGatePath"
+}
+. $legacyGatePath
+if (-not (Invoke-SasLegacyGate -ToolPath 'EnvSetup/Deploy-Shortcuts.ps1' -AllowLegacy:$AllowLegacy)) {
+  exit 42
+}
 
 $configPath = Join-Path $PSScriptRoot 'Deploy-Shortcuts.config.psd1'
 $cfg = @{}

--- a/Tests/bash/test_naabu_pipeline_contracts.sh
+++ b/Tests/bash/test_naabu_pipeline_contracts.sh
@@ -40,6 +40,12 @@ grep -q '\-silent' "$PLANNED" || { echo 'expected -silent in default command'; e
 grep -q '\-json' "$PLANNED" || { echo 'expected -json in default command'; exit 1; }
 grep -q '80,443,135,445,3389,5985,5986' "$PLANNED" || { echo 'expected full Cybernet key ports in default'; cat "$PLANNED"; exit 1; }
 
+if bash "$PIPE" --site testsite \
+  --list "$FIX/targets.sample.txt" --out "$OUT.json" --dry-run --rate 3001 2>/dev/null; then
+  echo 'expected rate above operational posture cap to fail'
+  exit 1
+fi
+
 # Pipe profile (keyports_cybernet_pipe) is txt stream: -silent -ec, full key ports, NO -json
 : > "$PLANNED"
 bash "$PIPE" --site testsite --profile keyports_cybernet_pipe \

--- a/Tests/bash/test_operational_posture_contracts.sh
+++ b/Tests/bash/test_operational_posture_contracts.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail() {
+  printf 'test_operational_posture_contracts: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+POSTURE="Config/operational-posture.json"
+BASH_GATE="scripts/sas-legacy-gate.sh"
+PS_GATE="scripts/Invoke-SasLegacyGate.ps1"
+
+for file in "$POSTURE" "$BASH_GATE" "$PS_GATE" docs/OPERATIONAL_POSTURE.md docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md; do
+  [[ -f "$file" ]] || fail "missing posture file: $file"
+done
+
+bash -n "$BASH_GATE"
+bash -n bash/apps/sas-install-apps.sh
+bash -n bash/apps/sas-stage-fileshare.sh
+
+python3 - "$POSTURE" <<'PY' || exit 1
+import json
+import os
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+
+defaults = data.get("defaults", {})
+assert defaults.get("legacyToolsEnabled") is False
+assert defaults.get("legacyEnableEnv") == "SAS_ALLOW_LEGACY_TOOLS"
+assert defaults.get("legacyDisabledClassification") == "LEGACY_TOOLS_DISABLED"
+assert int(defaults.get("naabuMaxRate")) == 3000
+
+lanes = {lane["id"]: lane for lane in data.get("lanes", [])}
+assert lanes["survey"]["targetMutation"] == "never"
+assert lanes["dashboard"]["targetMutation"] == "never"
+assert lanes["deployment"]["targetMutation"] == "authorized-only"
+assert lanes["deployment"]["legacyGateRequired"] is True
+
+legacy = data.get("legacyTools", [])
+assert legacy, "legacyTools must not be empty"
+for tool in legacy:
+    path = tool["path"]
+    assert os.path.exists(path), f"legacy path missing: {path}"
+    assert tool["lane"] == "deployment", f"legacy tool outside deployment lane: {path}"
+PY
+
+if bash "$BASH_GATE" --tool bash/apps/sas-install-apps.sh 2>"$ROOT/.legacy-gate.err"; then
+  rm -f "$ROOT/.legacy-gate.err"
+  fail "legacy gate must fail closed by default"
+fi
+grep -q 'LEGACY_TOOLS_DISABLED' "$ROOT/.legacy-gate.err" || fail "gate output missing disabled classification"
+rm -f "$ROOT/.legacy-gate.err"
+
+bash "$BASH_GATE" --tool bash/apps/sas-install-apps.sh --allow-legacy >/dev/null 2>&1 \
+  || fail "legacy gate must allow explicit --allow-legacy"
+
+grep -q 'bash scripts/sas-legacy-gate.sh' bash/apps/sas-install-apps.sh \
+  || fail "sas-install-apps.sh must call bash legacy gate"
+grep -q 'bash scripts/sas-legacy-gate.sh' bash/apps/sas-stage-fileshare.sh \
+  || fail "sas-stage-fileshare.sh must call bash legacy gate"
+grep -q 'Invoke-SasLegacyGate' mapping/Controllers/Map-Run-Controller.ps1 \
+  || fail "Map-Run-Controller.ps1 must call PowerShell legacy gate"
+grep -q 'Invoke-SasLegacyGate' EnvSetup/Deploy-Shortcuts.ps1 \
+  || fail "Deploy-Shortcuts.ps1 must call PowerShell legacy gate"
+
+grep -q 'Invoke-RemoteTransientCleanup' mapping/Controllers/Map-Run-Controller.ps1 \
+  || fail "Map-Run-Controller.ps1 must include transient cleanup"
+grep -q '\$adminScript' mapping/Controllers/Map-Run-Controller.ps1 \
+  || fail "Map-Run-Controller.ps1 cleanup must account for copied payload script"
+grep -q -- '--no-teardown' bash/apps/sas-install-apps.sh \
+  || fail "sas-install-apps.sh must expose --no-teardown debug escape"
+grep -q 'Worker self-teardown' bash/apps/sas-install-apps.sh \
+  || fail "sas-install-apps.sh must document worker self-teardown"
+grep -q -- '--teardown-after' bash/apps/sas-stage-fileshare.sh \
+  || fail "sas-stage-fileshare.sh must expose transient staging teardown"
+
+if grep -q 'sas-legacy-gate' survey/sas-run-naabu-pipeline.sh survey/sas-run-packet-probe.sh; then
+  fail "survey Naabu wrappers must not be legacy-gated"
+fi
+
+grep -q 'Config/operational-posture.json' AGENTS.md || fail "AGENTS.md missing posture authority"
+grep -q 'docs/OPERATIONAL_POSTURE.md' AGENTS.md || fail "AGENTS.md missing posture doc"
+grep -q 'low-waste' docs/OPERATIONAL_POSTURE.md || fail "posture doc missing low-waste language"
+grep -q 'LEGACY_TOOLS_DISABLED' docs/OPERATIONAL_POSTURE.md || fail "posture doc missing legacy classification"
+grep -q 'not stealth' docs/OPERATIONAL_POSTURE.md || fail "posture doc must reject stealth framing"
+
+grep -q 'dashboard/js/bundle.js' Tests/bash/test_repo_naabu_doctrine_conformance.sh \
+  && fail "Naabu conformance must no longer skip dashboard/js/bundle.js"
+grep -q "'\*.js'" Tests/bash/test_repo_naabu_doctrine_conformance.sh \
+  || fail "Naabu conformance must inspect JavaScript command strings"
+grep -q '3001' Tests/bash/test_naabu_pipeline_contracts.sh \
+  || fail "Naabu pipeline contract must assert rate cap"
+
+echo "test_operational_posture_contracts: PASS"

--- a/Tests/bash/test_repo_naabu_doctrine_conformance.sh
+++ b/Tests/bash/test_repo_naabu_doctrine_conformance.sh
@@ -26,12 +26,6 @@ check_raw_naabu_commands() {
   while IFS=: read -r path line_no text; do
     [[ -n "${path:-}" ]] || continue
 
-    # Generated dashboard bundles may contain copied operator guidance. Source docs/scripts carry
-    # the enforceable command text.
-    case "$path" in
-      dashboard/js/bundle.js) continue ;;
-    esac
-
     if [[ "$text" != *"-silent"* ]]; then
       printf 'missing -silent: %s:%s:%s\n' "$path" "$line_no" "$text" >&2
       bad=1
@@ -43,7 +37,7 @@ check_raw_naabu_commands() {
     fi
   done < <(
     git grep -n -I -E 'naabu[[:space:]]+-(list|host)' -- \
-      '*.md' '*.sh' '*.ps1' '*.psm1' '*.json' '*.go' ':!Config/cybernet-naabu-profiles.json' || true
+      '*.md' '*.sh' '*.ps1' '*.psm1' '*.json' '*.go' '*.js' ':!Config/cybernet-naabu-profiles.json' || true
   )
 
   [[ "$bad" -eq 0 ]] || fail "raw naabu command strings must preserve -silent and -ec"

--- a/bash/apps/sas-install-apps.sh
+++ b/bash/apps/sas-install-apps.sh
@@ -4,6 +4,7 @@
 # For each target: verifies admin-share access, drops a generated PowerShell
 # worker script (sas-install-worker.ps1), then creates and triggers a scheduled
 # task mirroring the pattern in mapping/Controllers/Map-Run-Controller.ps1.
+# Legacy deployment lane: requires --allow-legacy or SAS_ALLOW_LEGACY_TOOLS=1.
 #
 # Usage:
 #   ./bash/apps/sas-install-apps.sh --targets HOST1,HOST2 --list LIST_NAME [options]
@@ -27,6 +28,8 @@ SMB_PASS="${SAS_SMB_PASS:-}"
 SMB_DOMAIN="${SAS_SMB_DOMAIN:-}"
 TIMEOUT=10
 DRY_RUN=0
+ALLOW_LEGACY=0
+NO_TEARDOWN=0
 LOG_DIR="bash/apps/output"
 
 usage() {
@@ -50,6 +53,8 @@ Options:
   --smb-domain DOM    SMB domain (or set SAS_SMB_DOMAIN)
   --timeout SEC       SMB timeout seconds (default: 10)
   --dry-run           Generate worker script and print schtasks commands without executing
+  --allow-legacy      Enable this preserved legacy deployment lane for this run
+  --no-teardown       Debug only: leave transient worker/launcher/task artifacts on targets
   --log-dir PATH      Output log directory (default: bash/apps/output)
   -h, --help          Show help
 
@@ -83,6 +88,8 @@ while [[ $# -gt 0 ]]; do
     --smb-domain)  SMB_DOMAIN="${2:?missing value for --smb-domain}"; shift 2 ;;
     --timeout)     TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
     --dry-run)     DRY_RUN=1; shift ;;
+    --allow-legacy) ALLOW_LEGACY=1; shift ;;
+    --no-teardown) NO_TEARDOWN=1; shift ;;
     --log-dir)     LOG_DIR="${2:?missing value for --log-dir}"; shift 2 ;;
     -h|--help)     usage; exit 0 ;;
     --) shift; break ;;
@@ -90,6 +97,13 @@ while [[ $# -gt 0 ]]; do
     *) fail "Unexpected argument: $1" ;;
   esac
 done
+
+LEGACY_GATE_ARGS=(--tool "bash/apps/sas-install-apps.sh")
+[[ "$ALLOW_LEGACY" -eq 1 ]] && LEGACY_GATE_ARGS+=(--allow-legacy)
+bash scripts/sas-legacy-gate.sh "${LEGACY_GATE_ARGS[@]}" || exit $?
+if [[ "$NO_TEARDOWN" -eq 1 && "$ALLOW_LEGACY" -ne 1 && "${SAS_ALLOW_LEGACY_TOOLS:-0}" != "1" ]]; then
+  fail "--no-teardown requires --allow-legacy or SAS_ALLOW_LEGACY_TOOLS=1"
+fi
 
 [[ -n "$TARGETS_RAW" ]] || fail "--targets is required"
 [[ -n "$LIST_NAME" ]]   || fail "--list is required"
@@ -366,6 +380,30 @@ fi
 
 log "Worker script written: $WORKER_SCRIPT_PATH"
 
+if [[ "$NO_TEARDOWN" -eq 0 ]]; then
+  cat >> "$WORKER_SCRIPT_PATH" <<EOF
+
+# Best-effort teardown of transient SysAdminSuite deployment payloads.
+try {
+  schtasks.exe /Delete /TN "$TASK_NAME" /F | Out-Null
+} catch {
+  Write-Warning "Teardown warning deleting scheduled task: \$($_.Exception.Message)"
+}
+foreach (\$path in @((Join-Path \$PSScriptRoot 'Start-Installer.ps1'), \$PSCommandPath)) {
+  try {
+    if (\$path -and (Test-Path -LiteralPath \$path)) {
+      Remove-Item -LiteralPath \$path -Force -ErrorAction SilentlyContinue
+    }
+  } catch {
+    Write-Warning "Teardown warning removing transient payload \$path: \$($_.Exception.Message)"
+  }
+}
+EOF
+  log "Worker teardown enabled for transient payloads and scheduled task."
+else
+  log "WARN: --no-teardown requested; transient target payloads may remain for debugging."
+fi
+
 # ---------------------------------------------------------------------------
 # SMB helper
 # ---------------------------------------------------------------------------
@@ -438,6 +476,11 @@ for TARGET in "${TARGETS[@]}"; do
       echo "[DRY-RUN] Would copy worker to \\\\${TARGET}\\${SHARE}\\${REMOTE_BASE_SMB}\\sas-install-worker.ps1"
       echo "[DRY-RUN] schtasks /Create /S ${TARGET} /RU SYSTEM /SC ONCE /ST HH:MM /TN ${TASK_NAME} /TR \"${REMOTE_PWSH} -File ${REMOTE_WORKER_REMOTE}\" /RL HIGHEST /F"
       echo "[DRY-RUN] schtasks /Run /S ${TARGET} /TN ${TASK_NAME}"
+      if [[ "$NO_TEARDOWN" -eq 0 ]]; then
+        echo "[DRY-RUN] Worker self-teardown would delete task ${TASK_NAME}, Start-Installer.ps1, and sas-install-worker.ps1"
+      else
+        echo "[DRY-RUN] --no-teardown would leave worker artifacts for debugging"
+      fi
       echo "DRY_RUN_OK"
     elif ! has_cmd smbclient; then
       echo "ERROR: smbclient not found — cannot push to $TARGET"

--- a/bash/apps/sas-stage-fileshare.sh
+++ b/bash/apps/sas-stage-fileshare.sh
@@ -3,6 +3,7 @@
 # Stages installers from the local software repo onto a target host's admin share.
 # Verifies share reachability (mirrors sas-smb-readonly-recon.sh pattern) then
 # copies matching installers into \\TARGET\C$\SoftwareRepo\staged\<LIST_NAME>\.
+# Legacy deployment lane: requires --allow-legacy or SAS_ALLOW_LEGACY_TOOLS=1.
 #
 # Usage:
 #   ./bash/apps/sas-stage-fileshare.sh --target HOSTNAME --list LIST_NAME [options]
@@ -24,6 +25,8 @@ SMB_PASS="${SAS_SMB_PASS:-}"
 SMB_DOMAIN="${SAS_SMB_DOMAIN:-}"
 TIMEOUT=10
 DRY_RUN=0
+ALLOW_LEGACY=0
+TEARDOWN_AFTER=0
 LOG_DIR="bash/apps/output"
 
 usage() {
@@ -44,6 +47,8 @@ Options:
   --smb-domain DOM    SMB domain (or set SAS_SMB_DOMAIN)
   --timeout SEC       SMB timeout seconds (default: 10)
   --dry-run           Print what would be copied without copying
+  --allow-legacy      Enable this preserved legacy deployment lane for this run
+  --teardown-after    Remove the remote staged list directory after this transient run
   --log-dir PATH      Output log directory (default: bash/apps/output)
   -h, --help          Show help
 
@@ -68,6 +73,8 @@ while [[ $# -gt 0 ]]; do
     --smb-domain) SMB_DOMAIN="${2:?missing value for --smb-domain}"; shift 2 ;;
     --timeout)    TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
     --dry-run)    DRY_RUN=1; shift ;;
+    --allow-legacy) ALLOW_LEGACY=1; shift ;;
+    --teardown-after) TEARDOWN_AFTER=1; shift ;;
     --log-dir)    LOG_DIR="${2:?missing value for --log-dir}"; shift 2 ;;
     -h|--help)    usage; exit 0 ;;
     --) shift; break ;;
@@ -75,6 +82,10 @@ while [[ $# -gt 0 ]]; do
     *) fail "Unexpected argument: $1" ;;
   esac
 done
+
+LEGACY_GATE_ARGS=(--tool "bash/apps/sas-stage-fileshare.sh")
+[[ "$ALLOW_LEGACY" -eq 1 ]] && LEGACY_GATE_ARGS+=(--allow-legacy)
+bash scripts/sas-legacy-gate.sh "${LEGACY_GATE_ARGS[@]}" || exit $?
 
 [[ -n "$TARGET" ]]    || fail "--target is required"
 [[ -n "$LIST_NAME" ]] || fail "--list is required"
@@ -439,6 +450,20 @@ if [[ "$FAILED" -gt 0 && "$DRY_RUN" -eq 0 ]]; then
   log "Staging finished with $FAILED failure(s). Log: $LOG_FILE"
   exit 1
 else
+  if [[ "$TEARDOWN_AFTER" -eq 1 ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      log "[DRY-RUN] Would remove transient staged directory: \\\\${TARGET}\\${SHARE}\\${DEST_PATH//\//\\}"
+    elif [[ "$COPY_METHOD" == "smbclient" ]]; then
+      DEST_WIN="${DEST_PATH//\//\\}"
+      run_smb_cmd "del \"${DEST_WIN}\\*\"; rmdir \"${DEST_WIN}\"" >/dev/null 2>&1 || true
+      log "Best-effort teardown requested for staged directory: ${DEST_PATH}"
+    elif [[ "$COPY_METHOD" == "robocopy" ]]; then
+      cmd.exe /c "rmdir /S /Q \"\\\\${TARGET}\\${SHARE}\\${DEST_PATH//\//\\}\"" >/dev/null 2>&1 || true
+      log "Best-effort teardown requested for staged directory: \\\\${TARGET}\\${SHARE}\\${DEST_PATH//\//\\}"
+    fi
+  else
+    log "Staged installers intentionally retained. Use --teardown-after for transient staging runs."
+  fi
   log "Staging complete. Log: $LOG_FILE"
 fi
 

--- a/dashboard/js/app.js
+++ b/dashboard/js/app.js
@@ -940,7 +940,8 @@ const CYBERNET_TUTORIAL_STEPS = [
     checks: [
       'The dashboard does not run probes by itself.',
       'You copy commands when the tutorial gives them, run them on an admin machine, then load the output files back here.',
-      'Use approved target sources only; do not broaden the survey from guessed hosts.'
+      'Use approved target sources only; do not broaden the survey from guessed hosts.',
+      'Survey commands are the no-target-artifact lane; deployment and mapping tools are legacy-gated separately.'
     ],
     nextAction: 'Read this, then click Next to load or prepare your targets.',
     explain: 'Introduces the manual survey model: the dashboard teaches steps, but probes run only when you copy and run commands yourself.',

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -6151,7 +6151,8 @@ const CYBERNET_TUTORIAL_STEPS = [
     checks: [
       'The dashboard does not run probes by itself.',
       'You copy commands when the tutorial gives them, run them on an admin machine, then load the output files back here.',
-      'Use approved target sources only; do not broaden the survey from guessed hosts.'
+      'Use approved target sources only; do not broaden the survey from guessed hosts.',
+      'Survey commands are the no-target-artifact lane; deployment and mapping tools are legacy-gated separately.'
     ],
     nextAction: 'Read this, then click Next to load or prepare your targets.',
     explain: 'Introduces the manual survey model: the dashboard teaches steps, but probes run only when you copy and run commands yourself.',

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -7,6 +7,7 @@ whether a dependency is needed for a given use case."
 Human and agent entry points:
 
 - Registry: [`Config/toolbox-dependencies.json`](../Config/toolbox-dependencies.json)
+- Operational posture: [`Config/operational-posture.json`](../Config/operational-posture.json)
 - Live presence probe: `bash scripts/sas-probe-toolbox.sh`
 - Pin drift contract: `bash Tests/bash/test_dependency_registry_contracts.sh`
 

--- a/docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md
+++ b/docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md
@@ -1,0 +1,59 @@
+# Deployment teardown doctrine
+
+Deployment, mapping, and staging tools are an authorized mutation lane. They are
+not survey tools, and they are gated as legacy by default so they are not used in
+the wrong environment.
+
+## Rules
+
+- Preserve working PowerShell and Windows deployment tools; do not delete them as
+  part of Bash-first survey work.
+- Require explicit legacy authorization before remote mutation entrypoints run.
+- Treat copied payload scripts, launchers, status files, stop files, scheduled
+  tasks, and temporary staging folders as transient unless a document says they
+  are intentionally retained.
+- Write operator evidence and logs locally. Do not use target workstations as an
+  evidence store.
+- On success, remove transient remote payloads and scheduled tasks.
+- On failure or interruption, attempt best-effort cleanup and record the result
+  in the local operator log.
+- Do not describe cleanup as hiding activity or suppressing logs. Cleanup reduces
+  residual operational clutter; normal endpoint and network telemetry may exist.
+
+## Tool classes
+
+| Class | Examples | Teardown expectation |
+|-------|----------|----------------------|
+| Printer mapping controller | `mapping/Controllers/Map-Run-Controller.ps1` | Remove scheduled task, launcher, payload script, status/stop files, and empty remote working dirs |
+| App install worker | `bash/apps/sas-install-apps.sh` | Worker self-removes transient payloads and scheduled task after writing results |
+| Installer staging | `bash/apps/sas-stage-fileshare.sh` | Retain by default for deployment cache; `--teardown-after` removes transient staged files |
+| Shortcut deployment | `EnvSetup/Deploy-Shortcuts.ps1` | Shortcuts are the intended payload and are retained |
+
+## Legacy enablement
+
+Use the smallest explicit opt-in:
+
+```text
+--allow-legacy
+```
+
+or:
+
+```text
+SAS_ALLOW_LEGACY_TOOLS=1
+```
+
+The opt-in only enables preserved legacy tooling. It does not expand target
+scope, grant credentials, or change the need for authorized deployment intent.
+
+## Local output
+
+Deployment logs should stay on the operator machine, for example:
+
+- `bash/apps/output/`
+- `SysAdminSuite-Session-*`
+- documented local report paths
+
+If a tool intentionally leaves a deployment artifact on a target, the tool docs
+must state whether that artifact is a desired payload, a retained cache, or a
+transient file requiring teardown.

--- a/docs/OPERATIONAL_POSTURE.md
+++ b/docs/OPERATIONAL_POSTURE.md
@@ -1,0 +1,100 @@
+# Operational posture
+
+SysAdminSuite uses one low-waste posture across survey, dashboard, deployment,
+and cleanup work. The machine-readable authority is
+[`Config/operational-posture.json`](../Config/operational-posture.json).
+
+This posture is about scope control, local-only evidence, and transparent
+operator intent. It is not stealth, evasion, log suppression, or hiding activity.
+Assume normal operating-system, endpoint-protection, application, CI, and
+network monitoring may record authorized activity.
+
+## Lane model
+
+| Lane | Target mutation | Artifact rule | Default |
+|------|-----------------|---------------|---------|
+| Survey / recon | Never | Evidence stays in local ignored paths | Enabled |
+| Dashboard probes | Never | Relay and probe output stay local | Enabled |
+| Deployment / mapping | Authorized only | Transient payloads require teardown | Legacy-gated |
+
+Survey promises such as "no target-side writes" apply to the survey and dashboard
+lanes. Deployment and mapping tools are a separate lane: they may intentionally
+copy files, create scheduled tasks, install software, or place shortcuts when an
+operator explicitly authorizes that work.
+
+## Low-noise survey principles
+
+| Principle | SysAdminSuite control |
+|-----------|-----------------------|
+| AD-derived or approved manifests define population | `logs/targets/` handoff and survey manifests |
+| Naabu validates reachability only | `survey/sas-run-naabu-pipeline.sh` and `survey/sas-run-packet-probe.sh` |
+| Avoid CDN/cloud firewall waste | `-ec` is part of every approved Naabu reachability profile |
+| Avoid logo/banner noise | `-silent` is enforced for Naabu pipelines |
+| Prefer structured parser-facing output | JSON/JSONL profiles and local parsers |
+| Use raw text only for local pipe handoff | `keyports_cybernet_pipe` into `sas-cybernet-packet-followup.sh` |
+| Gate UDP, all-port, host-discovery, and public targets | explicit flags such as `--profile-justified` and `--approved-subnet-scope` |
+| Never leave survey artifacts on target boxes | write only to local ignored paths |
+
+Canonical references:
+
+- [`docs/LOW_NOISE_SURVEY_DOCTRINE.md`](LOW_NOISE_SURVEY_DOCTRINE.md)
+- [`survey/naabu_profiles.json`](../survey/naabu_profiles.json)
+- [`Config/cybernet-naabu-profiles.json`](../Config/cybernet-naabu-profiles.json)
+
+## Approved Naabu patterns
+
+Use suite wrappers for execution. These examples are local operator commands, not
+target-side scripts.
+
+### Durable JSON evidence
+
+```bash
+bash survey/sas-run-naabu-pipeline.sh \
+  --site <site> \
+  --profile keyports_cybernet_json \
+  --list logs/targets/<site>_confirm_hosts.txt \
+  --out logs/nmap/<site>_<runid>_naabu.json
+```
+
+### Raw local pipe handoff
+
+```bash
+bash survey/sas-run-naabu-pipeline.sh \
+  --site <site> \
+  --profile keyports_cybernet_pipe \
+  --list logs/targets/<site>_confirm_hosts.txt \
+  --pipe-followup \
+  --out logs/nmap/<site>_<runid>_cybernet_detect.jsonl
+```
+
+`httpx` is optional enrichment only. Use it through
+`survey/sas-cybernet-packet-followup.sh --use-httpx` so the pipeline remains
+silent and local.
+
+### Special profiles
+
+- UDP (`udp_dns_snmp_json`) requires `--profile-justified`.
+- All ports (`allports_low_noise_json`) requires `--allow-full-ports`.
+- Host discovery (`host_discovery_web_syn_txt`) requires `--approved-subnet-scope`.
+- Load-balanced hostnames use `-sa` only through the hostname profile when every
+  resolved IP is intentionally in scope.
+
+## Legacy deployment gate
+
+Legacy deployment/mapping tools are preserved for environments where they are
+still needed, but they are disabled by default:
+
+```bash
+SAS_ALLOW_LEGACY_TOOLS=1 bash bash/apps/sas-stage-fileshare.sh --allow-legacy ...
+```
+
+```powershell
+.\mapping\Controllers\Map-Run-Controller.ps1 -AllowLegacy ...
+```
+
+If the gate is not enabled, entrypoints fail closed with
+`LEGACY_TOOLS_DISABLED` and point back to this document. Enabling the gate does
+not bypass normal authorization, credentials, or target-scope requirements.
+
+Deployment teardown rules are documented in
+[`docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md`](DEPLOYMENT_TEARDOWN_DOCTRINE.md).

--- a/mapping/Controllers/Map-Run-Controller.ps1
+++ b/mapping/Controllers/Map-Run-Controller.ps1
@@ -6,6 +6,7 @@
  - Uses absolute path to powershell.exe (PS5.1) by default
  - Polls remote logs and collects immediately when ready
  - Best-effort cleanup of task and remote crumbs
+ - Legacy deployment lane: requires -AllowLegacy or SAS_ALLOW_LEGACY_TOOLS=1
  - Graceful Ctrl+C: partial results kept, summary printed
 
  Usage examples:
@@ -52,11 +53,25 @@
 
    # GUI-friendly stop + live status contract
    [string]$StopSignalPath,
-   [string]$StatusPath
+   [string]$StatusPath,
+
+   # Explicit opt-in for preserved legacy deployment/mapping lane
+   [switch]$AllowLegacy,
+
+   # Debug only: leave transient remote payloads for inspection
+   [switch]$NoTeardown
  )
  
  Set-StrictMode -Version Latest
  $ErrorActionPreference = 'Stop'
+$legacyGatePath = Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'scripts\Invoke-SasLegacyGate.ps1'
+if (-not (Test-Path -LiteralPath $legacyGatePath)) {
+  throw "Legacy gate helper not found: $legacyGatePath"
+}
+. $legacyGatePath
+if (-not (Invoke-SasLegacyGate -ToolPath 'mapping/Controllers/Map-Run-Controller.ps1' -AllowLegacy:$AllowLegacy)) {
+  exit 42
+}
  $script:undoRedoEnabled = $false
  $script:undoRedoSession = $null
  $script:undoRedoUtilityPath = $null
@@ -85,6 +100,40 @@
    Write-Host $stamp
    $stamp | Out-File -FilePath $ControllerLog -Encoding utf8 -Append
  }
+
+function Invoke-RemoteTransientCleanup {
+  param(
+    [string]$Computer,
+    [string[]]$Paths,
+    [string]$LogsPath,
+    [string]$BasePath
+  )
+
+  if ($NoTeardown) {
+    Write-Log "[$Computer] WARN: -NoTeardown requested; transient remote payloads may remain for debugging."
+    return
+  }
+
+  foreach ($path in ($Paths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)) {
+    try {
+      Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+    } catch {
+      Write-Log "[$Computer] Teardown warning removing ${path}: $($_.Exception.Message)"
+    }
+  }
+
+  foreach ($dir in @($LogsPath, $BasePath)) {
+    if ([string]::IsNullOrWhiteSpace($dir)) { continue }
+    try {
+      if ((Test-Path -LiteralPath $dir) -and -not (Get-ChildItem -LiteralPath $dir -Force -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+        Remove-Item -LiteralPath $dir -Force -ErrorAction SilentlyContinue
+        Write-Log "[$Computer] Removed empty remote transient directory: $dir"
+      }
+    } catch {
+      Write-Log "[$Computer] Teardown warning removing directory ${dir}: $($_.Exception.Message)"
+    }
+  }
+}
 
  function Initialize-ControllerRunControl {
    $candidatePaths = @(
@@ -414,6 +463,14 @@ $null = Register-ObjectEvent -InputObject ([Console]) -EventName CancelKeyPress 
    $adminLauncher = Join-AdminShare -Computer $Computer -SubPath $remoteLauncher
    $adminStopSignal = Join-AdminShare -Computer $Computer -SubPath $remoteStopSignal
    $adminStatusPath = Join-AdminShare -Computer $Computer -SubPath $remoteStatusPath
+  $transientRemotePaths = @(
+    $adminScript,
+    $adminUndoRedo,
+    $adminRunControl,
+    $adminLauncher,
+    $adminStopSignal,
+    $adminStatusPath
+  )
 
    $script:currentHost = $Computer
    $script:currentRemoteStopAdminPath = $adminStopSignal
@@ -453,6 +510,7 @@ $null = Register-ObjectEvent -InputObject ([Console]) -EventName CancelKeyPress 
      Write-Log "[$Computer] Wrote launcher -> $adminLauncher"
    } catch {
      Write-Log "[$Computer] ERROR copying script: $($_.Exception.Message)"
+    Invoke-RemoteTransientCleanup -Computer $Computer -Paths $transientRemotePaths -LogsPath $adminLogs -BasePath $adminBase
     return $false
    }
  
@@ -484,6 +542,7 @@ $null = Register-ObjectEvent -InputObject ([Console]) -EventName CancelKeyPress 
        Invoke-UndoRedo -Session $script:undoRedoSession -Action $createAction | Out-Null
      } catch {
        Write-Log "[$Computer] ERROR creating task via undo/redo action: $($_.Exception.Message)"
+      Invoke-RemoteTransientCleanup -Computer $Computer -Paths $transientRemotePaths -LogsPath $adminLogs -BasePath $adminBase
        return $false
      }
    } else {
@@ -492,6 +551,7 @@ $null = Register-ObjectEvent -InputObject ([Console]) -EventName CancelKeyPress 
      Write-Log "[$Computer] schtasks /Create output:`n$createOut"
     if ($createExit -ne 0) {
       Write-Log "[$Computer] ERROR creating task. ExitCode=$createExit"
+      Invoke-RemoteTransientCleanup -Computer $Computer -Paths $transientRemotePaths -LogsPath $adminLogs -BasePath $adminBase
       return $false
     }
    }
@@ -502,6 +562,7 @@ $null = Register-ObjectEvent -InputObject ([Console]) -EventName CancelKeyPress 
    Write-Log "[$Computer] schtasks /Run output:`n$runOut"
   if ($runExit -ne 0) {
     Write-Log "[$Computer] ERROR running task. ExitCode=$runExit"
+    Invoke-RemoteTransientCleanup -Computer $Computer -Paths $transientRemotePaths -LogsPath $adminLogs -BasePath $adminBase
     return $false
   }
  
@@ -563,7 +624,7 @@ $null = Register-ObjectEvent -InputObject ([Console]) -EventName CancelKeyPress 
        cmd /c ("schtasks /Delete /S {0} /TN {1} /F" -f $Computer, $TaskName) | Out-Null
        Write-Log "[$Computer] Deleted task $TaskName."
      }
-     Remove-Item -LiteralPath $adminStopSignal,$adminStatusPath,$adminLauncher -Force -ErrorAction SilentlyContinue
+    Invoke-RemoteTransientCleanup -Computer $Computer -Paths $transientRemotePaths -LogsPath $adminLogs -BasePath $adminBase
    } catch {
      Write-Log "[$Computer] Cleanup warning: $($_.Exception.Message)"
    }

--- a/scripts/Invoke-SasLegacyGate.ps1
+++ b/scripts/Invoke-SasLegacyGate.ps1
@@ -1,0 +1,36 @@
+function Invoke-SasLegacyGate {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ToolPath,
+
+    [switch]$AllowLegacy,
+
+    [string]$PosturePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'Config\operational-posture.json')
+  )
+
+  if ($AllowLegacy -or $env:SAS_ALLOW_LEGACY_TOOLS -eq '1') {
+    Write-Verbose "LEGACY_TOOLS_ENABLED: $ToolPath"
+    return $true
+  }
+
+  $classification = 'LEGACY_TOOLS_DISABLED'
+  if (Test-Path -LiteralPath $PosturePath) {
+    try {
+      $posture = Get-Content -LiteralPath $PosturePath -Raw -Encoding UTF8 | ConvertFrom-Json
+      if ($posture.defaults.legacyDisabledClassification) {
+        $classification = [string]$posture.defaults.legacyDisabledClassification
+      }
+    } catch {
+      Write-Verbose "Could not read operational posture manifest: $($_.Exception.Message)"
+    }
+  }
+
+  Write-Error @"
+${classification}: $ToolPath
+Legacy deployment/mapping tools are preserved but disabled by default for low-waste posture control.
+Use -AllowLegacy or set SAS_ALLOW_LEGACY_TOOLS=1 only for authorized deployment lanes.
+See docs/OPERATIONAL_POSTURE.md and docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md.
+"@
+  return $false
+}

--- a/scripts/sas-legacy-gate.sh
+++ b/scripts/sas-legacy-gate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fail-closed gate for preserved legacy deployment/mapping tools.
+set -euo pipefail
+
+TOOL_PATH=""
+ALLOW_LEGACY=0
+POSTURE_JSON="${SAS_OPERATIONAL_POSTURE_JSON:-Config/operational-posture.json}"
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/sas-legacy-gate.sh --tool PATH [--allow-legacy]
+
+Legacy deployment tools are disabled by default. Enable only for an authorized
+deployment/mapping lane with either --allow-legacy or SAS_ALLOW_LEGACY_TOOLS=1.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tool) TOOL_PATH="${2:?missing --tool value}"; shift 2 ;;
+    --allow-legacy) ALLOW_LEGACY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'LEGACY_GATE_ERROR: unknown argument: %s\n' "$1" >&2; usage >&2; exit 64 ;;
+  esac
+done
+
+[[ -n "$TOOL_PATH" ]] || { printf 'LEGACY_GATE_ERROR: --tool is required\n' >&2; exit 64; }
+
+if [[ "$ALLOW_LEGACY" -eq 1 || "${SAS_ALLOW_LEGACY_TOOLS:-0}" == "1" ]]; then
+  printf 'LEGACY_TOOLS_ENABLED: %s\n' "$TOOL_PATH" >&2
+  exit 0
+fi
+
+classification="LEGACY_TOOLS_DISABLED"
+if command -v python3 >/dev/null 2>&1 && [[ -f "$POSTURE_JSON" ]]; then
+  classification="$(python3 - "$POSTURE_JSON" <<'PY' 2>/dev/null || printf 'LEGACY_TOOLS_DISABLED'
+import json
+import sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    data = json.load(handle)
+print(data.get("defaults", {}).get("legacyDisabledClassification", "LEGACY_TOOLS_DISABLED"))
+PY
+)"
+fi
+
+cat >&2 <<EOF
+${classification}: ${TOOL_PATH}
+Legacy deployment/mapping tools are preserved but disabled by default for low-waste posture control.
+Use --allow-legacy or set SAS_ALLOW_LEGACY_TOOLS=1 only for authorized deployment lanes.
+See docs/OPERATIONAL_POSTURE.md and docs/DEPLOYMENT_TEARDOWN_DOCTRINE.md.
+EOF
+exit 42

--- a/survey/sas-cybernet-subnet-survey.sh
+++ b/survey/sas-cybernet-subnet-survey.sh
@@ -3,8 +3,8 @@
 # Authorized internal asset discovery only. Read-only. Local output only.
 # Low-noise survey doctrine: this subnet path is discovery context, NOT the registered
 # Cybernet population source. Prefer AD-derived host lists for confirm-windows reachability.
-# See docs/LOW_NOISE_SURVEY_DOCTRINE.md. Note: default --naabu-profile keyports_cdn_json
-# validates web ports (80,443); the doctrine keyports contract covers full Cybernet ports.
+# See docs/LOW_NOISE_SURVEY_DOCTRINE.md. Default --naabu-profile keyports_cybernet_json
+# validates full Cybernet key ports; web-only checks use the explicit web reachability profiles.
 
 set -euo pipefail
 

--- a/survey/sas-run-naabu-pipeline.sh
+++ b/survey/sas-run-naabu-pipeline.sh
@@ -132,7 +132,7 @@ build_naabu_argv() {
   py="$(find_python)"
   tmp="$(mktemp)"
   $py - "$PROFILE_JSON" "$PROFILE" "$LIST" "$HOST" "$OUT" "$ALLOW_FULL_PORTS" "$PROFILE_JUSTIFIED" "$APPROVED_SUBNET_SCOPE" "$RATE" <<'PY' > "$tmp"
-import json, sys
+import json, os, sys
 
 profile_path, profile_id, list_path, host, out_path, allow_full, justified, subnet_scope, rate = sys.argv[1:10]
 allow_full = allow_full == "1"
@@ -140,6 +140,12 @@ justified = justified == "1"
 subnet_scope = subnet_scope == "1"
 with open(profile_path, encoding="utf-8") as fh:
     cfg = json.load(fh)
+posture_path = os.path.join(os.path.dirname(profile_path), "operational-posture.json")
+max_rate = 3000
+if os.path.exists(posture_path):
+    with open(posture_path, encoding="utf-8") as fh:
+        posture = json.load(fh)
+    max_rate = int(posture.get("defaults", {}).get("naabuMaxRate", max_rate))
 profile_id = cfg.get("profileAliases", {}).get(profile_id, profile_id)
 profiles = cfg.get("profiles", {})
 if profile_id not in profiles:
@@ -197,6 +203,9 @@ if rate:
     if not str(rate).isdigit() or int(rate) <= 0:
         print("--rate must be a positive integer", file=sys.stderr)
         sys.exit(8)
+    if int(rate) > max_rate:
+        print(f"--rate must be <= {max_rate} per operational posture", file=sys.stderr)
+        sys.exit(9)
     argv += ["-rate", str(rate)]
 
 fmt = p.get("outputFormat", "txt")


### PR DESCRIPTION
## Summary
- Add Config/operational-posture.json plus OPERATIONAL_POSTURE and DEPLOYMENT_TEARDOWN doctrine docs
- Gate legacy deployment entrypoints behind SAS_ALLOW_LEGACY_TOOLS / --allow-legacy
- Add transient teardown hooks for Map-Run-Controller, sas-install-apps, and sas-stage-fileshare
- Cap Naabu pipeline --rate at 3000 and enforce bundle.js naabu conformance
- Add operational-posture.yml CI workflow and contract tests

## Test plan
- [x] bash Tests/bash/test_operational_posture_contracts.sh
- [x] bash Tests/bash/test_naabu_pipeline_contracts.sh
- [x] bash Tests/bash/test_packet_probe_contracts.sh
- [x] bash Tests/bash/test_repo_naabu_doctrine_conformance.sh

Made with [Cursor](https://cursor.com)