### PR TITLE
feat: wire target intake wrappers

### DIFF
--- a/.github/workflows/survey-doctrine.yml
+++ b/.github/workflows/survey-doctrine.yml
@@ -2,7 +2,7 @@ name: Survey doctrine
 
 on:
   push:
-    branches: [main, 'feat/**']
+    branches: [main, 'feat/**', 'feature/**']
     paths:
       - 'AGENTS.md'
       - '.cursor/rules/**'
@@ -12,11 +12,14 @@ on:
       - 'docs/NAABU_CYBERNET_PROFILES.md'
       - 'probe/packet-expenditure/**'
       - 'survey/**'
+      - 'scripts/SasTargetIntake.psm1'
+      - 'targets/README.md'
       - 'Tests/bash/*naabu*'
       - 'Tests/bash/test_cybernet_detect_contracts.sh'
       - 'Tests/bash/test_northwell_registry_verification_contracts.sh'
       - 'Tests/bash/test_packet_probe_contracts.sh'
       - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
+      - 'Tests/bash/test_target_intake_centralization_contracts.sh'
       - '.github/workflows/survey-doctrine.yml'
   pull_request:
     branches: [main]
@@ -29,11 +32,14 @@ on:
       - 'docs/NAABU_CYBERNET_PROFILES.md'
       - 'probe/packet-expenditure/**'
       - 'survey/**'
+      - 'scripts/SasTargetIntake.psm1'
+      - 'targets/README.md'
       - 'Tests/bash/*naabu*'
       - 'Tests/bash/test_cybernet_detect_contracts.sh'
       - 'Tests/bash/test_northwell_registry_verification_contracts.sh'
       - 'Tests/bash/test_packet_probe_contracts.sh'
       - 'Tests/bash/test_repo_naabu_doctrine_conformance.sh'
+      - 'Tests/bash/test_target_intake_centralization_contracts.sh'
       - '.github/workflows/survey-doctrine.yml'
 
 jobs:
@@ -50,6 +56,11 @@ jobs:
         shell: bash
         run: |
           bash Tests/bash/test_repo_naabu_doctrine_conformance.sh
+
+      - name: Central target intake contracts
+        shell: bash
+        run: |
+          bash Tests/bash/test_target_intake_centralization_contracts.sh
 
       - name: Northwell registry verification contracts
         shell: bash

--- a/Tests/bash/test_naabu_pipeline_contracts.sh
+++ b/Tests/bash/test_naabu_pipeline_contracts.sh
@@ -10,6 +10,8 @@ ENSURE="survey/sas-ensure-naabu.sh"
 PARSE="survey/sas-parse-naabu-evidence.sh"
 FIX="$ROOT/survey/fixtures/naabu_pipeline"
 CFG="$ROOT/Config/cybernet-naabu-profiles.json"
+export SAS_TARGET_ALLOW_TEST_FIXTURES=1
+export SAS_TARGET_ALLOW_NONSTANDARD_OUTPUT=1
 
 if command -v python3 >/dev/null 2>&1; then PYTHON_BIN=python3; else PYTHON_BIN=python; fi
 
@@ -25,6 +27,11 @@ bash -n "$PARSE"
 HELP="$(bash "$PIPE" --help)"
 echo "$HELP" | grep -qF 'keyports_cdn' || { echo 'help missing keyports_cdn'; exit 1; }
 echo "$HELP" | grep -qF '-ec' || { echo 'help missing -ec note'; exit 1; }
