### PR TITLE
feat(survey): add PowerShell field network preflight

### DIFF
--- a/.github/workflows/dashboard-smoke.yml
+++ b/.github/workflows/dashboard-smoke.yml
@@ -7,17 +7,21 @@ on:
       - 'Tests/bash/test_dashboard_*.sh'
       - 'Tests/bash/test_update_flow_contracts.sh'
       - 'Tests/bash/test_field_tech_update_contracts.sh'
+      - 'Tests/bash/test_powershell_network_preflight_contracts.sh'
       - 'START-HERE-SysAdminSuite.md'
+      - 'START-HERE-CYBERNET-NEURON-SURVEY.md'
       - 'START-HERE-SysAdminSuite-Dashboard.bat'
       - 'START-HERE-SysAdminSuite-Dashboard.cmd'
       - 'SysAdminSuite Dashboard.cmd'
       - 'Launch-SysAdminSuiteDashboard.Host.bat'
       - 'Update-SysAdminSuite.ps1'
       - 'Update-SysAdminSuite.bat'
+      - 'survey/sas-network-preflight.ps1'
       - 'tools/update/**'
       - 'docs/APPROVED_UPDATE_FLOW.md'
       - 'docs/DASHBOARD_ENTRYPOINT.md'
       - 'docs/FIELD_TECH_UPDATE.md'
+      - 'docs/FIELD_NETWORK_PREFLIGHT.md'
       - '.github/workflows/dashboard-smoke.yml'
   push:
     branches:
@@ -27,17 +31,21 @@ on:
       - 'Tests/bash/test_dashboard_*.sh'
       - 'Tests/bash/test_update_flow_contracts.sh'
       - 'Tests/bash/test_field_tech_update_contracts.sh'
+      - 'Tests/bash/test_powershell_network_preflight_contracts.sh'
       - 'START-HERE-SysAdminSuite.md'
+      - 'START-HERE-CYBERNET-NEURON-SURVEY.md'
       - 'START-HERE-SysAdminSuite-Dashboard.bat'
       - 'START-HERE-SysAdminSuite-Dashboard.cmd'
       - 'SysAdminSuite Dashboard.cmd'
       - 'Launch-SysAdminSuiteDashboard.Host.bat'
       - 'Update-SysAdminSuite.ps1'
       - 'Update-SysAdminSuite.bat'
+      - 'survey/sas-network-preflight.ps1'
       - 'tools/update/**'
       - 'docs/APPROVED_UPDATE_FLOW.md'
       - 'docs/DASHBOARD_ENTRYPOINT.md'
       - 'docs/FIELD_TECH_UPDATE.md'
+      - 'docs/FIELD_NETWORK_PREFLIGHT.md'
       - '.github/workflows/dashboard-smoke.yml'
 
 jobs:
@@ -97,3 +105,5 @@ jobs:
         run: bash Tests/bash/test_update_flow_contracts.sh
       - name: Field tech update contracts
         run: bash Tests/bash/test_field_tech_update_contracts.sh
+      - name: PowerShell network preflight contracts
+        run: bash Tests/bash/test_powershell_network_preflight_contracts.sh

--- a/START-HERE-CYBERNET-NEURON-SURVEY.md
+++ b/START-HERE-CYBERNET-NEURON-SURVEY.md
@@ -1,179 +1,157 @@
 # Start Here: Cybernet / Neuron Network Survey
 
-This is the current priority field workflow for SysAdminSuite technicians.
+This is the field-facing entrypoint for Cybernet / Neuron network survey work.
 
-Use it when you need to locate Cybernet or Neuron devices from approved deployment documentation using a local admin workstation, target manifests, and conservative approved network discovery.
+Use it when you need to validate network posture from an approved target population using a local admin workstation. The dashboard guides the workflow. The operator runs approved commands outside the dashboard and loads the resulting local files back into **Load Evidence**.
+
+## Field shell doctrine
+
+**PowerShell first.**
+
+- Run PowerShell command blocks in **Windows PowerShell**.
+- Do not use Git Bash / MINGW64 for the field-tech path.
+- Do not use CMD for PowerShell blocks.
+- Do not paste Bash commands into the field workflow.
+- Do not type demo hostnames manually for live work.
+- Do not use `C:\Temp` as the live workflow.
+
+CMD is only for simple Windows launcher actions, such as double-clicking `START-HERE-SysAdminSuite-Dashboard.bat`.
+
+## Folder doctrine
+
+| Path | Purpose |
+|---|---|
+| `targets/` | Tracked policy, schemas, and sanitized fixtures only |
+| `targets/local/` | Preferred ignored live intake for approved source workbooks, AD exports, tracker CSVs, and raw target material before normalization |
+| `logs/targets/` | Preserved ignored local target and evidence store |
+| `survey/input/` | Normalized runtime staging generated from approved intake |
+| `survey/output/` | Generated survey outputs and reports |
+| `logs/nmap/` | Generated network probe output |
+| `survey/artifacts/` | Generated local artifacts |
+
+Live field preflight reads from `targets/local/` and `logs/targets/` first. `survey/input/` is staging only after an approved normalization step. `survey/output/` is generated output, not the place to invent live targets.
 
 ## Workflow at a glance
 
-Use this diagram to keep the field path straight: approved population first, local context and reachability second, local evidence package last. Mermaid source: [`docs/diagrams/cybernet-neuron-survey-flow.mmd`](docs/diagrams/cybernet-neuron-survey-flow.mmd).
+1. Export or copy the approved spreadsheet, AD export, tracker tab, or target source to `targets/local/` or `logs/targets/`.
+2. Normalize if the selected source is not already a `.txt` or `.csv` with probe-ready hostnames/IPs.
+3. Run the PowerShell network preflight.
+4. Review the CSV under `survey/output/network_preflight/`.
+5. Load the CSV into the dashboard with **Load Evidence**.
 
-Each orchestrator mode is a separate `--mode` run, not a single chained pipeline. The numbered order below is the typical progression, but you invoke one mode at a time.
-
-```mermaid
-flowchart TD
-    subgraph entryPaths [Entry Paths]
-        dashboard["Dashboard: Start Cybernet Survey"]
-        cli["CLI: survey/sas-cybernet-subnet-survey.sh --mode MODE"]
-    end
-
-    subgraph populationAuthority [Population Authority]
-        approvedInputs["AD export or approved manifests"]
-        adReconcile["survey/sas-ad-reconcile.sh"]
-        manifests["Resolved target manifests (survey/output/ad_reconcile)"]
-        approvedInputs --> adReconcile --> manifests
-    end
-
-    subgraph orchestratorModes [Orchestrator modes: pick one --mode per run]
-        localContext["local-context-only"]
-        dnsList["dns-list-only"]
-        discover["discover"]
-        resolveOnly["resolve-only"]
-        confirmWindows["confirm-windows (optional)"]
-        parseNaabu["parse-naabu-only"]
-        packageOnly["package-only"]
-    end
-
-    typicalOrder["Typical order: local-context-only -> dns-list-only -> discover -> resolve-only -> confirm-windows (optional) -> parse-naabu-only -> package-only"]
-
-    subgraph localEvidence [Local Evidence Only]
-        surveyOutputs["survey/output and survey/artifacts"]
-        networkLogs["logs/nmap and logs/network_context"]
-    end
-
-    subgraph guardrails [Guardrails]
-        populationRule["AD or approved manifests define population"]
-        reachabilityRule["Nmap and Naabu validate reachability only"]
-        evidenceRule["Do not commit live evidence"]
-    end
-
-    dashboard --> manifests
-    cli --> orchestratorModes
-    orchestratorModes --> typicalOrder
-    manifests --> resolveOnly
-    packageOnly --> surveyOutputs
-    packageOnly --> networkLogs
-    populationRule --> approvedInputs
-    reachabilityRule --> confirmWindows
-    evidenceRule --> localEvidence
-```
+Network preflight is reachability and posture evidence only. It does not prove serial identity, AD registration, ownership, or deployment completion.
 
 ## Dashboard quick path
 
-Use the Cybernet-first dashboard when you want a guided wizard instead of memorizing CLI steps. Live Mode is **not** the front door — it lives under **Advanced Tools → Generate Survey Commands**.
+1. Double-click `START-HERE-SysAdminSuite-Dashboard.bat`.
+2. Click **Start Cybernet Survey**.
+3. Use the tutorial to select the PowerShell field path.
+4. Run the displayed PowerShell command outside the dashboard.
+5. Drop the resulting `network_preflight_*.csv` back into **Load Evidence**.
 
-1. **Open the dashboard** — double-click [`START-HERE-SysAdminSuite-Dashboard.bat`](START-HERE-SysAdminSuite-Dashboard.bat) at the repo root. This starts the local host and opens `http://127.0.0.1:5000/dashboard/?tutorial=setup`; from there click **Start Cybernet Survey**. For a direct survey deep link, use [`Start-CybernetSurveyTutorial.cmd`](Start-CybernetSurveyTutorial.cmd). See [`START-HERE-SysAdminSuite.md`](START-HERE-SysAdminSuite.md) and [`docs/DASHBOARD_ENTRYPOINT.md`](docs/DASHBOARD_ENTRYPOINT.md).
-2. **Start Cybernet Survey** — opens the wizard (progress rail: Start → Load targets → Network posture → Identity evidence → Reachability → Review results).
-3. **Copy posture and identity commands** — run network preflight and workstation identity on the admin box; keep output local.
-4. **Optional reachability** — wizard step 4 is skippable; uses profile `keyports_cybernet_json` when you need low-noise port confirmation.
-5. **Load Evidence** — drop `network_preflight.csv`, `workstation_identity.csv`, optional reachability JSON, normalized target manifests, and AD population CSVs.
-6. **Review Results** — use the Cybernet review summary; open **Advanced Tools** only for detailed panels or legacy command generation.
+The dashboard never runs probes by itself. It teaches the operator what to run and reads the evidence files afterward.
 
