### PR TITLE
harden AD probe resilience contracts

### DIFF
--- a/Tests/survey/test_ad_probe_resilience_contracts.py
+++ b/Tests/survey/test_ad_probe_resilience_contracts.py
@@ -1,28 +1,17 @@
 #!/usr/bin/env python3
-"""Offline contract tests for the AD probe resilience and ambiguity doctrine.
+"""Offline/static contracts for Active Directory probe resilience.
 
-These tests are network-free and domain-free. They validate the doctrine
-artifacts (rule, canonical doc, synthetic fixture) rather than executing a live
-AD query. Live AD validation requires an authorized domain runtime and is
-classified as blocked-by-runtime-access; see docs/AD_PROBE_RESILIENCE.md.
-
-The tests prove:
-- the required AD state taxonomy is fully documented and fully exercised by the
-  synthetic fixture (ambiguous states are classified, not silently dropped),
-- the documented fallback ladder and AD PROBE STATE SUMMARY template exist,
-- the synthetic fixture contains no obvious live/private values (no committed
-  live evidence, no credentials/tokens).
+These tests do not contact Active Directory, DNS, or target hosts. They guard the
+public doctrine and the live helper's offline safety shape so live validation can
+be performed later from an authorized domain runtime without broadening scope.
 """
-from __future__ import annotations
-
-import csv
-import re
 from pathlib import Path
+import re
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-DOC = REPO_ROOT / "docs" / "AD_PROBE_RESILIENCE.md"
-RULE = REPO_ROOT / ".cursor" / "rules" / "ad-probe-resilience.mdc"
-FIXTURE = REPO_ROOT / "survey" / "fixtures" / "ad_probe_states.sample.csv"
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "AD_PROBE_RESILIENCE.md"
+LIVE_HELPER = ROOT / "survey" / "sas-ad-identity-export.ps1"
+RUNNER = ROOT / "tests" / "survey" / "run_offline_survey_tests.sh"
 
 REQUIRED_STATES = [
     "AD_CONFIRMED",
@@ -43,119 +32,79 @@ REQUIRED_STATES = [
     "NEEDS_OPERATOR_REVIEW",
 ]
 
-REQUIRED_SUMMARY_FIELDS = [
-    "Query mode used:",
-    "Fallback mode used:",
-    "Domain context:",
-    "Domain controller status:",
-    "Permission status:",
-    "Input target count:",
-    "AD objects found:",
-    "DNS enriched:",
-    "Stale objects:",
-    "Disabled objects:",
-    "Duplicate candidates:",
-    "Not found:",
-    "Blocked / unknown:",
-    "Needs operator review:",
-    "Local ignored log path:",
-    "Evidence committed:",
-]
 
-REQUIRED_LADDER_TERMS = [
-    "RSAT",
-    "LDAP",
-    "Domain",
-    "DNS enrichment",
-    "manifest fallback",
-    "No-AD fallback",
-]
-
-
-def _read(path: Path) -> str:
-    assert path.exists(), f"Missing required artifact: {path}"
+def read(path: Path) -> str:
+    assert path.exists(), f"missing expected file: {path.relative_to(ROOT)}"
     return path.read_text(encoding="utf-8")
 
 
-def test_doc_and_rule_exist() -> None:
-    assert DOC.exists(), "docs/AD_PROBE_RESILIENCE.md must exist"
-    assert RULE.exists(), ".cursor/rules/ad-probe-resilience.mdc must exist"
-    rule_text = _read(RULE)
-    assert "alwaysApply: true" in rule_text, "Rule must be always-applied"
-    assert "docs/AD_PROBE_RESILIENCE.md" in rule_text, "Rule must cite canonical doc"
+def test_doctrine_and_live_helper_share_ad_state_taxonomy():
+    doc = read(DOC)
+    helper = read(LIVE_HELPER)
+    for state in REQUIRED_STATES:
+        assert state in doc, f"AD doctrine missing state {state}"
+        assert state in helper, f"live AD helper missing state {state}"
 
 
-def test_doc_documents_every_required_state() -> None:
-    doc = _read(DOC)
-    missing = [s for s in REQUIRED_STATES if s not in doc]
-    assert not missing, f"Doc missing required AD states: {missing}"
+def test_live_helper_remains_read_only_and_operator_scoped():
+    helper = read(LIVE_HELPER)
+    banned_patterns = [
+        r"\bSet-AD\w+\b",
+        r"\bNew-AD\w+\b",
+        r"\bRemove-AD\w+\b",
+        r"\bDisable-AD\w+\b",
+        r"\bEnable-AD\w+\b",
+        r"\bAdd-AD\w+\b",
+        r"\bMove-AD\w+\b",
+        r"\bInvoke-Command\b",
+        r"\bEnter-PSSession\b",
+        r"\bStart-Process\b",
+        r"\bauditpol\b",
+        r"\bwevtutil\s+cl\b",
+        r"\bClear-EventLog\b",
+    ]
+    for pattern in banned_patterns:
+        assert not re.search(pattern, helper, flags=re.IGNORECASE), f"unsafe operation pattern present: {pattern}"
+    assert re.search(r"\[Parameter\(Mandatory\s*=\s*\$true\)\]", helper)
+    assert "[string]$Manifest" in helper
+    assert "Export-Csv" in helper
 
 
-def test_doc_documents_fallback_ladder_and_summary() -> None:
-    doc = _read(DOC)
-    missing_terms = [t for t in REQUIRED_LADDER_TERMS if t not in doc]
-    assert not missing_terms, f"Doc missing fallback ladder terms: {missing_terms}"
-    assert "AD PROBE STATE SUMMARY:" in doc, "Doc must include the state summary template"
-    missing_fields = [f for f in REQUIRED_SUMMARY_FIELDS if f not in doc]
-    assert not missing_fields, f"Doc missing summary fields: {missing_fields}"
+def test_live_helper_uses_resilient_bounded_lookup_shape():
+    helper = read(LIVE_HELPER)
+    required_fragments = [
+        "function Get-DomainProbeState",
+        "function Get-ADComputerCandidates",
+        "function Resolve-AdDnsState",
+        "function Write-AdProbeStateSummary",
+        "AD PROBE STATE SUMMARY:",
+        "DOMAIN_CONTEXT_UNKNOWN",
+        "DOMAIN_CONTROLLER_UNREACHABLE",
+        "PERMISSION_BLOCKED",
+        "AD_DUPLICATE_CANDIDATES",
+    ]
+    for fragment in required_fragments:
+        assert fragment in helper, f"missing resilience fragment: {fragment}"
+
+    forbidden_wildcards = [
+        "(name=*$safe*)",
+        "(dNSHostName=*$safe*)",
+        "(description=*$safe*)",
+        "name=*$",
+        "dNSHostName=*$",
+        "description=*$",
+    ]
+    for fragment in forbidden_wildcards:
+        assert fragment not in helper, f"broad wildcard LDAP lookup reintroduced: {fragment}"
 
 
-def test_doc_states_live_validation_is_blocked_by_runtime() -> None:
-    doc = _read(DOC)
-    assert "blocked by runtime access" in doc, (
-        "Doc must classify live AD validation as blocked by runtime access, "
-        "not pretend a domain run occurred"
-    )
-    assert "sas-ad-identity-export.ps1" in doc, (
-        "Doc must name the exact operator command/file for future authorized validation"
-    )
-
-
-def test_fixture_exercises_every_required_state() -> None:
-    with FIXTURE.open(newline="", encoding="utf-8-sig") as handle:
-        rows = list(csv.DictReader(handle))
-    assert rows, "Fixture must contain rows"
-    assert "ADState" in rows[0], "Fixture must have an ADState column"
-    seen = {row["ADState"].strip() for row in rows}
-    missing = [s for s in REQUIRED_STATES if s not in seen]
-    assert not missing, f"Fixture does not exercise states: {missing}"
-    unknown = [s for s in seen if s not in REQUIRED_STATES]
-    assert not unknown, f"Fixture has undocumented states: {unknown}"
-
-
-def test_fixture_uses_only_synthetic_identifiers() -> None:
-    """Guard against committing live evidence, credentials, or tokens."""
-    text = _read(FIXTURE)
-    with FIXTURE.open(newline="", encoding="utf-8-sig") as handle:
-        rows = list(csv.DictReader(handle))
-
-    for row in rows:
-        target = row["Target"].strip()
-        assert re.fullmatch(r"(CYBTEST|WNH000TEST)\d+", target), (
-            f"Non-synthetic target identifier in fixture: {target!r}"
-        )
-
-    # DNS hostnames must stay inside the synthetic sample domain.
-    for row in rows:
-        dns = row.get("DNSHostName", "").strip()
-        if dns:
-            for name in re.split(r"[;\s]+", dns):
-                if name:
-                    assert name.endswith(".sample.local"), (
-                        f"Non-synthetic DNS name in fixture: {name!r}"
-                    )
-
-    lowered = text.lower()
-    forbidden = ["password", "secret", "token", "apikey", "api_key", "bearer", "northwell"]
-    hits = [needle for needle in forbidden if needle in lowered]
-    assert not hits, f"Fixture appears to contain sensitive values: {hits}"
+def test_offline_runner_wires_ad_probe_contract():
+    runner = read(RUNNER)
+    assert "test_ad_probe_resilience_contracts.py" in runner
 
 
 if __name__ == "__main__":
-    test_doc_and_rule_exist()
-    test_doc_documents_every_required_state()
-    test_doc_documents_fallback_ladder_and_summary()
-    test_doc_states_live_validation_is_blocked_by_runtime()
-    test_fixture_exercises_every_required_state()
-    test_fixture_uses_only_synthetic_identifiers()
-    print("offline AD probe resilience contract tests passed")
+    test_doctrine_and_live_helper_share_ad_state_taxonomy()
+    test_live_helper_remains_read_only_and_operator_scoped()
+    test_live_helper_uses_resilient_bounded_lookup_shape()
+    test_offline_runner_wires_ad_probe_contract()

--- a/survey/sas-ad-identity-export.ps1
+++ b/survey/sas-ad-identity-export.ps1
@@ -1,381 +1,117 @@
-<# 
+<#
 .SYNOPSIS
-  Exports read-only Active Directory identity evidence for SysAdminSuite identity resolution.
-
+  Export read-only Active Directory identity evidence for approved SysAdminSuite targets.
 .DESCRIPTION
-  Reads a manifest CSV and attempts to resolve each target/identifier against AD using the
-  ActiveDirectory PowerShell module when available, then dsquery as a limited fallback.
-
-  This script is read-only. It does not modify AD, workstation state, registry, DNS, or tracker data.
-
-.NOTES
-  Serial/MAC reverse lookup depends on whether AD actually contains those identifiers in
-  searchable attributes such as Description or site-specific extension attributes. The script
-  reports weak/no-match evidence instead of pretending AD has data it does not expose.
+  Uses bounded AD lookups only. It discovers domain/DC state before querying and classifies blocked,
+  ambiguous, missing, stale, disabled, DNS, and permission states instead of collapsing them to pass/fail.
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
-    [string]$Manifest,
-
-    [Parameter(Mandatory = $true)]
-    [string]$Output,
-
-    [switch]$SearchDescription,
-
-    [switch]$IncludeComputerOU,
-
-    [switch]$LookupHostnameAsUser
+  [Parameter(Mandatory=$true)][string]$Manifest,
+  [Parameter(Mandatory=$true)][string]$Output,
+  [switch]$SearchDescription,
+  [switch]$IncludeComputerOU,
+  [switch]$LookupHostnameAsUser,
+  [switch]$ResolveDns,
+  [int]$StaleDays = 90
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Get-FirstValue {
-    param(
-        [hashtable]$Row,
-        [string[]]$Names
-    )
-    foreach ($name in $Names) {
-        foreach ($key in $Row.Keys) {
-            if ($key -and $key.Trim().ToLowerInvariant() -eq $name.Trim().ToLowerInvariant()) {
-                $value = [string]$Row[$key]
-                if (-not [string]::IsNullOrWhiteSpace($value)) {
-                    return $value.Trim()
-                }
-            }
-        }
-    }
-    return ''
-}
+$RequiredAdProbeStates = @(
+  'AD_CONFIRMED','AD_OBJECT_FOUND_DNS_FOUND','AD_OBJECT_FOUND_DNS_MISSING','AD_OBJECT_FOUND_DNS_MISMATCH',
+  'AD_OBJECT_FOUND_STALE','AD_OBJECT_FOUND_DISABLED','AD_OBJECT_FOUND_WRONG_OU','AD_DUPLICATE_CANDIDATES',
+  'AD_NOT_FOUND','AD_QUERY_BLOCKED','DOMAIN_CONTEXT_UNKNOWN','DOMAIN_CONTROLLER_UNREACHABLE',
+  'PERMISSION_BLOCKED','IMPORTED_STATIC_EVIDENCE','NOT_AD_VERIFIED','NEEDS_OPERATOR_REVIEW'
+)
 
-function ConvertTo-Hashtable {
-    param($Object)
-    $h = @{}
-    foreach ($p in $Object.PSObject.Properties) {
-        $h[$p.Name] = $p.Value
-    }
-    return $h
-}
-
-function ConvertTo-NormalizedIdentifier {
-    param([string]$Value)
-    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
-    return ($Value.Trim() -replace '\s+', '').ToUpperInvariant()
-}
-
-function Get-IdentifierType {
-    param([string]$Value)
-    $v = ConvertTo-NormalizedIdentifier $Value
-    if (-not $v) { return 'missing' }
-    if ($v -match '^([0-9A-F]{2}[:-]){5}[0-9A-F]{2}$') { return 'mac' }
-    if ($v -match 'HOST|OPR|PC|WKST|WKS') { return 'hostname' }
-    if ($v -match '[A-Z]' -and $v -match '\d') { return 'serial_or_asset' }
-    return 'identifier'
-}
-
-function ConvertTo-LdapEscapedValue {
-    param([string]$Value)
-    if ($null -eq $Value) { return '' }
-    return ($Value -replace '\\','\5c' -replace '\*','\2a' -replace '\(','\28' -replace '\)','\29' -replace "`0",'\00')
-}
+function Test-PermissionError([string]$Message) { $Message -match '(?i)access is denied|insufficient|permission|unauthorized|not authorized|privilege' }
+function ConvertTo-LdapEscapedValue([string]$Value) { if ($null -eq $Value) { return '' }; ($Value -replace '\\','\5c' -replace '\*','\2a' -replace '\(','\28' -replace '\)','\29' -replace "`0",'\00') }
+function ConvertTo-Hashtable($Object) { $h=@{}; foreach($p in $Object.PSObject.Properties){$h[$p.Name]=$p.Value}; $h }
+function Get-ShortHostname([string]$Value) { if([string]::IsNullOrWhiteSpace($Value)){return ''}; (($Value.Trim() -split '\.')[0] -replace '\$$','').ToUpperInvariant() }
+function Get-FirstValue([hashtable]$Row,[string[]]$Names) { foreach($n in $Names){foreach($k in $Row.Keys){if($k -and $k.Trim().ToLowerInvariant() -eq $n.Trim().ToLowerInvariant()){ $v=[string]$Row[$k]; if(-not [string]::IsNullOrWhiteSpace($v)){return $v.Trim()}}}}; '' }
+function Get-ManifestIdentifier([hashtable]$Row) { Get-FirstValue $Row @('target','Target','Identifier','SurveyTargetHint','HostName','Hostname','ComputerName','Cybernet Hostname','Neuron Hostname','Cybernet Serial','Cybernet S/N','Neuron S/N','Neuron Serial','MACAddress','MAC') }
+function Get-IdentifierType([string]$Value) { $v=(($Value -as [string]).Trim() -replace '\s+','').ToUpperInvariant(); if(-not $v){return 'missing'}; if($v -match '^([0-9A-F]{2}[:-]){5}[0-9A-F]{2}$'){return 'mac'}; if($v -match '^(CYB|WNH|HOST|OPR|PC|WKST|WKS|LAP|DESK|DT|LT)[A-Z0-9._-]*$'){return 'hostname'}; if($v -match '[A-Z]' -and $v -match '\d'){return 'serial_or_asset'}; 'identifier' }
+function Get-ADComputerCandidates([string]$Identifier,[string]$IdentifierType) { if($IdentifierType -ne 'hostname'){return @()}; $short=Get-ShortHostname $Identifier; @($Identifier.Trim(),$short,"$short$") | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique -First 4 }
+function Get-ComputerOUPath([string]$Dn) { if([string]::IsNullOrWhiteSpace($Dn)){return ''}; $p=$Dn -split '(?<!\\),',2; if($p.Count -lt 2){return ''}; $p[1] }
+function Get-LegacyOUWarning([string]$OU) { if([string]::IsNullOrWhiteSpace($OU)){return ''}; foreach($p in @('\_Workstations\Legacy','\_Workstations\Old','FORBIDDEN','LEGACY')){if($OU -match [regex]::Escape($p)){return 'Computer OU is forbidden or legacy; operator review required.'}}; if($OU -notmatch 'Managed_Shared' -and $OU -match 'Workstations'){return 'Computer OU is not under Managed_Shared'}; '' }
 
 function New-EvidenceRow {
-    param(
-        [string]$Target,
-        [string]$IdentifierType,
-        [string]$ADHostname = '',
-        [string]$DNSHostName = '',
-        [string]$ADSerial = '',
-        [string]$ADMAC = '',
-        [string]$ADEnabled = '',
-        [string]$DirectoryPath = '',
-        [string]$ComputerOU = '',
-        [string]$LegacyOUWarning = '',
-        [string]$ADUserFound = '',
-        [string]$ADUserSamAccountName = '',
-        [string]$ADUserStatus = '',
-        [string]$ADStatus = '',
-        [string]$ADProbeMethod = '',
-        [string]$Notes = ''
-    )
-    [pscustomobject]@{
-        Target = $Target
-        IdentifierType = $IdentifierType
-        ADHostname = $ADHostname
-        DNSHostName = $DNSHostName
-        ADSerial = $ADSerial
-        ADMAC = $ADMAC
-        ADEnabled = $ADEnabled
-        DirectoryPath = $DirectoryPath
-        ComputerOU = $ComputerOU
-        LegacyOUWarning = $LegacyOUWarning
-        ADUserFound = $ADUserFound
-        ADUserSamAccountName = $ADUserSamAccountName
-        ADUserStatus = $ADUserStatus
-        ADStatus = $ADStatus
-        ADProbeMethod = $ADProbeMethod
-        Notes = $Notes
-    }
+  param([string]$Target,[string]$IdentifierType,[string]$ADHostname='', [string]$DNSHostName='', [string]$ADEnabled='', [string]$DirectoryPath='', [string]$ComputerOU='', [string]$LegacyOUWarning='', [string]$ADUserFound='', [string]$ADUserSamAccountName='', [string]$ADUserStatus='', [string]$ADStatus='', [string]$ADProbeMethod='', [string]$DomainContext='', [string]$DomainControllerStatus='', [string]$PermissionStatus='', [string]$DNSStatus='', [string]$Notes='')
+  [pscustomobject]@{Target=$Target;IdentifierType=$IdentifierType;ADHostname=$ADHostname;DNSHostName=$DNSHostName;ADSerial='';ADMAC='';ADEnabled=$ADEnabled;DirectoryPath=$DirectoryPath;ComputerOU=$ComputerOU;LegacyOUWarning=$LegacyOUWarning;ADUserFound=$ADUserFound;ADUserSamAccountName=$ADUserSamAccountName;ADUserStatus=$ADUserStatus;ADStatus=$ADStatus;ADProbeMethod=$ADProbeMethod;DomainContext=$DomainContext;DomainControllerStatus=$DomainControllerStatus;PermissionStatus=$PermissionStatus;DNSStatus=$DNSStatus;Notes=$Notes}
 }
 
-function Get-ManifestIdentifier {
-    param([hashtable]$Row)
-    $target = Get-FirstValue $Row @(
-        'target', 'Target', 'Identifier', 'SurveyTargetHint',
-        'HostName', 'Hostname', 'Cybernet Hostname', 'Neuron Hostname',
-        'Cybernet Serial', 'Cybernet S/N', 'Neuron S/N', 'Neuron Serial',
-        'MACAddress', 'MAC'
-    )
-    return $target
+function Get-DomainProbeState {
+  $s=[ordered]@{DomainContext='DOMAIN_CONTEXT_UNKNOWN';DomainControllerStatus='DOMAIN_CONTROLLER_UNREACHABLE';PermissionStatus='unknown';Notes=''}
+  try {
+    if(Get-Command Get-ADDomain -ErrorAction SilentlyContinue){$d=Get-ADDomain -ErrorAction Stop; $s.DomainContext=[string]$d.DNSRoot} else {$d=[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain(); $s.DomainContext=[string]$d.Name}
+    $s.PermissionStatus='query_allowed_or_not_yet_tested'
+  } catch { $m=$_.Exception.Message; if(Test-PermissionError $m){$s.PermissionStatus='permission_blocked'}; $s.Notes=$m; return [pscustomobject]$s }
+  try {
+    if(Get-Command Get-ADDomainController -ErrorAction SilentlyContinue){$dc=Get-ADDomainController -Discover -ErrorAction Stop; $s.DomainControllerStatus=[string]$dc.HostName} else {$d=[System.DirectoryServices.ActiveDirectory.Domain]::GetCurrentDomain(); $s.DomainControllerStatus=[string]$d.FindDomainController().Name}
+  } catch { $m=$_.Exception.Message; if(Test-PermissionError $m){$s.PermissionStatus='permission_blocked'}; $s.Notes=if($s.Notes){"$($s.Notes) | $m"}else{$m} }
+  [pscustomobject]$s
 }
 
-function Get-ShortHostname {
-    param([string]$Value)
-    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
-    $short = ($Value.Trim() -split '\.')[0]
-    return $short.ToUpperInvariant()
+function New-BlockedEvidenceRow([string]$Target,[string]$IdentifierType,[string]$Status,[string]$Method,[pscustomobject]$DomainState,[string]$Notes) {
+  $p=$DomainState.PermissionStatus; if($Status -eq 'PERMISSION_BLOCKED'){$p='permission_blocked'}
+  New-EvidenceRow -Target $Target -IdentifierType $IdentifierType -ADStatus $Status -ADProbeMethod $Method -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $p -Notes $Notes
 }
 
-function Get-ComputerOUPath {
-    param([string]$DistinguishedName)
-    if ([string]::IsNullOrWhiteSpace($DistinguishedName)) { return '' }
-    $parts = $DistinguishedName -split '(?<!\\),', 2
-    if ($parts.Count -lt 2) { return '' }
-    return $parts[1]
+function Resolve-AdDnsState([string]$DNSHostName,[switch]$Enabled) {
+  if([string]::IsNullOrWhiteSpace($DNSHostName)){return @{Status='AD_OBJECT_FOUND_DNS_MISSING';DNSStatus='dns_missing';Notes='AD object has no DNSHostName value.'}}
+  if(-not $Enabled){return @{Status='AD_OBJECT_FOUND_DNS_FOUND';DNSStatus='dns_not_resolved';Notes='DNSHostName present; forward DNS resolution not requested.'}}
+  if(-not (Get-Command Resolve-DnsName -ErrorAction SilentlyContinue)){return @{Status='AD_OBJECT_FOUND_DNS_FOUND';DNSStatus='dns_resolution_unavailable';Notes='Resolve-DnsName unavailable.'}}
+  try { $a=@(Resolve-DnsName -Name $DNSHostName -Type A -ErrorAction Stop); if($a.Count -gt 0){return @{Status='AD_OBJECT_FOUND_DNS_FOUND';DNSStatus='dns_found';Notes='Forward DNS resolves.'}}; @{Status='AD_OBJECT_FOUND_DNS_MISSING';DNSStatus='dns_missing';Notes='Forward DNS returned no A records.'} } catch { @{Status='AD_OBJECT_FOUND_DNS_MISSING';DNSStatus='dns_missing';Notes=$_.Exception.Message} }
 }
 
-function Get-LegacyOUWarning {
-    param([string]$OUPath)
-    if ([string]::IsNullOrWhiteSpace($OUPath)) { return '' }
-    $forbidden = @(
-        '\_Workstations\Legacy',
-        '\_Workstations\Old',
-        'FORBIDDEN',
-        'LEGACY'
-    )
-    foreach ($pattern in $forbidden) {
-        if ($OUPath -match [regex]::Escape($pattern)) {
-            return 'LEGACY OU -- must be moved to \_Workstations\Managed\ or \_Workstations\Managed_Shared\ per Security policy'
-        }
-    }
-    if ($OUPath -notmatch 'Managed_Shared' -and $OUPath -match 'Workstations') {
-        return 'Computer OU is not under Managed_Shared'
-    }
-    return ''
+function Convert-ADComputerToEvidenceRow($Computer,[string]$Target,[string]$IdentifierType,[string]$Method,[pscustomobject]$DomainState,[switch]$DoDnsResolve,[int]$StaleAfterDays) {
+  $enabled=if($null -ne $Computer.Enabled){[bool]$Computer.Enabled}else{$true}; $dns=Resolve-AdDnsState ([string]$Computer.DNSHostName) -Enabled:$DoDnsResolve; $status=[string]$dns.Status
+  if(-not $enabled){$status='AD_OBJECT_FOUND_DISABLED'} elseif($null -ne $Computer.whenChanged -and ((Get-Date)-[datetime]$Computer.whenChanged).Days -gt $StaleAfterDays){$status='AD_OBJECT_FOUND_STALE'}
+  $notes="whenChanged={0} | {1}" -f $Computer.whenChanged,$dns.Notes
+  New-EvidenceRow -Target $Target -IdentifierType $IdentifierType -ADHostname ([string]$Computer.Name) -DNSHostName ([string]$Computer.DNSHostName) -ADEnabled ([string]$enabled) -DirectoryPath ([string]$Computer.DistinguishedName) -ADStatus $status -ADProbeMethod $Method -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $DomainState.PermissionStatus -DNSStatus ([string]$dns.DNSStatus) -Notes $notes
 }
 
-function Find-ADUserByShortHostname {
-    param([string]$Hostname)
-    $short = Get-ShortHostname $Hostname
-    if (-not $short) {
-        return @{
-            Found = 'no'
-            SamAccountName = ''
-            Status = 'ad_user_missing'
-            Notes = 'Hostname empty; cannot lookup AD user.'
-        }
-    }
-    try {
-        $user = Get-ADUser -Identity $short -Properties SamAccountName, Enabled, DistinguishedName -ErrorAction Stop
-        return @{
-            Found = 'yes'
-            SamAccountName = [string]$user.SamAccountName
-            Status = 'ad_user_found'
-            Notes = ("Enabled={0}; DN={1}" -f $user.Enabled, $user.DistinguishedName)
-        }
-    } catch {
-        return @{
-            Found = 'no'
-            SamAccountName = ''
-            Status = 'ad_user_missing'
-            Notes = $_.Exception.Message
-        }
-    }
+function Find-WithADModule([string]$Identifier,[string]$IdentifierType,[switch]$AllowDescriptionSearch,[pscustomobject]$DomainState,[switch]$DoDnsResolve,[int]$StaleAfterDays) {
+  $props=@('Enabled','DistinguishedName','DNSHostName','Description','Name','whenChanged'); $matches=@()
+  foreach($c in Get-ADComputerCandidates $Identifier $IdentifierType){try{$matches+=Get-ADComputer -Identity $c -Properties $props -ErrorAction Stop}catch{$m=$_.Exception.Message; if(Test-PermissionError $m){return New-BlockedEvidenceRow $Identifier $IdentifierType 'PERMISSION_BLOCKED' 'active_directory_module_identity' $DomainState $m}}}
+  if($matches.Count -eq 0){
+    $clauses=@(); foreach($c in Get-ADComputerCandidates $Identifier $IdentifierType){$safe=ConvertTo-LdapEscapedValue $c; if($safe){$clauses += "(name=$safe)"; $clauses += "(dNSHostName=$safe)"}}
+    if($AllowDescriptionSearch){$safe=ConvertTo-LdapEscapedValue $Identifier; if($safe){$clauses += "(description=$safe)"}}
+    if($clauses.Count -gt 0){$filter=if($clauses.Count -eq 1){$clauses[0]}else{"(|$($clauses -join ''))"}; try{$matches=@(Get-ADComputer -LDAPFilter $filter -Properties $props -ResultSetSize 10 -ErrorAction Stop)}catch{$m=$_.Exception.Message; $st=if(Test-PermissionError $m){'PERMISSION_BLOCKED'}else{'AD_QUERY_BLOCKED'}; return New-BlockedEvidenceRow $Identifier $IdentifierType $st 'active_directory_module_exact_filter' $DomainState $m}}
+  }
+  $u=@{}; foreach($x in $matches){if($x.DistinguishedName -and -not $u.ContainsKey([string]$x.DistinguishedName)){$u[[string]$x.DistinguishedName]=$x}}; $d=@($u.Values)
+  if($d.Count -eq 1){return Convert-ADComputerToEvidenceRow $d[0] $Identifier $IdentifierType 'active_directory_module_bounded_lookup' $DomainState -DoDnsResolve:$DoDnsResolve -StaleAfterDays $StaleAfterDays}
+  if($d.Count -gt 1){return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType -ADStatus 'AD_DUPLICATE_CANDIDATES' -ADProbeMethod 'active_directory_module_bounded_lookup' -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $DomainState.PermissionStatus -Notes ("Multiple candidate AD computer objects found: {0}" -f (($d|Select-Object -ExpandProperty Name)-join ';'))}
+  New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType -ADStatus 'AD_NOT_FOUND' -ADProbeMethod 'active_directory_module_bounded_lookup' -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $DomainState.PermissionStatus -Notes 'No matching AD computer object found with bounded candidate lookup.'
 }
 
-function Find-WithADModule {
-    param(
-        [string]$Identifier,
-        [string]$IdentifierType,
-        [switch]$AllowDescriptionSearch
-    )
-
-    $props = @('Enabled', 'DistinguishedName', 'DNSHostName', 'Description', 'Name', 'whenChanged')
-
-    if ($IdentifierType -eq 'hostname') {
-        try {
-            $direct = Get-ADComputer -Identity $Identifier -Properties $props -ErrorAction Stop
-            return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-                -ADHostname ([string]$direct.Name) `
-                -DNSHostName ([string]$direct.DNSHostName) `
-                -ADEnabled ([string]$direct.Enabled) `
-                -DirectoryPath ([string]$direct.DistinguishedName) `
-                -ADStatus 'ad_object_found' `
-                -ADProbeMethod 'active_directory_module_identity' `
-                -Notes ("whenChanged={0}" -f $direct.whenChanged)
-        } catch {
-            # Continue into broad lookup.
-        }
-    }
-
-    $safe = ConvertTo-LdapEscapedValue $Identifier
-    $filter = "(|(name=*$safe*)(dNSHostName=*$safe*)"
-    if ($AllowDescriptionSearch) {
-        $filter += "(description=*$safe*)"
-    }
-    $filter += ")"
-
-    try {
-        $adMatches = @(Get-ADComputer -LDAPFilter $filter -Properties $props -ResultSetSize 5 -ErrorAction Stop)
-        if ($adMatches.Count -eq 1) {
-            $m = $adMatches[0]
-            return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-                -ADHostname ([string]$m.Name) `
-                -DNSHostName ([string]$m.DNSHostName) `
-                -ADEnabled ([string]$m.Enabled) `
-                -DirectoryPath ([string]$m.DistinguishedName) `
-                -ADStatus 'ad_object_found' `
-                -ADProbeMethod 'active_directory_module_attribute_search' `
-                -Notes ("Matched one AD computer object. whenChanged={0}" -f $m.whenChanged)
-        }
-        if ($adMatches.Count -gt 1) {
-            return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-                -ADStatus 'ad_multiple_matches' `
-                -ADProbeMethod 'active_directory_module_attribute_search' `
-                -Notes ("Multiple candidate AD computer objects found: {0}" -f (($adMatches | Select-Object -ExpandProperty Name) -join ';'))
-        }
-    } catch {
-        return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-            -ADStatus 'ad_query_failed' `
-            -ADProbeMethod 'active_directory_module' `
-            -Notes $_.Exception.Message
-    }
-
-    return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-        -ADStatus 'ad_no_match' `
-        -ADProbeMethod 'active_directory_module' `
-        -Notes 'No matching AD computer object found.'
+function Find-WithDsquery([string]$Identifier,[string]$IdentifierType,[pscustomobject]$DomainState) {
+  if($IdentifierType -ne 'hostname'){return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType -ADStatus 'NOT_AD_VERIFIED' -ADProbeMethod 'dsquery_hostname_only' -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $DomainState.PermissionStatus -Notes 'dsquery fallback supports exact hostname lookup only.'}
+  try{$raw=& dsquery.exe computer -name (Get-ShortHostname $Identifier) 2>&1; if($LASTEXITCODE -eq 0 -and $raw){$lines=@($raw|Where-Object{$_ -and $_.ToString().Trim()}); if($lines.Count -gt 1){return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType -ADStatus 'AD_DUPLICATE_CANDIDATES' -ADProbeMethod 'dsquery_computer_exact_name' -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $DomainState.PermissionStatus -Notes ($lines -join ';')}; $host=if($lines[0] -match '^"?CN=([^,"]+)'){$matches[1]}else{''}; return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType -ADHostname $host -DirectoryPath ([string]$lines[0]) -ADStatus 'NOT_AD_VERIFIED' -ADProbeMethod 'dsquery_computer_exact_name' -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $DomainState.PermissionStatus -Notes 'Resolved through dsquery fallback; DNS/enabled/stale fields unavailable.'}; New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType -ADStatus 'AD_NOT_FOUND' -ADProbeMethod 'dsquery_computer_exact_name' -DomainContext $DomainState.DomainContext -DomainControllerStatus $DomainState.DomainControllerStatus -PermissionStatus $DomainState.PermissionStatus -Notes (($raw|Out-String).Trim())}catch{$m=$_.Exception.Message; $st=if(Test-PermissionError $m){'PERMISSION_BLOCKED'}else{'AD_QUERY_BLOCKED'}; New-BlockedEvidenceRow $Identifier $IdentifierType $st 'dsquery_computer_exact_name' $DomainState $m}
 }
 
-function Find-WithDsquery {
-    param(
-        [string]$Identifier,
-        [string]$IdentifierType
-    )
-
-    if ($IdentifierType -ne 'hostname') {
-        return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-            -ADStatus 'ad_probe_limited' `
-            -ADProbeMethod 'dsquery_hostname_only' `
-            -Notes 'dsquery fallback only supports hostname/name lookup in this script.'
-    }
-
-    try {
-        $raw = & dsquery.exe computer -name $Identifier 2>&1
-        if ($LASTEXITCODE -eq 0 -and $raw) {
-            $line = @($raw | Where-Object { $_ -and $_.ToString().Trim() } | Select-Object -First 1)[0]
-            $resolvedHost = ''
-            if ($line -match '^"CN=([^,"]+)') { $resolvedHost = $matches[1] }
-            elseif ($line -match '^CN=([^,]+)') { $resolvedHost = $matches[1] }
-            return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-                -ADHostname $resolvedHost `
-                -DirectoryPath ([string]$line) `
-                -ADStatus 'ad_object_found' `
-                -ADProbeMethod 'dsquery_computer_name' `
-                -Notes 'Resolved through dsquery fallback.'
-        }
-        return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-            -ADStatus 'ad_no_match' `
-            -ADProbeMethod 'dsquery_computer_name' `
-            -Notes (($raw | Out-String).Trim())
-    } catch {
-        return New-EvidenceRow -Target $Identifier -IdentifierType $IdentifierType `
-            -ADStatus 'ad_query_failed' `
-            -ADProbeMethod 'dsquery_computer_name' `
-            -Notes $_.Exception.Message
-    }
+function Expand-EvidenceRow([pscustomobject]$Row,[string]$Identifier,[switch]$WantComputerOU,[switch]$WantUserLookup) {
+  $ou=''; $warn=''; $status=$Row.ADStatus; $notes=$Row.Notes
+  if($WantComputerOU -and $Row.DirectoryPath){$ou=Get-ComputerOUPath $Row.DirectoryPath; $warn=Get-LegacyOUWarning $ou; if($warn){$status='AD_OBJECT_FOUND_WRONG_OU'}}
+  if($WantUserLookup){$notes=if($notes){"$notes | AD user lookup intentionally not run in this bounded probe."}else{'AD user lookup intentionally not run in this bounded probe.'}}
+  New-EvidenceRow -Target $Row.Target -IdentifierType $Row.IdentifierType -ADHostname $Row.ADHostname -DNSHostName $Row.DNSHostName -ADEnabled $Row.ADEnabled -DirectoryPath $Row.DirectoryPath -ComputerOU $ou -LegacyOUWarning $warn -ADStatus $status -ADProbeMethod $Row.ADProbeMethod -DomainContext $Row.DomainContext -DomainControllerStatus $Row.DomainControllerStatus -PermissionStatus $Row.PermissionStatus -DNSStatus $Row.DNSStatus -Notes $notes
 }
 
-function Expand-EvidenceRow {
-    param(
-        [pscustomobject]$Row,
-        [string]$Identifier,
-        [switch]$WantComputerOU,
-        [switch]$WantUserLookup
-    )
-
-    $computerOU = ''
-    $legacyWarning = ''
-    if ($WantComputerOU -and $Row.DirectoryPath) {
-        $computerOU = Get-ComputerOUPath $Row.DirectoryPath
-        $legacyWarning = Get-LegacyOUWarning $computerOU
-    }
-
-    $userFound = ''
-    $userSam = ''
-    $userStatus = ''
-    $userNotes = $Row.Notes
-    if ($WantUserLookup) {
-        $userLookup = Find-ADUserByShortHostname -Hostname $Identifier
-        $userFound = $userLookup.Found
-        $userSam = $userLookup.SamAccountName
-        $userStatus = $userLookup.Status
-        if ($userLookup.Notes) {
-            $userNotes = if ($userNotes) { "$userNotes | $($userLookup.Notes)" } else { $userLookup.Notes }
-        }
-    }
-
-    return New-EvidenceRow -Target $Row.Target -IdentifierType $Row.IdentifierType `
-        -ADHostname $Row.ADHostname -DNSHostName $Row.DNSHostName `
-        -ADSerial $Row.ADSerial -ADMAC $Row.ADMAC -ADEnabled $Row.ADEnabled `
-        -DirectoryPath $Row.DirectoryPath -ComputerOU $computerOU -LegacyOUWarning $legacyWarning `
-        -ADUserFound $userFound -ADUserSamAccountName $userSam -ADUserStatus $userStatus `
-        -ADStatus $Row.ADStatus -ADProbeMethod $Row.ADProbeMethod -Notes $userNotes
+function Write-AdProbeStateSummary([object[]]$Results,[pscustomobject]$DomainState,[string]$QueryMode,[string]$FallbackMode,[string]$OutputPath,[string]$SummaryPath) {
+  $counts=@{}; foreach($s in $RequiredAdProbeStates){$counts[$s]=0}; foreach($r in $Results){$s=[string]$r.ADStatus; if(-not $counts.ContainsKey($s)){$counts[$s]=0}; $counts[$s]++}
+  $found=$counts['AD_CONFIRMED']+$counts['AD_OBJECT_FOUND_DNS_FOUND']+$counts['AD_OBJECT_FOUND_DNS_MISSING']+$counts['AD_OBJECT_FOUND_DNS_MISMATCH']+$counts['AD_OBJECT_FOUND_STALE']+$counts['AD_OBJECT_FOUND_DISABLED']+$counts['AD_OBJECT_FOUND_WRONG_OU']+$counts['NOT_AD_VERIFIED']; $blocked=$counts['AD_QUERY_BLOCKED']+$counts['DOMAIN_CONTEXT_UNKNOWN']+$counts['DOMAIN_CONTROLLER_UNREACHABLE']+$counts['PERMISSION_BLOCKED']; $dnsEnriched=@($Results|Where-Object{$_.DNSStatus}).Count
+  Write-Host 'AD PROBE STATE SUMMARY:'; Write-Host ("- Query mode used: {0}" -f $QueryMode); Write-Host ("- Fallback mode used: {0}" -f $FallbackMode); Write-Host ("- Domain context: {0}" -f $DomainState.DomainContext); Write-Host ("- Domain controller status: {0}" -f $DomainState.DomainControllerStatus); Write-Host ("- Permission status: {0}" -f $DomainState.PermissionStatus); Write-Host ("- Input target count: {0}" -f $Results.Count); Write-Host ("- AD objects found: {0}" -f $found); Write-Host ("- DNS enriched: {0}" -f $dnsEnriched); Write-Host ("- Stale objects: {0}" -f $counts['AD_OBJECT_FOUND_STALE']); Write-Host ("- Disabled objects: {0}" -f $counts['AD_OBJECT_FOUND_DISABLED']); Write-Host ("- Duplicate candidates: {0}" -f $counts['AD_DUPLICATE_CANDIDATES']); Write-Host ("- Not found: {0}" -f $counts['AD_NOT_FOUND']); Write-Host ("- Blocked / unknown: {0}" -f $blocked); Write-Host ("- Needs operator review: {0}" -f ($counts['NEEDS_OPERATOR_REVIEW']+$counts['AD_DUPLICATE_CANDIDATES']+$counts['AD_OBJECT_FOUND_WRONG_OU'])); Write-Host ("- Local ignored log path: {0}" -f $SummaryPath); Write-Host '- Evidence committed: none, or sanitized fixture only'
+  [ordered]@{query_mode_used=$QueryMode;fallback_mode_used=$FallbackMode;domain_context=$DomainState.DomainContext;domain_controller_status=$DomainState.DomainControllerStatus;permission_status=$DomainState.PermissionStatus;input_target_count=$Results.Count;ad_objects_found=$found;dns_enriched=$dnsEnriched;stale_objects=$counts['AD_OBJECT_FOUND_STALE'];disabled_objects=$counts['AD_OBJECT_FOUND_DISABLED'];duplicate_candidates=$counts['AD_DUPLICATE_CANDIDATES'];not_found=$counts['AD_NOT_FOUND'];blocked_unknown=$blocked;needs_operator_review=($counts['NEEDS_OPERATOR_REVIEW']+$counts['AD_DUPLICATE_CANDIDATES']+$counts['AD_OBJECT_FOUND_WRONG_OU']);output_path=$OutputPath;evidence_committed='none; local operator evidence only';counts_by_state=$counts} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $SummaryPath -Encoding UTF8
 }
 
-if (-not (Test-Path -LiteralPath $Manifest)) {
-    throw "Manifest not found: $Manifest"
-}
-
-$outDir = Split-Path -Parent $Output
-if ($outDir -and -not (Test-Path -LiteralPath $outDir)) {
-    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
-}
-
-$manifestRows = Import-Csv -LiteralPath $Manifest
-$hasADModule = $null -ne (Get-Module -ListAvailable -Name ActiveDirectory | Select-Object -First 1)
-$hasDsquery = $null -ne (Get-Command dsquery.exe -ErrorAction SilentlyContinue)
-
-$results = foreach ($raw in $manifestRows) {
-    $row = ConvertTo-Hashtable $raw
-    $identifier = Get-ManifestIdentifier $row
-    $identifierType = Get-IdentifierType $identifier
-
-    if ([string]::IsNullOrWhiteSpace($identifier)) {
-        New-EvidenceRow -Target '' -IdentifierType 'missing' -ADStatus 'ad_input_missing' -ADProbeMethod 'none' -Notes 'Manifest row did not contain an identifier.'
-        continue
-    }
-
-    $evidence = $null
-    if ($hasADModule) {
-        $evidence = Find-WithADModule -Identifier $identifier -IdentifierType $identifierType -AllowDescriptionSearch:$SearchDescription
-    } elseif ($hasDsquery) {
-        $evidence = Find-WithDsquery -Identifier $identifier -IdentifierType $identifierType
-    } else {
-        $evidence = New-EvidenceRow -Target $identifier -IdentifierType $identifierType `
-            -ADStatus 'ad_probe_unavailable' `
-            -ADProbeMethod 'none' `
-            -Notes 'Neither ActiveDirectory PowerShell module nor dsquery.exe is available in this runtime.'
-    }
-
-    if ($IncludeComputerOU -or $LookupHostnameAsUser) {
-        Expand-EvidenceRow -Row $evidence -Identifier $identifier `
-            -WantComputerOU:$IncludeComputerOU -WantUserLookup:$LookupHostnameAsUser
-    } else {
-        $evidence
-    }
-}
-
+if(-not (Test-Path -LiteralPath $Manifest)){throw "Manifest not found: $Manifest"}
+$outDir=Split-Path -Parent $Output; if($outDir -and -not (Test-Path -LiteralPath $outDir)){New-Item -ItemType Directory -Path $outDir -Force | Out-Null}
+$manifestRows=Import-Csv -LiteralPath $Manifest; $hasADModule=$null -ne (Get-Module -ListAvailable -Name ActiveDirectory | Select-Object -First 1); $hasDsquery=$null -ne (Get-Command dsquery.exe -ErrorAction SilentlyContinue); $domainState=Get-DomainProbeState
+$queryMode=if($hasADModule){'active_directory_module_bounded_lookup'}elseif($hasDsquery){'dsquery_exact_hostname_fallback'}else{'no_live_ad_tooling_available'}; $fallbackMode=if($hasADModule){'none'}elseif($hasDsquery){'dsquery'}else{'operator_manifest_required'}
+$results=foreach($raw in $manifestRows){$row=ConvertTo-Hashtable $raw; $id=Get-ManifestIdentifier $row; $type=Get-IdentifierType $id; if([string]::IsNullOrWhiteSpace($id)){New-EvidenceRow -Target '' -IdentifierType 'missing' -ADStatus 'NEEDS_OPERATOR_REVIEW' -ADProbeMethod 'none' -DomainContext $domainState.DomainContext -DomainControllerStatus $domainState.DomainControllerStatus -PermissionStatus $domainState.PermissionStatus -Notes 'Manifest row did not contain an identifier.'; continue}; if($domainState.PermissionStatus -eq 'permission_blocked'){$e=New-BlockedEvidenceRow $id $type 'PERMISSION_BLOCKED' 'domain_discovery' $domainState $domainState.Notes}elseif($domainState.DomainContext -eq 'DOMAIN_CONTEXT_UNKNOWN'){$e=New-BlockedEvidenceRow $id $type 'DOMAIN_CONTEXT_UNKNOWN' 'domain_discovery' $domainState 'Domain context could not be determined; run from a domain-joined or RSAT-equipped operator workstation.'}elseif($domainState.DomainControllerStatus -eq 'DOMAIN_CONTROLLER_UNREACHABLE'){$e=New-BlockedEvidenceRow $id $type 'DOMAIN_CONTROLLER_UNREACHABLE' 'domain_controller_discovery' $domainState 'Domain context exists but no reachable domain controller was discovered.'}elseif($hasADModule){$e=Find-WithADModule $id $type -AllowDescriptionSearch:$SearchDescription -DomainState $domainState -DoDnsResolve:$ResolveDns -StaleAfterDays $StaleDays}elseif($hasDsquery){$e=Find-WithDsquery $id $type $domainState}else{$e=New-BlockedEvidenceRow $id $type 'AD_QUERY_BLOCKED' 'none' $domainState 'Neither ActiveDirectory PowerShell module nor dsquery.exe is available in this runtime.'}; if($IncludeComputerOU -or $LookupHostnameAsUser){Expand-EvidenceRow $e $id -WantComputerOU:$IncludeComputerOU -WantUserLookup:$LookupHostnameAsUser}else{$e}}
 $results | Export-Csv -LiteralPath $Output -NoTypeInformation -Encoding UTF8
+$summaryPath=[System.IO.Path]::ChangeExtension($Output,'.summary.json')
+Write-AdProbeStateSummary -Results @($results) -DomainState $domainState -QueryMode $queryMode -FallbackMode $fallbackMode -OutputPath $Output -SummaryPath $summaryPath
 Write-Host ("AD identity evidence written: {0}" -f $Output)


### PR DESCRIPTION
## Summary

- Harden the live AD identity export helper with bounded lookup behavior.
- Add domain/DC blocked-state handling and AD probe summary output.
- Add offline contract coverage for AD probe resilience expectations.

## Validation

- `bash Tests/survey/run_offline_survey_tests.sh`
- `git diff --check`
- `powershell.exe` parser check: `PS_PARSE_OK`

## Notes

Live AD validation still requires an authorized domain or RSAT-equipped operator workstation and an approved manifest.