+echo "$HELP" | grep -qF 'targets/local' || { echo 'help missing central target root note'; exit 1; }
+
+grep -qF 'source "$TARGET_INTAKE_HELPER"' "$PIPE" || { echo 'pipeline must source shared target intake helper'; exit 1; }
+grep -qF 'sas_target_require_input_file "$file" "Naabu target list"' "$PIPE" || { echo 'pipeline must validate --list through target helper'; exit 1; }
+grep -qF 'sas_target_require_output_path "$OUT" "Naabu output file"' "$PIPE" || { echo 'pipeline must validate --out through target helper'; exit 1; }
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/Tests/bash/test_target_intake_centralization_contracts.sh
+++ b/Tests/bash/test_target_intake_centralization_contracts.sh
@@ -13,14 +13,21 @@ PS_MODULE="scripts/SasTargetIntake.psm1"
 DISPATCH="survey/sas-target-intake-dispatch.ps1"
 PREFLIGHT="survey/sas-network-preflight.ps1"
 TARGETS_README="targets/README.md"
+NAABU_PIPE="survey/sas-run-naabu-pipeline.sh"
+SUBNET_RUNNER="survey/sas-cybernet-subnet-survey.sh"
+AD_EXPORT="survey/sas-export-ad-registered-population.sh"
 
-for f in "$BASH_HELPER" "$PS_MODULE" "$DISPATCH" "$PREFLIGHT" "$TARGETS_README"; do
+for f in "$BASH_HELPER" "$PS_MODULE" "$DISPATCH" "$PREFLIGHT" "$TARGETS_README" "$NAABU_PIPE" "$SUBNET_RUNNER" "$AD_EXPORT"; do
   [[ -f "$f" ]] || fail "missing central target intake file: $f"
 done
 
 bash -n "$BASH_HELPER"
+bash -n "$NAABU_PIPE"
+bash -n "$SUBNET_RUNNER"
+bash -n "$AD_EXPORT"
 
 contains 'sas_target_require_input_file' "$BASH_HELPER" 'Bash helper missing input validation function'
+contains 'sas_target_require_manifest_file' "$BASH_HELPER" 'Bash helper missing manifest validation function'
 contains 'sas_target_require_output_path' "$BASH_HELPER" 'Bash helper missing output validation function'
 contains 'targets/local' "$BASH_HELPER" 'Bash helper missing targets/local root'
 contains 'logs/targets' "$BASH_HELPER" 'Bash helper missing logs/targets root'
@@ -28,6 +35,8 @@ contains 'survey/input' "$BASH_HELPER" 'Bash helper missing survey/input staging
 contains 'survey/output' "$BASH_HELPER" 'Bash helper missing survey/output root'
 contains 'logs/nmap' "$BASH_HELPER" 'Bash helper missing logs/nmap root'
 contains 'survey/artifacts' "$BASH_HELPER" 'Bash helper missing survey/artifacts root'
+contains 'SAS_TARGET_ALLOW_TEST_FIXTURES' "$BASH_HELPER" 'Bash helper missing fixture-only test switch'
+contains 'SAS_TARGET_ALLOW_NONSTANDARD_OUTPUT' "$BASH_HELPER" 'Bash helper missing explicit nonstandard output test switch'
 
 contains 'Get-SasTargetIntakeRoots' "$PS_MODULE" 'PowerShell module missing root set function'
 contains 'Assert-SasApprovedInputPath' "$PS_MODULE" 'PowerShell module missing input assertion'
@@ -45,6 +54,18 @@ contains 'Test-SasPathUnderAnyRoot' "$PREFLIGHT" 'PowerShell preflight must vali
 contains 'No -TargetFile was provided. Stopping without probing.' "$PREFLIGHT" 'PowerShell preflight must still refuse empty target selection'
 contains 'NONSTANDARD INPUT OVERRIDE' "$PREFLIGHT" 'PowerShell preflight must clearly label nonstandard override mode'
 