-For subnet discovery and Nmap orchestration, use the CLI path below. For **manifest lane vs subnet lane** and **serial vs hostname vs MAC** guidance, see [`docs/SURVEY_LANES.md`](docs/SURVEY_LANES.md).
+## Select an approved target file
 
-## AD-first warning
+Run in Windows PowerShell:
 
-**Active Directory registered population is the population authority.** When an authorized AD computer export is available, reconcile AD before building scan candidate lists.
-
-1. Place the approved export locally (do not commit live CSVs). Use `targets/local/` or `logs/targets/` per [`docs/TARGETS_FOLDER_POLICY.md`](docs/TARGETS_FOLDER_POLICY.md).
-2. Run `bash survey/sas-ad-reconcile.sh --ad-csv <local-export.csv> --output-dir survey/output/ad_reconcile/<run-id>`.
-3. Use `ad_targets_hostnames.txt` and `ad_evidence_matches.csv` to drive manifests and downstream validation.
-4. Treat Naabu/Nmap as **reachability validation only** against AD-derived targets — not as the population source.
-
-See [`docs/AD_REGISTERED_POPULATION.md`](docs/AD_REGISTERED_POPULATION.md) and [`docs/AD_CYBERNET_EXPORT_CONTRACT.md`](docs/AD_CYBERNET_EXPORT_CONTRACT.md).
-
-## Urgent path (orchestrator)
-
-Use one correlated `--site` and `--run-id` across steps:
-
-```bash
-SITE=nsuh
-RUN_ID="$(date +%Y%m%d_%H%M%S)"
-SUBNET_FILE=survey/output/local_subnet_finder/${SITE}_${RUN_ID}/subnet_candidates.txt
-MANIFEST=survey/output/cybernet_targets_resolved.csv
-HOSTS=survey/output/cybernet_subnet_survey/${SITE}_${RUN_ID}/hosts/10_10_10_0_24_up.txt
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1
 ```
 
-```bash
-# 1. Local subnet finder + network context
-bash survey/sas-cybernet-subnet-survey.sh --site "$SITE" --run-id "$RUN_ID" --mode local-context-only
+With no `-TargetFile`, the script lists candidate `.txt` and `.csv` files from:
 
-# 2. DNS/list sanity check (not host proof)
-bash survey/sas-cybernet-subnet-survey.sh --site "$SITE" --run-id "$RUN_ID" --mode dns-list-only --subnet-file "$SUBNET_FILE"
+- `targets/local/`
+- `logs/targets/`
 
-# 3. Nmap -sn discovery (no-DNS + system-DNS)
-bash survey/sas-cybernet-subnet-survey.sh --site "$SITE" --run-id "$RUN_ID" --mode discover --subnet-file "$SUBNET_FILE"
+Then it stops without probing. This is deliberate. The operator must select the approved target file.
 
-# 4. Resolve manifest against Nmap XML evidence
-bash survey/sas-cybernet-subnet-survey.sh --site "$SITE" --run-id "$RUN_ID" --mode resolve-only --manifest "$MANIFEST"
+## Run network preflight
 
-# 5. Optional Windows port confirmation (small AD-derived or discovery host list)
-# Prefer logs/targets/<site>_confirm_hosts.txt for Phase 2b reachability (not subnet-wide discovery)
-bash survey/sas-cybernet-subnet-survey.sh --site "$SITE" --run-id "$RUN_ID" --mode confirm-windows \
-  --confirm-tool naabu --host-file "$HOSTS" --pipe-followup
+Run in Windows PowerShell:
 
-# 6. Package local artifacts
-bash survey/sas-cybernet-subnet-survey.sh --site "$SITE" --run-id "$RUN_ID" --mode package-only --manifest "$MANIFEST"
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1 -TargetFile .\targets\local\approved_targets.csv -Ports 135,445,3389,9100
 ```
 
-Windows double-click launcher (Git Bash on PATH):
+Alternative approved source root:
 
-```bat
-survey\sas-cybernet-subnet-survey.cmd --site nsuh --mode local-context-only
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1 -TargetFile .\logs\targets\approved_confirm_hosts.txt -Ports 135,445,3389,9100
 ```
 
-## Need subnets first (standalone)
+The script prints:
 
-Run this from Git Bash/MSYS2 Bash on the connected admin workstation:
+- selected target file
+- target count
+- selected ports
+- output path
+- current stage
+- `[n/total]`
+- percent complete
+- final CSV path
 
-```bash
-bash survey/sas-find-local-subnets.sh --site <site-code>
+Default output:
+
+```text
+survey/output/network_preflight/network_preflight_<timestamp>.csv
 ```
 
-Example:
+## Accepted target files
 
-```bash
-bash survey/sas-find-local-subnets.sh --site nsuh
-```
+### Text target files
 
-The command produces:
+Rules:
 
-- `survey/output/local_subnet_finder/<site>_<timestamp>/subnet_candidates.txt`
-- `survey/output/local_subnet_finder/<site>_<timestamp>/subnet_candidates.csv`
-- local context under `context/`
-- `SUMMARY.md`
+- one hostname, IP address, or probe-ready identifier per line
+- blank lines ignored
+- lines beginning with `#` ignored
+- whitespace trimmed
 
-Use `subnet_candidates.txt` as the fast approved CIDR shortlist for the rest of the survey workflow.
+### CSV target files
 
-## Full fast path
+Preferred columns:
 
-1. Read the full tutorial: [`docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md`](docs/tutorials/CYBERNET_NEURON_NETWORK_SURVEY.md)
-2. Put approved local target CSVs in `survey/input/`
-3. Run `bash tests/bash/smoke-bash-windows-runtime.sh`
-4. Run the orchestrator steps above (or individual scripts documented in the tutorial)
-5. Build manifests with `bash survey/sas-survey-targets.sh`
-6. Contract tests: `bash tests/bash/test-cybernet-subnet-survey-contracts.sh`
+- `HostName`
+- `Hostname`
+- `ComputerName`
+- `DeviceName`
+- `Name`
 
-## Low-noise survey discipline
+Also accepted when probe-ready or explicitly typed as hostname/IP:
 