+for wrapper in "$NAABU_PIPE" "$SUBNET_RUNNER" "$AD_EXPORT"; do
+  contains 'TARGET_INTAKE_HELPER' "$wrapper" "$wrapper must locate shared Bash helper"
+  contains 'source "$TARGET_INTAKE_HELPER"' "$wrapper" "$wrapper must source shared Bash helper"
+done
+contains 'sas_target_require_input_file "$file" "Naabu target list"' "$NAABU_PIPE" 'Naabu pipeline must validate target list through helper'
+contains 'sas_target_require_output_path "$OUT" "Naabu output file"' "$NAABU_PIPE" 'Naabu pipeline must validate output through helper'
+contains 'sas_target_require_input_file "$HOST_FILE" "confirm-windows host file"' "$SUBNET_RUNNER" 'subnet runner must validate host file through helper'
+contains 'sas_target_require_input_file "$file" "subnet CIDR file"' "$SUBNET_RUNNER" 'subnet runner must validate subnet file through helper'
+contains 'sas_target_require_manifest_file "$MANIFEST" "resolve-only manifest"' "$SUBNET_RUNNER" 'subnet runner must validate resolver manifest through helper'
+contains 'sas_target_require_input_file "$AD_CSV" "AD registered population CSV export"' "$AD_EXPORT" 'AD export must validate AD CSV through helper'
+contains 'sas_target_require_output_path "$OUTPUT_DIR/ad_registered_normalized.csv"' "$AD_EXPORT" 'AD export must validate output through helper'
+
 for mode in ListCandidates NetworkPreflight NaabuPlan ADRegisteredPlan SubnetConfirmPlan; do
   contains "$mode" "$DISPATCH" "dispatcher missing mode $mode"
 done
@@ -60,9 +81,9 @@ contains 'subnet discovery' "$TARGETS_README" 'targets README missing subnet use
 contains 'AD exports' "$TARGETS_README" 'targets README missing AD use-case coverage'
 contains 'low-noise reachability planning' "$TARGETS_README" 'targets README missing reachability use-case coverage'
 
-not_contains '/tmp/sas-cybernet' "$DISPATCH" 'dispatcher must not revive emergency temp path'
-not_contains 'C:\Temp' "$DISPATCH" 'dispatcher must not revive emergency Windows temp path'
-not_contains '/tmp/sas-cybernet' "$PREFLIGHT" 'preflight must not revive emergency temp path'
-not_contains 'C:\Temp' "$PREFLIGHT" 'preflight must not revive emergency Windows temp path'
+for f in "$DISPATCH" "$PREFLIGHT" "$NAABU_PIPE" "$SUBNET_RUNNER" "$AD_EXPORT"; do
+  not_contains '/tmp/sas-cybernet' "$f" "$f must not revive emergency temp path"
+  not_contains 'C:\Temp' "$f" "$f must not revive emergency Windows temp path"
+done
 
 echo 'PASS: central target intake contracts'

--- a/survey/lib/sas-target-intake.sh
+++ b/survey/lib/sas-target-intake.sh
@@ -81,27 +81,42 @@ sas_target_list_candidates() {
   done
 }
 
-sas_target_require_input_file() {
+sas_target_roots_for_input() {
+  local allow_staging="${1:-0}" allow_generated="${2:-0}" repo="${3:-$(sas_target_repo_root)}"
+  printf '%s\n' "$repo/targets/local" "$repo/logs/targets"
+  [[ "$allow_staging" == "1" ]] && printf '%s\n' "$repo/survey/input"
+  [[ "$allow_generated" == "1" ]] && printf '%s\n' "$repo/survey/output" "$repo/logs/nmap" "$repo/survey/artifacts"
+  if [[ "${SAS_TARGET_ALLOW_TEST_FIXTURES:-0}" == "1" ]]; then
+    printf '%s\n' "$repo/survey/fixtures" "$repo/targets/sanitized"
+  fi
+}
+
+sas_target_require_file_under_roots() {
   local file="$1"
   local role="${2:-target input}"
   local allow_staging="${3:-0}"
-  local repo="${4:-$(sas_target_repo_root)}"
+  local allow_generated="${4:-0}"
+  local repo="${5:-$(sas_target_repo_root)}"
   [[ -n "$file" ]] || { echo "[target-intake] ERROR: $role path is required" >&2; return 1; }
   [[ -f "$file" ]] || { echo "[target-intake] ERROR: $role not found: $file" >&2; return 1; }
 
   local roots=()
-  roots+=("$repo/targets/local" "$repo/logs/targets")
-  [[ "$allow_staging" == "1" ]] && roots+=("$repo/survey/input")
-  if [[ "${SAS_TARGET_ALLOW_TEST_FIXTURES:-0}" == "1" ]]; then
-    roots+=("$repo/survey/fixtures" "$repo/targets/sanitized")
-  fi
-
+  while IFS= read -r root; do roots+=("$root"); done < <(sas_target_roots_for_input "$allow_staging" "$allow_generated" "$repo")
   if ! sas_target_is_under_any_root "$file" "${roots[@]}"; then
-    echo "[target-intake] ERROR: $role is outside approved target intake roots: $file" >&2
+    echo "[target-intake] ERROR: $role is outside approved SysAdminSuite target roots: $file" >&2
     echo "[target-intake] Use targets/local/ or logs/targets/ first; survey/input/ only after normalization." >&2
+    echo "[target-intake] Generated rosters/manifests may be read from survey/output/ only when explicitly produced by an earlier SysAdminSuite step." >&2
     echo "[target-intake] Set SAS_TARGET_ALLOW_TEST_FIXTURES=1 only for sanitized repo fixture tests." >&2
     return 1
   fi
+}
+
+sas_target_require_input_file() {
+  sas_target_require_file_under_roots "$1" "${2:-target input}" "${3:-0}" 0 "${4:-$(sas_target_repo_root)}"
+}
+
+sas_target_require_manifest_file() {
+  sas_target_require_file_under_roots "$1" "${2:-target manifest}" 1 1 "${3:-$(sas_target_repo_root)}"
 }
 
 sas_target_require_output_path() {
@@ -111,6 +126,10 @@ sas_target_require_output_path() {
   [[ -n "$path" ]] || { echo "[target-intake] ERROR: $role path is required" >&2; return 1; }
   local roots=("$repo/survey/output" "$repo/logs/nmap" "$repo/survey/artifacts")
   if ! sas_target_is_under_any_root "$path" "${roots[@]}"; then
+    if [[ "${SAS_TARGET_ALLOW_NONSTANDARD_OUTPUT:-0}" == "1" ]]; then
+      echo "[target-intake] WARNING: $role is outside generated output roots because SAS_TARGET_ALLOW_NONSTANDARD_OUTPUT=1: $path" >&2
+      return 0
+    fi
     echo "[target-intake] ERROR: $role is outside generated output roots: $path" >&2
     echo "[target-intake] Use survey/output/, logs/nmap/, or survey/artifacts/." >&2
     return 1

--- a/survey/sas-cybernet-subnet-survey.sh
+++ b/survey/sas-cybernet-subnet-survey.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-VERSION="0.1.1"
+VERSION="0.1.2"
 SITE=""
 MODE=""
 RUN_ID="$(date +%Y%m%d_%H%M%S)"
@@ -39,6 +39,10 @@ MAX_HOSTS=256
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_INTAKE_HELPER="${SCRIPT_DIR}/lib/sas-target-intake.sh"
+[[ -f "$TARGET_INTAKE_HELPER" ]] || { echo "[cybernet-subnet-survey] ERROR: Missing target intake helper: $TARGET_INTAKE_HELPER" >&2; exit 1; }
+# shellcheck source=survey/lib/sas-target-intake.sh
+source "$TARGET_INTAKE_HELPER"
 
 usage() {
   cat <<'USAGE'
@@ -65,10 +69,10 @@ Required:
 
 Options:
   --mode MODE          One of the modes above (required)
-  --manifest PATH      Target manifest CSV (resolve-only, package-only)
+  --manifest PATH      Target manifest CSV from approved intake/staging or generated SysAdminSuite output
   --cidr CIDR          Approved IPv4 CIDR. Repeatable
-  --subnet-file PATH   Plain-text CIDR list (e.g. subnet_candidates.txt)
-  --host-file PATH     Host list for confirm-windows (required except Naabu --host mode)
+  --subnet-file PATH   Plain-text CIDR list from approved intake/staging
+  --host-file PATH     Host list for confirm-windows from approved intake/staging
   --output-root DIR    Default: survey/output/cybernet_subnet_survey
   --logs-root DIR      Default: logs/nmap
   --run-id ID          Correlate multi-step runs. Default: timestamp
@@ -95,7 +99,7 @@ Options:
 
 Urgent path:
   1. local-context-only
-  2. dns-list-only (--subnet-file from finder)
+  2. dns-list-only (--subnet-file from approved intake/staging)
   3. discover
   4. resolve-only (--manifest)
   5. confirm-windows (--host-file) optional
@@ -152,7 +156,7 @@ PY
 
 load_subnet_file() {
   local file="$1" line
-  [[ -f "$file" ]] || fail "Subnet file not found: $file"
+  sas_target_require_input_file "$file" "subnet CIDR file" 1 "$REPO_ROOT" || exit 1
   while IFS= read -r line || [[ -n "$line" ]]; do
     line="${line%%#*}"
     line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
@@ -265,7 +269,10 @@ run_parse_naabu_evidence() {
     --output "$csv_out"
   )
   [[ -n "$followup_out" ]] && parse_args+=(--followup "$followup_out")
-  [[ -n "$MANIFEST" && -f "$MANIFEST" ]] && parse_args+=(--manifest "$MANIFEST")
+  if [[ -n "$MANIFEST" && -f "$MANIFEST" ]]; then
+    sas_target_require_manifest_file "$MANIFEST" "resolver manifest" "$REPO_ROOT" || exit 1
+    parse_args+=(--manifest "$MANIFEST")
+  fi
   if [[ "$DRY_RUN" -eq 1 ]]; then
     printf '%s\n' "${parse_args[@]}" >> "$PLANNED_FILE"
     log "DRY-RUN: ${parse_args[*]}"
@@ -308,7 +315,7 @@ collect_cidrs_for_scan() {
 
 validate_host_file() {
   [[ -n "$HOST_FILE" ]] || fail "confirm-windows requires --host-file"
-  [[ -f "$HOST_FILE" ]] || fail "Host file not found: $HOST_FILE"
+  sas_target_require_input_file "$HOST_FILE" "confirm-windows host file" 1 "$REPO_ROOT" || exit 1
   local line count=0
   while IFS= read -r line || [[ -n "$line" ]]; do
     line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
@@ -495,6 +502,7 @@ pick_default_nmap_xml() {
 
 mode_resolve_only() {
   [[ -n "$MANIFEST" ]] || fail "resolve-only requires --manifest"
+  sas_target_require_manifest_file "$MANIFEST" "resolve-only manifest" "$REPO_ROOT" || exit 1
   [[ -f "$MANIFEST" ]] || fail "Manifest not found: $MANIFEST"
   ensure_run_dir
   local xml="$NMAP_XML"
@@ -566,6 +574,7 @@ mode_package_only() {
   shopt -u nullglob
 
   if [[ -n "$MANIFEST" && -f "$MANIFEST" ]]; then
+    sas_target_require_manifest_file "$MANIFEST" "package manifest" "$REPO_ROOT" || exit 1
     mkdir -p "$artifact_dir/manifests"
     cp "$MANIFEST" "$artifact_dir/manifests/$(basename "$MANIFEST")"
     echo "manifests/$(basename "$MANIFEST")" >> "$PACKAGE_LIST"

--- a/survey/sas-export-ad-registered-population.sh
+++ b/survey/sas-export-ad-registered-population.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RECONCILE="$ROOT/survey/sas-ad-reconcile.sh"
 OUTPUT_DIR="$ROOT/survey/output/ad_registered_population"
+TARGET_INTAKE_HELPER="$ROOT/survey/lib/sas-target-intake.sh"
+[[ -f "$TARGET_INTAKE_HELPER" ]] || { echo "[ad-registered-population] ERROR: Missing target intake helper: $TARGET_INTAKE_HELPER" >&2; exit 1; }
+# shellcheck source=survey/lib/sas-target-intake.sh
+source "$TARGET_INTAKE_HELPER"
 
 usage() {
   cat <<'USAGE'
@@ -17,7 +21,7 @@ export. AD is the registered-device authority; network and identity evidence are
 optional comparison layers, not proof supplied by AD.
 
 Options mirror sas-ad-reconcile.sh:
-  --ad-csv PATH         Required approved AD computer CSV export
+  --ad-csv PATH         Required approved AD computer CSV export from targets/local/ or logs/targets/
   --evidence-csv PATH   Optional approved manifest/tracker evidence CSV
   --network-csv PATH    Optional pre-validated reachability evidence CSV
   --serial-csv PATH     Optional live-serial / identity evidence CSV
@@ -47,20 +51,33 @@ find_python() {
 # underlying script never receives a duplicate --output-dir flag.
 args=()
 have_ad_csv=0
+AD_CSV=""
+EVIDENCE_CSV=""
+NETWORK_CSV=""
+SERIAL_CSV=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage; exit 0 ;;
-    --ad-csv) have_ad_csv=1; args+=("$1" "${2:?}"); shift 2 ;;
+    --ad-csv) have_ad_csv=1; AD_CSV="${2:?}"; args+=("$1" "$AD_CSV"); shift 2 ;;
     --output-dir) OUTPUT_DIR="${2:?}"; shift 2 ;;
-    --evidence-csv|--network-csv|--serial-csv|--prefix|--stale-days)
+    --evidence-csv) EVIDENCE_CSV="${2:?}"; args+=("$1" "$EVIDENCE_CSV"); shift 2 ;;
+    --network-csv) NETWORK_CSV="${2:?}"; args+=("$1" "$NETWORK_CSV"); shift 2 ;;
+    --serial-csv) SERIAL_CSV="${2:?}"; args+=("$1" "$SERIAL_CSV"); shift 2 ;;
+    --prefix|--stale-days)
       args+=("$1" "${2:?}"); shift 2 ;;
     --pass-thru|--version) args+=("$1"); shift ;;
     *) fail "Unknown argument: $1 (run with --help)" ;;
   esac
 done
 
-[[ "$have_ad_csv" -eq 1 ]] || fail "--ad-csv is required; place approved exports in logs/targets/ or pass an explicit scoped CSV"
+[[ "$have_ad_csv" -eq 1 ]] || fail "--ad-csv is required; place approved exports in targets/local/ or logs/targets/"
 [[ -f "$RECONCILE" ]] || fail "Missing reconcile script: $RECONCILE"
+
+sas_target_require_input_file "$AD_CSV" "AD registered population CSV export" 0 "$ROOT" || exit 1
+[[ -n "$EVIDENCE_CSV" ]] && sas_target_require_manifest_file "$EVIDENCE_CSV" "AD evidence CSV" "$ROOT"
+[[ -n "$NETWORK_CSV" ]] && sas_target_require_manifest_file "$NETWORK_CSV" "AD network evidence CSV" "$ROOT"
+[[ -n "$SERIAL_CSV" ]] && sas_target_require_manifest_file "$SERIAL_CSV" "AD serial evidence CSV" "$ROOT"
+sas_target_require_output_path "$OUTPUT_DIR/ad_registered_normalized.csv" "AD registered population output" "$ROOT" || exit 1
 
 log "Building AD registered population roster from approved CSV input"
 bash "$RECONCILE" "${args[@]}" --output-dir "$OUTPUT_DIR"

--- a/survey/sas-run-naabu-pipeline.sh
+++ b/survey/sas-run-naabu-pipeline.sh
@@ -5,7 +5,7 @@
 # live in Config/cybernet-naabu-profiles.json (doctrine contract: survey/naabu_profiles.json).
 set -euo pipefail
 
-VERSION="0.1.0"
+VERSION="0.1.1"
 SITE=""
 PROFILE="keyports_cybernet_json"
 LIST=""
@@ -27,6 +27,10 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROFILE_JSON="${REPO_ROOT}/Config/cybernet-naabu-profiles.json"
 FOLLOWUP_SCRIPT="${SCRIPT_DIR}/sas-cybernet-packet-followup.sh"
 ENSURE_SCRIPT="${SCRIPT_DIR}/sas-ensure-naabu.sh"
+TARGET_INTAKE_HELPER="${SCRIPT_DIR}/lib/sas-target-intake.sh"
+[[ -f "$TARGET_INTAKE_HELPER" ]] || { echo "[naabu-pipeline] ERROR: Missing target intake helper: $TARGET_INTAKE_HELPER" >&2; exit 1; }
+# shellcheck source=survey/lib/sas-target-intake.sh
+source "$TARGET_INTAKE_HELPER"
 
 usage() {
   cat <<'USAGE'
@@ -42,12 +46,12 @@ Required:
   --site SITE              Site label
 
 Target input (one required unless --dry-run with --host):
-  --list PATH              Approved target file (one IP/hostname per line)
+  --list PATH              Approved target file from targets/local, logs/targets, or normalized survey/input
   --host URL               Hostname/URL for -sa multi-A scan (hostname_all_ips profile)
 
 Options:
   --profile NAME           Profile from Config/cybernet-naabu-profiles.json. Default: keyports_cybernet_json
-  --out PATH               Output file (txt or json per profile)
+  --out PATH               Output file (txt or json per profile; generated roots only)
   --pipe-followup          Pipe naabu -silent stdout into sas-cybernet-packet-followup.sh
   --allow-full-ports       Permit allports_low_noise_json profile (-p - -ec)
   --profile-justified      Acknowledge justification for justification-required profiles (UDP, all-ports)
@@ -55,7 +59,7 @@ Options:
   --allow-public           Permit public IPs in target list
   --rate N                 Optional naabu -rate value
   --dry-run                Write planned command only; no packets
-  --planned-file PATH      Append planned command to file
+  --planned-file PATH      Append planned command to file (generated roots only)
   --verbose                Log resolved argv
   -h, --help               Show help
 
@@ -86,9 +90,18 @@ safe_site() {
   [[ -n "$SITE" ]] || fail "--site is required"
 }
 
+validate_output_paths() {
+  if [[ -n "$OUT" ]]; then
+    sas_target_require_output_path "$OUT" "Naabu output file" "$REPO_ROOT" || exit 1
+  fi
+  if [[ -n "$PLANNED_FILE" ]]; then
+    sas_target_require_output_path "$PLANNED_FILE" "Naabu planned command file" "$REPO_ROOT" || exit 1
+  fi
+}
+
 validate_target_file() {
   local file="$1" line n=0
-  [[ -f "$file" ]] || fail "Target list not found: $file"
+  sas_target_require_input_file "$file" "Naabu target list" 1 "$REPO_ROOT" || exit 1
   while IFS= read -r line || [[ -n "$line" ]]; do
     line="${line%%#*}"
     line="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
@@ -228,6 +241,7 @@ PY
 
 run_pipeline() {
   local naabu_bin followup_out count
+  validate_output_paths
   naabu_bin="$(bash "$ENSURE_SCRIPT" ${DRY_RUN:+--dry-run})"
   vlog "naabu binary: $naabu_bin"
 


### PR DESCRIPTION
Wires the shared target-intake helper into Naabu, subnet, and AD roster wrapper paths. Adds direct Survey doctrine CI coverage for central target-intake contracts. No live target files or generated evidence added.