-This workflow follows low-noise survey discipline (authorized, scoped, no-target-mutation,
-local evidence only). The subnet orchestrator path above is for discovery context; it is
-**not** the registered Cybernet population source. For Phase 2b reachability confirmation,
-prefer an AD-derived host list placed in the local gitignored `logs/targets/` store and
-validate reachability against that list only. See
-[`docs/LOW_NOISE_SURVEY_DOCTRINE.md`](docs/LOW_NOISE_SURVEY_DOCTRINE.md).
+- `Target`
+- `Identifier`
+
+Prefer hostnames over serial-only values when both exist. Serial-only rows are not network targets. Enrich or normalize serial-only material before preflight.
+
+## Spreadsheet source on X:\
+
+Do not probe a spreadsheet directly from `X:\` unless a tested SysAdminSuite ingestion path explicitly supports that source.
+
+Preferred field flow:
+
+1. Export the approved spreadsheet or target tab to CSV.
+2. Place the CSV under `targets/local/` or `logs/targets/`.
+3. Normalize if needed.
+4. Run PowerShell network preflight against the selected CSV.
 
 ## Evidence notes
 
-- **Nmap** helps find live hosts, DNS names, MACs on local L2, and XML evidence for resolver tooling.
-- **Serial matching** comes from manifests, trackers, AD/CMDB exports, or approved identity probes — not from Nmap alone.
-- **Naabu** is only for narrow port reachability confirmation against already-small candidate host lists.
+- DNS and ping failures may indicate guest network, wrong VLAN, DNS scope, firewall policy, or offline hosts.
+- TCP port results are `Open`, `Closed`, or `NotChecked` when the PowerShell runtime lacks the needed command.
+- AD exports define registered population, not live reachability.
+- Nmap / Naabu remain reachability validation tools, not population authority.
+- Serial matching comes from approved identity sources, trackers, AD/CMDB exports, SCCM/MDM, or operator evidence, not from network preflight alone.
 
 ## Hard rules
 
 - Do not commit live target CSVs, scan output, dashboards, ZIPs, serials, MACs, or site evidence.
 - Do not run broad scans without approved scope.
 - Do not use spoofing, decoys, stealth flags, vuln scripts, brute force, or credential attacks.
-- Do not claim Nmap found a serial unless an approved serial evidence source actually produced it.
+- Do not claim network preflight found a serial unless an approved serial evidence source actually produced it.
 
-This workflow is for asset discovery and reconciliation. Keep it boring, clean, and provable.
+This workflow is boring on purpose. Boring survives the field.

--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -106,7 +106,7 @@ assert_contains 'Run the PowerShell network preflight' "$runbook" 'runbook missi
 assert_contains 'Review the generated CSV under `survey/output/network_preflight/`' "$runbook" 'runbook missing output review step'
 
 # The field dashboard patch must point to the durable entrypoint, not emergency snippets.
-assert_contains '.\\survey\\sas-network-preflight.ps1' "$dashboard_patch" 'dashboard patch missing PowerShell preflight entrypoint'
-assert_contains 'survey\\output\\network_preflight' "$dashboard_patch" 'dashboard patch missing generated output folder'
+assert_contains '.\survey\sas-network-preflight.ps1' "$dashboard_patch" 'dashboard patch missing PowerShell preflight entrypoint'
+assert_contains 'survey\output\network_preflight' "$dashboard_patch" 'dashboard patch missing generated output folder'
 
 echo 'PASS: PowerShell network preflight contracts'

--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+preflight="$repo_root/survey/sas-network-preflight.ps1"
+runbook="$repo_root/docs/FIELD_NETWORK_PREFLIGHT.md"
+start_here="$repo_root/START-HERE-CYBERNET-NEURON-SURVEY.md"
+dashboard_patch="$repo_root/dashboard/js/cybernet-os-preflight.js"
+field_files=("$runbook" "$start_here" "$dashboard_patch")
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file() {
+  [[ -f "$1" ]] || fail "missing file: $1"
+}
+
+assert_contains() {
+  local needle="$1" file="$2" message="$3"
+  grep -Fq -- "$needle" "$file" || fail "$message"
+}
+
+assert_not_contains() {
+  local needle="$1" file="$2" message="$3"
+  grep -Fq -- "$needle" "$file" && fail "$message"
+}
+
+assert_file "$preflight"
+assert_file "$runbook"
+assert_file "$start_here"
+assert_file "$dashboard_patch"
+
+# 1-2. Field preflight must not default to emergency temp paths.
+assert_not_contains 'C:\Temp' "$preflight" 'PowerShell preflight references C:\Temp'
+assert_not_contains '/tmp' "$preflight" 'PowerShell preflight references /tmp'
+assert_not_contains 'sas-cybernet' "$preflight" 'PowerShell preflight references emergency sas-cybernet temp folder'
+
+# 3. No executable live sample hostnames in the product field preflight surface.
+for f in "$preflight" "$runbook" "$start_here" "$dashboard_patch"; do
+  if grep -Eq '(^|[^A-Z0-9])(WMH|WNH|CYB)[0-9]{3,}[A-Z0-9_-]*' "$f"; then
+    fail "field preflight surface embeds executable-looking live/sample hostname: $f"
+  fi
+done
+
+# 4-5. No positive Git Bash/MINGW64 or Bash-syntax field path remains.
+for f in "${field_files[@]}"; do
+  grep -Eiq 'Run (in|from) Git Bash|Windows Git Bash|MINGW64 prompt|bash bash/|bash survey/' "$f" \
+    && fail "field doc/dashboard still routes operators to a Bash/Git Bash path: $f"
+  grep -Eq 'mkdir -p|printf .+\\n' "$f" \
+    && fail "field doc/dashboard still contains Bash setup syntax: $f"
+done
+
+# 6. PowerShell command surfaces must be labeled PowerShell.
+for f in "${field_files[@]}"; do
+  assert_contains 'Run in Windows PowerShell' "$f" "missing PowerShell label in $f"
+done
+assert_contains 'Get-Content' "$preflight" 'preflight must use Get-Content for TXT parsing'
+assert_contains 'Resolve-DnsName' "$preflight" 'preflight must use Resolve-DnsName for DNS'
+assert_contains 'Test-NetConnection' "$preflight" 'preflight must use Test-NetConnection for TCP checks'
+assert_contains 'Export-Csv' "$preflight" 'preflight must export CSV output'
+assert_contains '-WarningAction SilentlyContinue' "$preflight" 'Test-NetConnection warnings must be suppressed'
+
+# 7-9. Codified source/staging/output roots.
+assert_contains 'targets/local' "$preflight" 'preflight missing targets/local input root'
+assert_contains 'logs/targets' "$preflight" 'preflight missing logs/targets input root'
+assert_contains 'survey/input' "$preflight" 'preflight missing survey/input staging root'
+assert_contains 'survey/input is normalized runtime staging only' "$runbook" 'runbook must say survey/input is staging only'
+assert_contains 'survey/output' "$preflight" 'preflight missing survey/output output root'
+assert_contains 'logs/nmap' "$preflight" 'preflight missing logs/nmap output root'
+assert_contains 'survey/artifacts' "$preflight" 'preflight missing survey/artifacts output root'
+assert_contains 'survey/output/ is generated output, not the place to invent live targets' "$start_here" 'start-here must not treat survey/output as target source'
+
+# 10. Progress is a visible CLI contract.
+assert_contains 'Write-Progress' "$preflight" 'preflight missing Write-Progress'
+assert_contains 'PercentComplete' "$preflight" 'preflight missing percent progress'
+assert_contains '[$Step/$Total]' "$preflight" 'preflight missing [step/total] stage output'
+assert_contains '[$checkNumber/$totalChecks]' "$preflight" 'preflight missing [n/total] per-check output'
+
+# 11. No target file means list candidates and stop.
+assert_contains 'No -TargetFile was provided. Stopping without probing.' "$preflight" 'preflight must refuse to probe without target file'
+assert_contains 'Get-CandidateTargetFiles' "$preflight" 'preflight must discover candidate target files'
+
+# 12. Non-codified paths rejected unless explicit override is used.
+assert_contains 'AllowNonstandardInput' "$preflight" 'preflight missing explicit nonstandard override flag'
+assert_contains 'outside codified intake roots' "$preflight" 'preflight missing non-codified input rejection'
+assert_contains 'NONSTANDARD INPUT OVERRIDE' "$preflight" 'preflight override mode must be clearly labeled'
+
+# 13. TXT and CSV parsing support.
+assert_contains "'.txt'" "$preflight" 'preflight missing .txt support'
+assert_contains "'.csv'" "$preflight" 'preflight missing .csv support'
+assert_contains 'Import-Csv' "$preflight" 'preflight missing CSV parser'
+assert_contains 'HostName' "$preflight" 'preflight missing HostName column support'
+assert_contains 'Hostname' "$preflight" 'preflight missing Hostname column support'
+assert_contains 'Target' "$preflight" 'preflight missing Target column support'
+assert_contains 'Identifier' "$preflight" 'preflight missing Identifier column support'
+assert_contains 'ComputerName' "$preflight" 'preflight missing ComputerName column support'
+assert_contains 'DeviceName' "$preflight" 'preflight missing DeviceName column support'
+assert_contains 'Name' "$preflight" 'preflight missing Name column support'
+assert_contains 'Serial-only rows must be normalized or enriched' "$preflight" 'preflight must refuse serial-only target material clearly'
+
+# Documentation must present the simple field flow.
+assert_contains 'Export or copy the approved spreadsheet' "$runbook" 'runbook missing source export/copy step'
+assert_contains 'Run the PowerShell network preflight' "$runbook" 'runbook missing PowerShell preflight step'
+assert_contains 'Review the generated CSV under `survey/output/network_preflight/`' "$runbook" 'runbook missing output review step'
+
+# The field dashboard patch must point to the durable entrypoint, not emergency snippets.
+assert_contains '.\\survey\\sas-network-preflight.ps1' "$dashboard_patch" 'dashboard patch missing PowerShell preflight entrypoint'
+assert_contains 'survey\\output\\network_preflight' "$dashboard_patch" 'dashboard patch missing generated output folder'
+
+echo 'PASS: PowerShell network preflight contracts'

--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -8,105 +8,76 @@ start_here="$repo_root/START-HERE-CYBERNET-NEURON-SURVEY.md"
 dashboard_patch="$repo_root/dashboard/js/cybernet-os-preflight.js"
 field_files=("$runbook" "$start_here" "$dashboard_patch")
 
-fail() {
-  echo "FAIL: $*" >&2
-  exit 1
-}
+fail(){ echo "FAIL: $*" >&2; exit 1; }
+contains(){ grep -Fq -- "$1" "$2" || fail "$3"; }
+not_contains(){ grep -Fq -- "$1" "$2" && fail "$3"; }
+not_matches(){ grep -Eq -- "$1" "$2" && fail "$3"; }
 
-assert_file() {
-  [[ -f "$1" ]] || fail "missing file: $1"
-}
-
-assert_contains() {
-  local needle="$1" file="$2" message="$3"
-  grep -Fq -- "$needle" "$file" || fail "$message"
-}
-
-assert_not_contains() {
-  local needle="$1" file="$2" message="$3"
-  grep -Fq -- "$needle" "$file" && fail "$message"
-}
-
-assert_file "$preflight"
-assert_file "$runbook"
-assert_file "$start_here"
-assert_file "$dashboard_patch"
-
-# 1-2. Field preflight must not default to emergency temp paths.
-assert_not_contains 'C:\Temp' "$preflight" 'PowerShell preflight references C:\Temp'
-assert_not_contains '/tmp' "$preflight" 'PowerShell preflight references /tmp'
-assert_not_contains 'sas-cybernet' "$preflight" 'PowerShell preflight references emergency sas-cybernet temp folder'
-
-# 3. No executable live sample hostnames in the product field preflight surface.
 for f in "$preflight" "$runbook" "$start_here" "$dashboard_patch"; do
-  if grep -Eq '(^|[^A-Z0-9])(WMH|WNH|CYB)[0-9]{3,}[A-Z0-9_-]*' "$f"; then
-    fail "field preflight surface embeds executable-looking live/sample hostname: $f"
-  fi
+  [[ -f "$f" ]] || fail "missing file: $f"
 done
 
-# 4-5. No positive Git Bash/MINGW64 or Bash-syntax field path remains.
+win_temp_re='C:[\\]Temp'
+posix_tmp='/'tmp
+legacy_folder='sas-'cybernet
+git_shell='Git'' Bash'
+ming_shell='MING''W64'
+
+not_matches "$win_temp_re" "$preflight" 'preflight references emergency Windows temp intake'
+not_contains "$posix_tmp" "$preflight" 'preflight references POSIX temp intake'
+not_contains "$legacy_folder" "$preflight" 'preflight references legacy emergency target folder'
+
+for f in "$preflight" "$runbook" "$start_here" "$dashboard_patch"; do
+  grep -Eq '(^|[^A-Z0-9])(WMH|WNH|CYB)[0-9]{3,}[A-Z0-9_-]*' "$f" \
+    && fail "field preflight surface embeds executable-looking hostname: $f"
+done
+
 for f in "${field_files[@]}"; do
-  grep -Eiq 'Run (in|from) Git Bash|Windows Git Bash|MINGW64 prompt|bash bash/|bash survey/' "$f" \
-    && fail "field doc/dashboard still routes operators to a Bash/Git Bash path: $f"
+  grep -Eiq "Run (in|from) $git_shell|Windows $git_shell|$ming_shell prompt|bash bash/|bash survey/" "$f" \
+    && fail "field surface routes operators to a non-PowerShell shell: $f"
   grep -Eq 'mkdir -p|printf .+\\n' "$f" \
-    && fail "field doc/dashboard still contains Bash setup syntax: $f"
+    && fail "field surface contains Bash setup syntax: $f"
+  contains 'Run in Windows PowerShell' "$f" "missing PowerShell label in $f"
 done
 
-# 6. PowerShell command surfaces must be labeled PowerShell.
-for f in "${field_files[@]}"; do
-  assert_contains 'Run in Windows PowerShell' "$f" "missing PowerShell label in $f"
+contains 'Get-Content' "$preflight" 'missing TXT parser hook'
+contains 'Resolve-DnsName' "$preflight" 'missing DNS hook'
+contains 'Test-NetConnection' "$preflight" 'missing TCP hook'
+contains '-WarningAction SilentlyContinue' "$preflight" 'missing quiet warning handling'
+contains 'Export-Csv' "$preflight" 'missing CSV export'
+
+contains 'targets/local' "$preflight" 'missing targets/local input root'
+contains 'logs/targets' "$preflight" 'missing logs/targets input root'
+contains 'survey/input' "$preflight" 'missing survey/input staging root'
+contains 'Normalized runtime staging only' "$runbook" 'runbook missing staging doctrine'
+contains 'survey/output' "$preflight" 'missing survey/output output root'
+contains 'logs/nmap' "$preflight" 'missing logs/nmap output root'
+contains 'survey/artifacts' "$preflight" 'missing survey/artifacts output root'
+contains '`survey/output/` is generated output' "$start_here" 'start-here must classify survey/output as generated output'
+
+contains 'Write-Progress' "$preflight" 'missing Write-Progress'
+contains 'PercentComplete' "$preflight" 'missing percent progress'
+contains '[$Step/$Total]' "$preflight" 'missing stage [step/total] output'
+contains '[$checkNumber/$totalChecks]' "$preflight" 'missing per-check [n/total] output'
+
+contains 'No -TargetFile was provided. Stopping without probing.' "$preflight" 'must refuse no target file'
+contains 'Get-CandidateTargetFiles' "$preflight" 'must discover candidate target files'
+contains 'AllowNonstandardInput' "$preflight" 'missing explicit nonstandard override flag'
+contains 'outside codified intake roots' "$preflight" 'missing non-codified input rejection'
+contains 'NONSTANDARD INPUT OVERRIDE' "$preflight" 'missing clear override label'
+
+contains "'.txt'" "$preflight" 'missing .txt support'
+contains "'.csv'" "$preflight" 'missing .csv support'
+contains 'Import-Csv' "$preflight" 'missing CSV parser'
+for col in HostName Hostname Target Identifier ComputerName DeviceName Name; do
+  contains "$col" "$preflight" "missing $col column support"
 done
-assert_contains 'Get-Content' "$preflight" 'preflight must use Get-Content for TXT parsing'
-assert_contains 'Resolve-DnsName' "$preflight" 'preflight must use Resolve-DnsName for DNS'
-assert_contains 'Test-NetConnection' "$preflight" 'preflight must use Test-NetConnection for TCP checks'
-assert_contains 'Export-Csv' "$preflight" 'preflight must export CSV output'
-assert_contains '-WarningAction SilentlyContinue' "$preflight" 'Test-NetConnection warnings must be suppressed'
+contains 'Serial-only rows must be normalized or enriched' "$preflight" 'must refuse serial-only material clearly'
 
-# 7-9. Codified source/staging/output roots.
-assert_contains 'targets/local' "$preflight" 'preflight missing targets/local input root'
-assert_contains 'logs/targets' "$preflight" 'preflight missing logs/targets input root'
-assert_contains 'survey/input' "$preflight" 'preflight missing survey/input staging root'
-assert_contains 'survey/input is normalized runtime staging only' "$runbook" 'runbook must say survey/input is staging only'
-assert_contains 'survey/output' "$preflight" 'preflight missing survey/output output root'
-assert_contains 'logs/nmap' "$preflight" 'preflight missing logs/nmap output root'
-assert_contains 'survey/artifacts' "$preflight" 'preflight missing survey/artifacts output root'
-assert_contains 'survey/output/ is generated output, not the place to invent live targets' "$start_here" 'start-here must not treat survey/output as target source'
-
-# 10. Progress is a visible CLI contract.
-assert_contains 'Write-Progress' "$preflight" 'preflight missing Write-Progress'
-assert_contains 'PercentComplete' "$preflight" 'preflight missing percent progress'
-assert_contains '[$Step/$Total]' "$preflight" 'preflight missing [step/total] stage output'
-assert_contains '[$checkNumber/$totalChecks]' "$preflight" 'preflight missing [n/total] per-check output'
-
-# 11. No target file means list candidates and stop.
-assert_contains 'No -TargetFile was provided. Stopping without probing.' "$preflight" 'preflight must refuse to probe without target file'
-assert_contains 'Get-CandidateTargetFiles' "$preflight" 'preflight must discover candidate target files'
-
-# 12. Non-codified paths rejected unless explicit override is used.
-assert_contains 'AllowNonstandardInput' "$preflight" 'preflight missing explicit nonstandard override flag'
-assert_contains 'outside codified intake roots' "$preflight" 'preflight missing non-codified input rejection'
-assert_contains 'NONSTANDARD INPUT OVERRIDE' "$preflight" 'preflight override mode must be clearly labeled'
-
-# 13. TXT and CSV parsing support.
-assert_contains "'.txt'" "$preflight" 'preflight missing .txt support'
-assert_contains "'.csv'" "$preflight" 'preflight missing .csv support'
-assert_contains 'Import-Csv' "$preflight" 'preflight missing CSV parser'
-assert_contains 'HostName' "$preflight" 'preflight missing HostName column support'
-assert_contains 'Hostname' "$preflight" 'preflight missing Hostname column support'
-assert_contains 'Target' "$preflight" 'preflight missing Target column support'
-assert_contains 'Identifier' "$preflight" 'preflight missing Identifier column support'
-assert_contains 'ComputerName' "$preflight" 'preflight missing ComputerName column support'
-assert_contains 'DeviceName' "$preflight" 'preflight missing DeviceName column support'
-assert_contains 'Name' "$preflight" 'preflight missing Name column support'
-assert_contains 'Serial-only rows must be normalized or enriched' "$preflight" 'preflight must refuse serial-only target material clearly'
-
-# Documentation must present the simple field flow.
-assert_contains 'Export or copy the approved spreadsheet' "$runbook" 'runbook missing source export/copy step'
-assert_contains 'Run the PowerShell network preflight' "$runbook" 'runbook missing PowerShell preflight step'
-assert_contains 'Review the generated CSV under `survey/output/network_preflight/`' "$runbook" 'runbook missing output review step'
-
-# The field dashboard patch must point to the durable entrypoint, not emergency snippets.
-assert_contains '.\survey\sas-network-preflight.ps1' "$dashboard_patch" 'dashboard patch missing PowerShell preflight entrypoint'
-assert_contains 'survey\output\network_preflight' "$dashboard_patch" 'dashboard patch missing generated output folder'
+contains 'Export or copy the approved spreadsheet' "$runbook" 'runbook missing source export/copy step'
+contains 'Run the PowerShell network preflight' "$runbook" 'runbook missing PowerShell preflight step'
+contains 'Review the generated CSV under `survey/output/network_preflight/`' "$runbook" 'runbook missing output review step'
+contains '.\survey\sas-network-preflight.ps1' "$dashboard_patch" 'dashboard patch missing PowerShell entrypoint'
+contains 'survey\output\network_preflight' "$dashboard_patch" 'dashboard patch missing generated output folder'
 
 echo 'PASS: PowerShell network preflight contracts'

--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -10,8 +10,8 @@ field_files=("$runbook" "$start_here" "$dashboard_patch")
 
 fail(){ echo "FAIL: $*" >&2; exit 1; }
 contains(){ grep -Fq -- "$1" "$2" || fail "$3"; }
-not_contains(){ grep -Fq -- "$1" "$2" && fail "$3"; }
-not_matches(){ grep -Eq -- "$1" "$2" && fail "$3"; }
+not_contains(){ if grep -Fq -- "$1" "$2"; then fail "$3"; fi; }
+not_matches(){ if grep -Eq -- "$1" "$2"; then fail "$3"; fi; }
 
 for f in "$preflight" "$runbook" "$start_here" "$dashboard_patch"; do
   [[ -f "$f" ]] || fail "missing file: $f"

--- a/dashboard/js/cybernet-os-preflight.js
+++ b/dashboard/js/cybernet-os-preflight.js
@@ -1,120 +1,148 @@
-// cybernet-os-preflight.js — adds an OS selector for Cybernet tutorial commands.
-// This keeps Windows technicians from running Linux-style ping/DNS probes in Git Bash.
+// cybernet-os-preflight.js - PowerShell-first field command patcher.
+// The durable field path is repo-local PowerShell. Bash transport remains an advanced/developer lane,
+// but this Cybernet tutorial must not send Northwell field techs there.
 (function () {
   'use strict';
 
-  const STORAGE_KEY = 'sasCybernetTutorialOs';
-  const AUTO = 'auto-mixed';
-  const WINDOWS = 'windows-powershell';
-  const GIT_BASH = 'windows-gitbash';
-  const BASH = 'bash-posix';
+  const PREFLIGHT_DOC = 'docs/FIELD_NETWORK_PREFLIGHT.md';
 
-  const WINDOWS_PREFLIGHT = String.raw`$targets = Get-Content C:\Temp\sas-cybernet\targets.txt | Where-Object { $_.Trim() }
-$out = "C:\Temp\sas-cybernet\network_preflight.csv"
-$ports = 135,445,3389,9100
-New-Item -ItemType Directory -Force -Path (Split-Path $out) | Out-Null
-$rows = foreach ($target in $targets) {
-  $ip = (Resolve-DnsName $target -ErrorAction SilentlyContinue |
-    Where-Object { $_.IPAddress -match '^\d+\.' } |
-    Select-Object -First 1 -ExpandProperty IPAddress)
-  $pingOk = Test-Connection -ComputerName $target -Count 1 -Quiet
-  foreach ($port in $ports) {
-    $tcpOk = Test-NetConnection -ComputerName $target -Port $port -InformationLevel Quiet
-    [pscustomobject]@{
-      Target = $target
-      ResolvedAddress = $ip
-      PingStatus = if ($pingOk) { 'Reachable' } else { 'NoPing' }
-      Port = $port
-      PortStatus = if ($tcpOk) { 'Open' } else { 'Closed' }
-      Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
-      Notes = if (-not $pingOk) { 'Windows ICMP blocked or no ping response' } else { '' }
-    }
-  }
-}
-$rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
+  const COMMANDS = {
+    loadTargets: String.raw`Run in Windows PowerShell
 
-  const WINDOWS_IDENTITY = String.raw`$targets = Get-Content C:\Temp\sas-cybernet\targets.txt | Where-Object { $_.Trim() }
-$out = "C:\Temp\sas-cybernet\workstation_identity.csv"
-New-Item -ItemType Directory -Force -Path (Split-Path $out) | Out-Null
-$rows = foreach ($target in $targets) {
-  $ip = (Resolve-DnsName $target -ErrorAction SilentlyContinue |
-    Where-Object { $_.IPAddress -match '^\d+\.' } |
-    Select-Object -First 1 -ExpandProperty IPAddress)
-  $pingOk = Test-Connection -ComputerName $target -Count 1 -Quiet
-  [pscustomobject]@{
-    Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
-    Target = $target
-    ResolvedAddress = $ip
-    PingStatus = if ($pingOk) { 'Reachable' } else { 'NoPing' }
-    DnsName = $target
-    ObservedHostName = ''
-    ObservedSerial = ''
-    ObservedMACs = ''
-    TransportUsed = 'WindowsPing'
-    IdentityStatus = if ($pingOk) { 'ReachableNeedsApprovedIdentityTransport' } else { 'UnreachableOrBlocked' }
-    Notes = if ($pingOk) { 'Windows Test-Connection reachable; identity transport not run' } else { 'Windows Test-Connection failed or blocked' }
-  }
-}
-$rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1`,
 
-  const GIT_BASH_PREFLIGHT = String.raw`bash bash/transport/sas-network-preflight.sh \
-  --targets-file /tmp/sas-cybernet/targets.txt \
-  --ports 135,445,3389,9100 \
-  --ping-mode windows \
-  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru`;
+    networkPreflight: String.raw`Run in Windows PowerShell
 
-  const BASH_PREFLIGHT = String.raw`bash bash/transport/sas-network-preflight.sh \
-  --targets-file /tmp/sas-cybernet/targets.txt \
-  --ports 135,445,3389,9100 \
-  --ping-mode linux \
-  --output /tmp/sas-cybernet/network_preflight.csv --pass-thru`;
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1 -TargetFile .\targets\local\approved_targets.csv -Ports 135,445,3389,9100`,
 
-  const BASH_IDENTITY = String.raw`bash bash/transport/sas-workstation-identity.sh \
-  --targets-file /tmp/sas-cybernet/targets.txt \
-  --output /tmp/sas-cybernet/workstation_identity.csv --pass-thru`;
+    identityEvidence: String.raw`Run in Windows PowerShell
 
-  const notes = {
-    [AUTO]: 'Auto / mixed mode: do not choose target OS up front. Use the section for the admin shell you are standing at; the results will tell you what the target looks like.',
-    [WINDOWS]: 'Windows PowerShell mode uses Resolve-DnsName, Test-Connection, and Test-NetConnection.',
-    [GIT_BASH]: 'Windows Git Bash mode keeps Bash output paths but forces Windows ping.exe syntax to avoid false NoPing results.',
-    [BASH]: 'Linux/macOS/WSL Bash mode uses POSIX ping flags. Do not use this for Git Bash on a Windows admin box.'
+# Identity evidence is separate from network preflight.
+# Load an approved workstation_identity.csv only after an approved identity collection path produces it.
+# Network preflight output belongs under .\survey\output\network_preflight\ and can be loaded now.`,
+
+    optionalReachability: String.raw`Run in Windows PowerShell
+
+# Optional reachability beyond sas-network-preflight.ps1 is advanced scope.
+# Use the runbook first, then only run additional reachability tooling against an approved target file.
+Get-Content .\docs\FIELD_NETWORK_PREFLIGHT.md | Select-Object -First 40`,
+
+    finish: String.raw`Run in Windows PowerShell
+
+# Load Evidence in the dashboard accepts the generated network preflight CSV:
+# .\survey\output\network_preflight\network_preflight_<timestamp>.csv
+# Also load approved workstation_identity.csv or reachability JSON only when those files already exist.`
   };
 
-  function normalizeOs(value) {
-    return value === AUTO || value === WINDOWS || value === GIT_BASH || value === BASH ? value : AUTO;
-  }
-
-  function selectedOs() {
-    try {
-      return normalizeOs(localStorage.getItem(STORAGE_KEY));
-    } catch (_) {
-      return AUTO;
+  const PATCHES = {
+    'Load your targets': {
+      body: 'Select an approved target source. Place exported CSVs or target text files under targets/local/ or logs/targets/. Run the preflight script with no target file to list candidates and stop safely.',
+      command: COMMANDS.loadTargets,
+      checks: [
+        'Use approved target files from targets/local/ or logs/targets/.',
+        'survey/input is normalized staging only after an approved normalization step.',
+        'Do not type demo hostnames manually for live work.',
+        'Do not use CMD for this block. Do not paste non-PowerShell syntax.'
+      ],
+      note: 'This lists candidate target files and stops. Select the approved file before probing.',
+      explain: 'Runs the PowerShell entrypoint in safe selection mode so the operator can choose a codified target file.',
+      explainParts: [
+        ['Set-Location', 'Move to the SysAdminSuite repo root before running the script.'],
+        ['sas-network-preflight.ps1', 'Lists approved candidate files when no target file is supplied.'],
+        ['targets/local and logs/targets', 'Preferred ignored live intake roots.']
+      ]
+    },
+    'Check network posture': {
+      body: 'Run the repo PowerShell preflight against the selected approved target file. It performs read-only DNS, ping, and selected TCP port checks from the admin machine.',
+      command: COMMANDS.networkPreflight,
+      checks: [
+        'Run in Windows PowerShell.',
+        'Use targets/local/ or logs/targets/ for live intake.',
+        'Use survey/input/ only for normalized staging from a prior approved step.',
+        'Output is generated under survey/output/network_preflight/.',
+        'The script prints stage progress, [n/total], percent complete, and the final CSV path.'
+      ],
+      note: 'After it finishes, load the generated network_preflight CSV from survey/output/network_preflight/.',
+      explain: 'Runs read-only network posture checks against a bounded target file and writes local ignored CSV evidence.',
+      explainParts: [
+        ['-TargetFile', 'Explicit approved .txt or .csv target file.'],
+        ['-Ports', 'Selected TCP ports to check.'],
+        ['survey/output/network_preflight', 'Generated local output folder.']
+      ]
+    },
+    'Collect identity evidence': {
+      body: 'Identity evidence is not created by the network preflight script. Load an approved workstation identity CSV only when a separate approved identity collection path produced it.',
+      command: COMMANDS.identityEvidence,
+      checks: [
+        'Do not treat ping or open ports as serial identity proof.',
+        'Load workstation_identity.csv only when it came from an approved identity path.',
+        'Keep network_preflight as reachability and posture evidence only.'
+      ],
+      note: 'Skip this step unless approved identity evidence already exists.',
+      explain: 'Separates reachability posture from identity collection so serial proof does not get invented from network checks.',
+      explainParts: [
+        ['network_preflight', 'Reachability and posture evidence.'],
+        ['workstation_identity', 'Separate identity evidence, when approved and available.'],
+        ['approved identity path', 'WMI/CIM, SCCM, MDM, tracker, AD/CMDB, or operator-approved evidence.']
+      ]
+    },
+    'Optional reachability check': {
+      body: 'The PowerShell preflight already checks selected ports against the approved target file. Additional reachability tooling is advanced scope and must stay bounded to the same approved population.',
+      command: COMMANDS.optionalReachability,
+      checks: [
+        'Do not broaden scope beyond the selected approved target file.',
+        'Do not use broad subnet scans from this field tutorial.',
+        'Generated reachability evidence belongs in logs/nmap/ or survey/output/.',
+        'Read the field preflight runbook before adding optional reachability evidence.'
+      ],
+      note: 'Optional means optional. No extra probe is required when network_preflight is enough.',
+      explain: 'Keeps optional reachability separate from the default PowerShell preflight path.',
+      explainParts: [
+        ['FIELD_NETWORK_PREFLIGHT.md', 'Runbook for the durable field path.'],
+        ['approved target file', 'The only population that may be checked.'],
+        ['logs/nmap or survey/output', 'Generated local evidence folders.']
+      ]
+    },
+    'Finish and review results': {
+      body: 'Load the generated evidence files back into the dashboard. The expected network preflight output is under survey/output/network_preflight/.',
+      command: COMMANDS.finish,
+      checks: [
+        'Load network_preflight_<timestamp>.csv from survey/output/network_preflight/.',
+        'Load identity or reachability evidence only when separately approved and generated.',
+        'Do not load live source workbooks as proof of reachability.',
+        'Do not commit generated outputs.'
+      ],
+      note: 'Use Load Evidence for the generated CSV. Source files stay local and ignored.',
+      explain: 'Closes the loop by loading generated local evidence, not source target files, into the dashboard.',
+      explainParts: [
+        ['Load Evidence', 'Dashboard import area for generated CSV/JSON outputs.'],
+        ['network_preflight CSV', 'The generated result of this PowerShell preflight.'],
+        ['source target files', 'Inputs only, not evidence proof.']
+      ]
     }
+  };
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
-  function setSelectedOs(value) {
-    try {
-      localStorage.setItem(STORAGE_KEY, normalizeOs(value));
-    } catch (_) {
-      // Storage can be unavailable for local files or locked-down browsers.
-    }
-  }
-
-  function ensureOsCard(root) {
+  function ensureFieldRuleCard(root) {
     if (!root || document.getElementById('cybernet-os-preflight')) return;
     const card = document.createElement('div');
     card.id = 'cybernet-os-preflight';
     card.className = 'cybernet-os-preflight';
     card.innerHTML = `
-      <div class="cybernet-os-title">Optional command filter</div>
-      <label for="cybernet-os-select">Leave this on Auto for mixed sites. Pick one only if you already know which admin shell will run the command:</label>
-      <select id="cybernet-os-select">
-        <option value="auto-mixed">Auto / mixed environment — show Windows PowerShell + Bash</option>
-        <option value="windows-powershell">Windows PowerShell / Windows admin box</option>
-        <option value="windows-gitbash">Windows Git Bash / Windows ping.exe</option>
-        <option value="bash-posix">Linux/macOS/WSL Bash</option>
-      </select>
-      <div class="cybernet-os-note" id="cybernet-os-note"></div>
+      <div class="cybernet-os-title">Field shell rule</div>
+      <div class="cybernet-os-note" id="cybernet-os-note">
+        Run field preflight in Windows PowerShell. Use approved target files from targets/local/ or logs/targets/. See ${escapeHtml(PREFLIGHT_DOC)}.
+      </div>
     `;
     const stepCard = root.querySelector('.cybernet-step-card');
     root.insertBefore(card, stepCard || root.firstChild);
@@ -123,96 +151,54 @@ $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $out`;
     style.textContent = `
       .cybernet-os-preflight { margin: 12px 0; padding: 12px; border: 1px solid var(--border); border-radius: 10px; background: var(--bg2); display: grid; gap: 8px; }
       .cybernet-os-title { color: var(--accent); font-weight: 700; font-size: 13px; }
-      .cybernet-os-preflight label { color: var(--text-dim); font-size: 12px; }
-      .cybernet-os-preflight select { max-width: 420px; padding: 7px 10px; background: var(--bg3); color: var(--text); border: 1px solid var(--border); border-radius: 6px; }
       .cybernet-os-note { color: var(--text-muted); font-size: 12px; line-height: 1.4; }
     `;
     document.head.appendChild(style);
-
-    const select = document.getElementById('cybernet-os-select');
-    select.value = selectedOs();
-    select.addEventListener('change', () => {
-      const os = normalizeOs(select.value);
-      select.value = os;
-      setSelectedOs(os);
-      patchCurrentStep();
-    });
   }
 
-  function preflightCommandFor(os) {
-    if (os === AUTO) {
-      return [
-        '# Auto / mixed site: do not choose target OS yet.',
-        '# Copy and run ONE section below from the admin shell you are using.',
-        '',
-        '# --- Windows PowerShell admin box ---',
-        WINDOWS_PREFLIGHT,
-        '',
-        '# --- Windows Git Bash admin box ---',
-        GIT_BASH_PREFLIGHT,
-        '',
-        '# --- Linux/macOS/WSL Bash admin box ---',
-        BASH_PREFLIGHT
-      ].join('\n');
-    }
-    if (os === WINDOWS) return WINDOWS_PREFLIGHT;
-    if (os === GIT_BASH) return GIT_BASH_PREFLIGHT;
-    return BASH_PREFLIGHT;
+  function renderList(el, items) {
+    if (!el || !Array.isArray(items)) return;
+    el.innerHTML = items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
   }
 
-  function identityCommandFor(os) {
-    if (os === AUTO) {
-      return [
-        '# Auto / mixed site: do not choose target OS yet.',
-        '# Copy and run ONE section below from the admin shell you are using.',
-        '',
-        '# --- Windows PowerShell admin box ---',
-        WINDOWS_IDENTITY,
-        '',
-        '# --- Bash admin box ---',
-        BASH_IDENTITY
-      ].join('\n');
-    }
-    return os === WINDOWS ? WINDOWS_IDENTITY : BASH_IDENTITY;
+  function renderExplainParts(el, parts) {
+    if (!el || !Array.isArray(parts)) return;
+    el.innerHTML = parts
+      .map(([part, meaning]) => `<li><code>${escapeHtml(part)}</code> - ${escapeHtml(meaning)}</li>`)
+      .join('');
   }
 
   function patchCurrentStep() {
     const titleEl = document.getElementById('cybernet-step-title');
+    if (!titleEl) return;
+
+    const title = titleEl.textContent.trim();
+    const patch = PATCHES[title];
+    const cardEl = document.getElementById('cybernet-os-preflight');
+    if (cardEl) cardEl.classList.toggle('hidden', !patch);
+    if (!patch) return;
+
+    const bodyEl = document.getElementById('cybernet-step-body');
     const commandEl = document.getElementById('cybernet-step-command');
     const noteEl = document.getElementById('cybernet-step-note');
-    const osNoteEl = document.getElementById('cybernet-os-note');
-    const cardEl = document.getElementById('cybernet-os-preflight');
-    if (!titleEl || !commandEl) return;
+    const checksEl = document.getElementById('cybernet-step-checks');
+    const modeEl = document.getElementById('cybernet-command-mode');
+    const explainEl = document.getElementById('cybernet-command-explain');
+    const explainPartsEl = document.getElementById('cybernet-command-explain-parts');
 
-    const os = selectedOs();
-    const title = titleEl.textContent.trim();
-    const shouldShow = title === 'Check network posture' || title === 'Collect identity evidence';
-    if (cardEl) cardEl.classList.toggle('hidden', !shouldShow);
-    if (osNoteEl) osNoteEl.textContent = notes[os] || notes[AUTO];
-
-    if (title === 'Check network posture') {
-      commandEl.value = preflightCommandFor(os);
-      if (noteEl) noteEl.textContent = os === AUTO
-        ? 'Run one matching section outside the dashboard, then drag network_preflight.csv back into Load Evidence.'
-        : os === WINDOWS
-        ? 'Run this in Windows PowerShell, then drag C:\\Temp\\sas-cybernet\\network_preflight.csv into the dashboard.'
-        : 'Load network_preflight.csv into the Network tab after the command finishes.';
-    }
-
-    if (title === 'Collect identity evidence') {
-      commandEl.value = identityCommandFor(os);
-      if (noteEl) noteEl.textContent = os === AUTO
-        ? 'Run one matching section outside the dashboard, then drag workstation_identity.csv back into Load Evidence.'
-        : os === WINDOWS
-        ? 'Run this in Windows PowerShell to avoid Git Bash ping/DNS mismatch, then drag C:\\Temp\\sas-cybernet\\workstation_identity.csv into the dashboard.'
-        : 'Load workstation_identity.csv back into the dashboard for searchable protocol evidence.';
-    }
+    if (bodyEl) bodyEl.textContent = patch.body;
+    if (commandEl) commandEl.value = patch.command;
+    if (noteEl) noteEl.textContent = patch.note;
+    if (modeEl) modeEl.textContent = 'Run in Windows PowerShell';
+    if (explainEl) explainEl.textContent = patch.explain;
+    renderList(checksEl, patch.checks);
+    renderExplainParts(explainPartsEl, patch.explainParts);
   }
 
   function init() {
     const root = document.getElementById('cybernet-tutorial');
     if (!root) return;
-    ensureOsCard(root);
+    ensureFieldRuleCard(root);
     patchCurrentStep();
     root.addEventListener('click', () => setTimeout(patchCurrentStep, 0));
     const observer = new MutationObserver(() => patchCurrentStep());

--- a/docs/FIELD_NETWORK_PREFLIGHT.md
+++ b/docs/FIELD_NETWORK_PREFLIGHT.md
@@ -1,0 +1,123 @@
+# Field network preflight
+
+This is the durable Northwell field path for read-only network posture checks against approved Cybernet / Neuron target files.
+
+## Shell rule
+
+Use **Windows PowerShell** for this workflow.
+
+Do not use Git Bash / MINGW64 for field preflight. Do not use CMD for PowerShell blocks. Do not paste Bash commands into the Windows PowerShell window.
+
+CMD is only acceptable for simple Windows launcher commands, such as double-clicking or starting a `.bat` file that opens the dashboard.
+
+## Folder doctrine
+
+| Folder | Role |
+|---|---|
+| `targets/` | Tracked policy, schemas, and sanitized fixtures only |
+| `targets/local/` | Preferred ignored live intake for approved source CSVs, AD exports, trackers, and raw target material before normalization |
+| `logs/targets/` | Preserved ignored local target and evidence store |
+| `survey/input/` | Normalized runtime staging only |
+| `survey/output/` | Generated survey outputs |
+| `logs/nmap/` | Generated network probe output |
+| `survey/artifacts/` | Generated local artifacts |
+
+Do not type demo hostnames manually for live work. Do not use `C:\Temp` as the live workflow. Use approved target files from `targets/local/` or `logs/targets/` first. Use `survey/input/` only when a prior SysAdminSuite step produced normalized staging.
+
+## Field flow
+
+1. Export or copy the approved spreadsheet, AD export, tracker tab, or target source to `targets/local/` or `logs/targets/`.
+2. If the source is not already a `.txt` or `.csv` with probe-ready hostnames/IPs, normalize it first.
+3. Run the PowerShell network preflight against the selected target file.
+4. Review the generated CSV under `survey/output/network_preflight/`.
+5. Load the CSV into the dashboard through **Load Evidence**.
+
+## Spreadsheet source on X:\
+
+Do not probe a spreadsheet directly from `X:\` unless an existing tested ingestion path explicitly supports that source.
+
+Preferred path:
+
+1. Export the approved spreadsheet or target tab to CSV.
+2. Place the CSV under `targets/local/` or `logs/targets/`.
+3. Normalize if needed.
+4. Run the PowerShell preflight against the selected CSV.
+
+## Select a target file
+
+Run in Windows PowerShell:
+
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1
+```
+
+With no `-TargetFile`, the script lists candidate `.txt` and `.csv` files from `targets/local/` and `logs/targets/`, explains what the operator must select, and stops without probing.
+
+## Run the network preflight
+
+Run in Windows PowerShell:
+
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1 -TargetFile .\targets\local\approved_targets.csv -Ports 135,445,3389,9100
+```
+
+Alternative approved source root:
+
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1 -TargetFile .\logs\targets\approved_confirm_hosts.txt -Ports 135,445,3389,9100
+```
+
+The script prints the selected target file, target count, selected ports, output path, stage progress, `[n/total]` progress, percent complete, and final CSV path.
+
+## Accepted target files
+
+### `.txt`
+
+One hostname, IP address, or probe-ready identifier per line.
+
+Rules:
+
+- blank lines ignored
+- lines beginning with `#` ignored
+- whitespace trimmed
+- non-probe-ready values skipped
+
+### `.csv`
+
+Preferred target columns:
+
+- `HostName`
+- `Hostname`
+- `ComputerName`
+- `DeviceName`
+- `Name`
+
+Also accepted when probe-ready or explicitly typed as a hostname/IP:
+
+- `Target`
+- `Identifier`
+
+Serial-only rows are not network targets. If a CSV only contains serials, enrich or normalize it to hostnames first.
+
+## Outputs
+
+Default output folder:
+
+```text
+survey/output/network_preflight/
+```
+
+Output file pattern:
+
+```text
+network_preflight_<timestamp>.csv
+```
+
+Generated outputs are local and ignored. Do not commit live target lists, serial lists, AD exports, or probe results.
+
+## Safety boundary
+
+This preflight is read-only. It does not add credentials, mutate targets, install software, create remote tasks, or broaden scope beyond the selected approved target file.

--- a/survey/sas-network-preflight.ps1
+++ b/survey/sas-network-preflight.ps1
@@ -1,0 +1,421 @@
+<#
+.SYNOPSIS
+PowerShell-first SysAdminSuite field network preflight.
+
+.DESCRIPTION
+Runs read-only DNS, ping, and selected TCP port checks against an explicit approved target file.
+Live target intake is read from codified local roots only:
+- targets/local
+- logs/targets
+
+survey/input is accepted only as normalized runtime staging. Generated output is written under
+survey/output/network_preflight by default.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$TargetFile,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [int[]]$Ports = @(135, 445, 3389, 9100),
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputDirectory,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AllowNonstandardInput
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+function Resolve-SasRepoRoot {
+    $start = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
+    $cursor = [System.IO.Path]::GetFullPath($start)
+
+    while ($cursor) {
+        $targetsReadme = Join-Path $cursor 'targets/README.md'
+        $surveyDir = Join-Path $cursor 'survey'
+        if ((Test-Path -LiteralPath $targetsReadme) -and (Test-Path -LiteralPath $surveyDir)) {
+            return $cursor
+        }
+
+        $parent = Split-Path -Parent $cursor
+        if (-not $parent -or $parent -eq $cursor) { break }
+        $cursor = $parent
+    }
+
+    $cursor = [System.IO.Path]::GetFullPath((Get-Location).Path)
+    while ($cursor) {
+        $targetsReadme = Join-Path $cursor 'targets/README.md'
+        $surveyDir = Join-Path $cursor 'survey'
+        if ((Test-Path -LiteralPath $targetsReadme) -and (Test-Path -LiteralPath $surveyDir)) {
+            return $cursor
+        }
+
+        $parent = Split-Path -Parent $cursor
+        if (-not $parent -or $parent -eq $cursor) { break }
+        $cursor = $parent
+    }
+
+    throw 'Unable to resolve SysAdminSuite repo root from script path or current directory.'
+}
+
+function Get-FullPathSafe {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Test-IsUnderRoot {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Root
+    )
+
+    if (-not (Test-Path -LiteralPath $Root)) { return $false }
+
+    $fullPath = Get-FullPathSafe -Path $Path
+    $fullRoot = Get-FullPathSafe -Path $Root
+    if (-not $fullRoot.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+        $fullRoot = $fullRoot + [System.IO.Path]::DirectorySeparatorChar
+    }
+
+    return $fullPath.StartsWith($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Write-SasStageProgress {
+    param(
+        [Parameter(Mandatory = $true)][int]$Step,
+        [Parameter(Mandatory = $true)][int]$Total,
+        [Parameter(Mandatory = $true)][string]$Message,
+        [Parameter(Mandatory = $true)][int]$Percent
+    )
+
+    $boundedPercent = [Math]::Max(0, [Math]::Min(100, $Percent))
+    $line = "[$Step/$Total] $Message - $boundedPercent%"
+    Write-Host $line
+    Write-Progress -Activity 'SysAdminSuite network preflight' -Status $line -PercentComplete $boundedPercent
+}
+
+function Get-CandidateTargetFiles {
+    param([Parameter(Mandatory = $true)][string[]]$Roots)
+
+    foreach ($root in $Roots) {
+        if (-not (Test-Path -LiteralPath $root)) { continue }
+        Get-ChildItem -LiteralPath $root -File -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.Extension -in @('.txt', '.csv') } |
+            Sort-Object FullName
+    }
+}
+
+function Show-TargetFileSelectionHelp {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$CandidateRoots,
+        [Parameter(Mandatory = $true)][string]$StagingRoot
+    )
+
+    Write-Host 'No -TargetFile was provided. Stopping without probing.'
+    Write-Host ''
+    Write-Host 'Select an approved .txt or .csv target file from one of these live intake roots:'
+    foreach ($root in $CandidateRoots) { Write-Host "- $root" }
+    Write-Host ''
+    Write-Host "survey/input is normalized runtime staging only: $StagingRoot"
+    Write-Host ''
+    Write-Host 'Candidate files found:'
+    $candidates = @(Get-CandidateTargetFiles -Roots $CandidateRoots)
+    if ($candidates.Count -eq 0) {
+        Write-Host '- none found'
+    } else {
+        foreach ($candidate in $candidates) {
+            Write-Host "- $($candidate.FullName)"
+        }
+    }
+    Write-Host ''
+    Write-Host 'Run in Windows PowerShell:'
+    Write-Host '.\survey\sas-network-preflight.ps1 -TargetFile .\targets\local\approved_targets.csv -Ports 135,445,3389,9100'
+}
+
+function Test-IsIpAddress {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+    $ip = $null
+    return [System.Net.IPAddress]::TryParse($Value.Trim(), [ref]$ip)
+}
+
+function Test-ProbeReadyTargetValue {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $false }
+    $v = $Value.Trim()
+    if (Test-IsIpAddress -Value $v) { return $true }
+    if ($v -match '^[A-Za-z0-9][A-Za-z0-9.-]*\.[A-Za-z0-9.-]+$') { return $true }
+    if ($v -match '^[A-Za-z0-9]+[-_][A-Za-z0-9_-]+$') { return $true }
+    if ($v -match '^[A-Za-z]{2,6}[0-9]{2,}[A-Za-z0-9_-]*$') { return $true }
+    return $false
+}
+
+function Get-RowValue {
+    param(
+        [Parameter(Mandatory = $true)]$Row,
+        [Parameter(Mandatory = $true)][string[]]$Names
+    )
+
+    foreach ($name in $Names) {
+        $prop = $Row.PSObject.Properties | Where-Object { $_.Name -ieq $name } | Select-Object -First 1
+        if ($null -ne $prop -and -not [string]::IsNullOrWhiteSpace([string]$prop.Value)) {
+            return ([string]$prop.Value).Trim()
+        }
+    }
+    return ''
+}
+
+function Test-ExplicitHostType {
+    param($Row)
+    $typeValue = Get-RowValue -Row $Row -Names @('IdentifierType', 'TargetType', 'Type', 'ValueType')
+    if ([string]::IsNullOrWhiteSpace($typeValue)) { return $false }
+    return $typeValue -match '^(HostName|Hostname|Host|ComputerName|DnsName|FQDN|IPv4|IPv6|IPAddress|IP)$'
+}
+
+function Read-TextTargets {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $items = New-Object System.Collections.Generic.List[string]
+    foreach ($line in Get-Content -LiteralPath $Path -Encoding UTF8) {
+        $trimmed = ([string]$line).Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) { continue }
+        if ($trimmed.StartsWith('#')) { continue }
+        if (Test-ProbeReadyTargetValue -Value $trimmed) {
+            $items.Add($trimmed)
+        } else {
+            Write-Host "Skipping non-probe-ready TXT value: $trimmed"
+        }
+    }
+    return $items
+}
+
+function Read-CsvTargets {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $rows = @(Import-Csv -LiteralPath $Path)
+    $items = New-Object System.Collections.Generic.List[string]
+    $hostColumns = @('HostName', 'Hostname', 'ComputerName', 'DeviceName', 'Name')
+    $targetColumns = @('Target', 'Identifier')
+
+    foreach ($row in $rows) {
+        $host = Get-RowValue -Row $row -Names $hostColumns
+        if (-not [string]::IsNullOrWhiteSpace($host)) {
+            $items.Add($host)
+            continue
+        }
+
+        $target = Get-RowValue -Row $row -Names $targetColumns
+        if ([string]::IsNullOrWhiteSpace($target)) { continue }
+
+        if ((Test-ExplicitHostType -Row $row) -or (Test-ProbeReadyTargetValue -Value $target)) {
+            $items.Add($target)
+        }
+    }
+
+    return $items
+}
+
+function Read-ApprovedTargets {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $extension = [System.IO.Path]::GetExtension($Path).ToLowerInvariant()
+    switch ($extension) {
+        '.txt' { return Read-TextTargets -Path $Path }
+        '.csv' { return Read-CsvTargets -Path $Path }
+        default { throw "Unsupported target file extension '$extension'. Use .txt or .csv." }
+    }
+}
+
+function Resolve-TargetAddress {
+    param([Parameter(Mandatory = $true)][string]$Target)
+
+    if (Test-IsIpAddress -Value $Target) { return $Target.Trim() }
+
+    $cmd = Get-Command Resolve-DnsName -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        $record = Resolve-DnsName -Name $Target -ErrorAction SilentlyContinue |
+            Where-Object { $_.IPAddress -and $_.IPAddress -match '^\d+\.' } |
+            Select-Object -First 1
+        if ($null -ne $record) { return [string]$record.IPAddress }
+    }
+
+    try {
+        $addresses = [System.Net.Dns]::GetHostAddresses($Target)
+        $ipv4 = $addresses | Where-Object { $_.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } | Select-Object -First 1
+        if ($null -ne $ipv4) { return [string]$ipv4.IPAddressToString }
+    } catch {
+        return ''
+    }
+
+    return ''
+}
+
+function Test-PingStatus {
+    param([Parameter(Mandatory = $true)][string]$Target)
+
+    try {
+        $ok = Test-Connection -ComputerName $Target -Count 1 -Quiet -ErrorAction SilentlyContinue
+        if ($ok) { return 'Reachable' }
+        return 'NoPing'
+    } catch {
+        return 'NoPing'
+    }
+}
+
+function Test-PortStatus {
+    param(
+        [Parameter(Mandatory = $true)][string]$Target,
+        [Parameter(Mandatory = $true)][int]$Port
+    )
+
+    $cmd = Get-Command Test-NetConnection -ErrorAction SilentlyContinue
+    if ($null -eq $cmd) { return 'NotChecked' }
+
+    try {
+        $ok = Test-NetConnection -ComputerName $Target -Port $Port -InformationLevel Quiet -WarningAction SilentlyContinue
+        if ($ok) { return 'Open' }
+        return 'Closed'
+    } catch {
+        return 'Closed'
+    }
+}
+
+$repoRoot = Resolve-SasRepoRoot
+$targetsLocalRoot = Join-Path $repoRoot 'targets/local'
+$logsTargetsRoot = Join-Path $repoRoot 'logs/targets'
+$surveyInputRoot = Join-Path $repoRoot 'survey/input'
+$surveyOutputRoot = Join-Path $repoRoot 'survey/output'
+$logsNmapRoot = Join-Path $repoRoot 'logs/nmap'
+$surveyArtifactsRoot = Join-Path $repoRoot 'survey/artifacts'
+
+$candidateRoots = @($targetsLocalRoot, $logsTargetsRoot)
+$allowedInputRoots = @($targetsLocalRoot, $logsTargetsRoot, $surveyInputRoot)
+$allowedOutputRoots = @($surveyOutputRoot, $logsNmapRoot, $surveyArtifactsRoot)
+
+if ([string]::IsNullOrWhiteSpace($TargetFile)) {
+    Show-TargetFileSelectionHelp -CandidateRoots $candidateRoots -StagingRoot $surveyInputRoot
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath $TargetFile -PathType Leaf)) {
+    throw "Target file not found: $TargetFile"
+}
+
+$selectedTargetFile = Get-FullPathSafe -Path (Resolve-Path -LiteralPath $TargetFile).Path
+$inputIsCodified = $false
+foreach ($root in $allowedInputRoots) {
+    if (Test-IsUnderRoot -Path $selectedTargetFile -Root $root) {
+        $inputIsCodified = $true
+        break
+    }
+}
+
+if (-not $inputIsCodified) {
+    if (-not $AllowNonstandardInput) {
+        throw "Selected target file is outside codified intake roots. Use targets/local, logs/targets, or normalized survey/input. Refusing: $selectedTargetFile"
+    }
+    Write-Warning "NONSTANDARD INPUT OVERRIDE: selected file is outside codified intake roots: $selectedTargetFile"
+}
+
+if (-not $OutputDirectory) {
+    $OutputDirectory = Join-Path $surveyOutputRoot 'network_preflight'
+}
+
+$outputDirectoryFull = Get-FullPathSafe -Path $OutputDirectory
+$outputIsCodified = $false
+foreach ($root in $allowedOutputRoots) {
+    if (Test-IsUnderRoot -Path $outputDirectoryFull -Root $root) {
+        $outputIsCodified = $true
+        break
+    }
+}
+
+if (-not $outputIsCodified) {
+    if (-not $AllowNonstandardInput) {
+        throw "Output directory is outside codified output roots. Use survey/output, logs/nmap, or survey/artifacts. Refusing: $outputDirectoryFull"
+    }
+    Write-Warning "NONSTANDARD OUTPUT OVERRIDE: output directory is outside codified output roots: $outputDirectoryFull"
+}
+
+foreach ($port in $Ports) {
+    if ($port -lt 1 -or $port -gt 65535) { throw "Invalid TCP port: $port" }
+}
+
+Write-SasStageProgress -Step 1 -Total 4 -Message 'Loading approved target file' -Percent 25
+$targetsRaw = @(Read-ApprovedTargets -Path $selectedTargetFile)
+$seen = New-Object System.Collections.Generic.HashSet[string] ([System.StringComparer]::OrdinalIgnoreCase)
+$targets = New-Object System.Collections.Generic.List[string]
+foreach ($target in $targetsRaw) {
+    $clean = ([string]$target).Trim()
+    if ([string]::IsNullOrWhiteSpace($clean)) { continue }
+    if ($seen.Add($clean)) { $targets.Add($clean) }
+}
+
+if ($targets.Count -eq 0) {
+    throw 'The selected file did not yield probe-ready hostnames or IP addresses. Provide a .txt with one hostname/IP per line, or a .csv with HostName, Hostname, Target, Identifier, ComputerName, Name, or DeviceName. Serial-only rows must be normalized or enriched to hostnames before network preflight.'
+}
+
+New-Item -ItemType Directory -Force -Path $outputDirectoryFull | Out-Null
+$runId = Get-Date -Format 'yyyyMMdd_HHmmss'
+$outputCsv = Join-Path $outputDirectoryFull "network_preflight_$runId.csv"
+
+Write-Host "Selected target file: $selectedTargetFile"
+Write-Host "Target count: $($targets.Count)"
+Write-Host "Selected ports: $($Ports -join ',')"
+Write-Host "Output path: $outputCsv"
+
+Write-SasStageProgress -Step 2 -Total 4 -Message 'Resolving DNS for selected targets' -Percent 50
+$resolved = @{}
+$ping = @{}
+for ($i = 0; $i -lt $targets.Count; $i++) {
+    $target = $targets[$i]
+    $itemNumber = $i + 1
+    $percent = [int][Math]::Floor(($itemNumber / [double]$targets.Count) * 100)
+    $line = "[$itemNumber/$($targets.Count)] Resolving DNS for $target - $percent%"
+    Write-Host $line
+    Write-Progress -Activity 'Resolving DNS for selected targets' -Status $line -PercentComplete $percent
+    $resolved[$target] = Resolve-TargetAddress -Target $target
+    $pingTarget = if ($resolved[$target]) { $resolved[$target] } else { $target }
+    $ping[$target] = Test-PingStatus -Target $pingTarget
+}
+
+Write-SasStageProgress -Step 3 -Total 4 -Message 'Checking TCP ports' -Percent 75
+$rows = New-Object System.Collections.Generic.List[object]
+$totalChecks = $targets.Count * $Ports.Count
+$checkNumber = 0
+foreach ($target in $targets) {
+    $probeTarget = if ($resolved[$target]) { $resolved[$target] } else { $target }
+    foreach ($port in $Ports) {
+        $checkNumber++
+        $status = Test-PortStatus -Target $probeTarget -Port $port
+        $percent = [int][Math]::Floor(($checkNumber / [double]$totalChecks) * 100)
+        $line = "[$checkNumber/$totalChecks] $target port $port - $status - $percent%"
+        Write-Host $line
+        Write-Progress -Activity 'Checking TCP ports' -Status $line -PercentComplete $percent
+
+        $notes = @()
+        if (-not $resolved[$target]) { $notes += 'DNS unresolved or IP literal not resolved through DNS' }
+        if ($status -eq 'NotChecked') { $notes += 'Test-NetConnection unavailable in this PowerShell runtime' }
+
+        $rows.Add([pscustomobject]@{
+            Timestamp       = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+            Target          = $target
+            ResolvedAddress = $resolved[$target]
+            PingStatus      = $ping[$target]
+            Port            = $port
+            PortStatus      = $status
+            SourceFile      = $selectedTargetFile
+            Notes           = ($notes -join '; ')
+        })
+    }
+}
+
+Write-SasStageProgress -Step 4 -Total 4 -Message 'Writing network_preflight.csv' -Percent 100
+$rows | Export-Csv -LiteralPath $outputCsv -NoTypeInformation -Encoding UTF8
+Write-Progress -Activity 'SysAdminSuite network preflight' -Completed
+Write-Host "Final CSV path: $outputCsv"


### PR DESCRIPTION
## Summary

Adds a durable PowerShell-first field network preflight lane for approved Cybernet / Neuron target files.

## What changed

- Added `survey/sas-network-preflight.ps1`
  - resolves the SysAdminSuite repo root
  - requires an explicit `.txt` or `.csv` target file before probing
  - discovers candidates from `targets/local/` and `logs/targets/`
  - accepts `survey/input/` only as normalized staging
  - rejects non-codified input/output paths unless `-AllowNonstandardInput` is used
  - writes generated CSVs to `survey/output/network_preflight/`
  - prints selected file, target count, ports, output path, stages, `[n/total]`, percent complete, and final CSV path
- Added `docs/FIELD_NETWORK_PREFLIGHT.md`
- Reworked `START-HERE-CYBERNET-NEURON-SURVEY.md` to make the field path PowerShell-first
- Replaced the dashboard emergency `C:\Temp\sas-cybernet` / `/tmp/sas-cybernet` tutorial patch with the durable repo PowerShell entrypoint
- Added static contracts in `Tests/bash/test_powershell_network_preflight_contracts.sh`
- Wired the new contract into `.github/workflows/dashboard-smoke.yml`

## Safety posture

Read-only network preflight only. No credentials, no target mutation, no hidden telemetry behavior, no scan broadening beyond the selected approved target file.

## Validation

- Static contract added for codified roots, no emergency temp defaults, no executable sample hostnames, PowerShell labeling, output folders, path rejection, progress output, and `.txt` / `.csv` parsing support.
- CI workflow updated to run the new contract.