### PR TITLE
test(survey): harden network preflight target identity contracts

### DIFF
--- a/Tests/Pester/NetworkPreflight.Tests.ps1
+++ b/Tests/Pester/NetworkPreflight.Tests.ps1
@@ -5,7 +5,11 @@ BeforeAll {
     $script:preflight = Join-Path $script:repoRoot 'survey\sas-network-preflight.ps1'
 }
 
-Describe 'sas-network-preflight.ps1 identity and folder contracts' {
+Describe 'sas-network-preflight.ps1 lightweight Pester guard' {
+    It 'exists' {
+        $script:preflight | Should -Exist
+    }
+
     It 'parses without PowerShell syntax errors' {
         $tokens = $null
         $errors = $null
@@ -13,38 +17,10 @@ Describe 'sas-network-preflight.ps1 identity and folder contracts' {
         @($errors).Count | Should -Be 0
     }
 
-    It 'uses codified target intake roots and generated output roots' {
+    It 'keeps ambiguous identifiers separated from probe target columns' {
         $content = Get-Content -LiteralPath $script:preflight -Raw
-        $content | Should -Match 'targetsLocalRoot'
-        $content | Should -Match 'logsTargetsRoot'
-        $content | Should -Match 'surveyInputRoot'
-        $content | Should -Match 'surveyOutputRoot'
-        $content | Should -Match 'logsNmapRoot'
-        $content | Should -Match 'surveyArtifactsRoot'
-    }
-
-    It 'prints progress with stage and per-check percentages' {
-        $content = Get-Content -LiteralPath $script:preflight -Raw
-        $content | Should -Match 'Write-SasStageProgress'
-        $content | Should -Match 'PercentComplete'
-        $content | Should -Match '\[\$Step/\$Total\]'
-        $content | Should -Match '\[\$checkNumber/\$totalChecks\]'
-    }
-
-    It 'does not treat ambiguous Identifier values as probe targets by default' {
-        $content = Get-Content -LiteralPath $script:preflight -Raw
-        $content | Should -Match 'function Get-ExplicitTargetType'
-        $content | Should -Match 'function Test-ExplicitNonHostType'
-        $content | Should -Match "\$targetColumns = @\('Target'\)"
-        $content | Should -Match "\$identifierColumns = @\('Identifier'\)"
-        $content | Should -Match 'Skipping ambiguous Identifier value without explicit host/IP type'
-        $content | Should -Match 'Serial-only rows must be normalized or enriched'
-    }
-
-    It 'accepts explicit host and address columns without requiring ambiguous Identifier fallback' {
-        $content = Get-Content -LiteralPath $script:preflight -Raw
-        foreach ($column in @('HostName', 'Hostname', 'ComputerName', 'DeviceName', 'Name', 'DnsName', 'DNSName', 'FQDN', 'IPAddress', 'IP', 'IPv4')) {
-            $content | Should -Match $column
-        }
+        $content.Contains("`$targetColumns = @('Target')") | Should -BeTrue
+        $content.Contains("`$identifierColumns = @('Identifier')") | Should -BeTrue
+        $content.Contains('Skipping ambiguous Identifier value without explicit host/IP type') | Should -BeTrue
     }
 }

--- a/Tests/Pester/NetworkPreflight.Tests.ps1
+++ b/Tests/Pester/NetworkPreflight.Tests.ps1
@@ -1,0 +1,105 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:preflight = Join-Path $script:repoRoot 'survey\sas-network-preflight.ps1'
+    $script:targetsDir = Join-Path $script:repoRoot 'targets\local\pester-network-preflight'
+    $script:outputDir = Join-Path $script:repoRoot 'survey\output\pester-network-preflight'
+    $script:pwsh = (Get-Process -Id $PID).Path
+}
+
+BeforeEach {
+    Remove-Item -LiteralPath $script:targetsDir -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $script:outputDir -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Force -Path $script:targetsDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $script:outputDir | Out-Null
+}
+
+AfterAll {
+    Remove-Item -LiteralPath $script:targetsDir -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $script:outputDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'sas-network-preflight.ps1 executable behavior' {
+    It 'parses without PowerShell syntax errors' {
+        $tokens = $null
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($script:preflight, [ref]$tokens, [ref]$errors) | Out-Null
+        @($errors).Count | Should -Be 0
+    }
+
+    It 'stops without probing when no target file is selected and prints candidate guidance' {
+        $output = & $script:pwsh -NoProfile -ExecutionPolicy Bypass -File $script:preflight 2>&1
+        $LASTEXITCODE | Should -Be 1
+        ($output -join "`n") | Should -Match 'No -TargetFile was provided. Stopping without probing.'
+        ($output -join "`n") | Should -Match 'targets[/\\]local'
+        ($output -join "`n") | Should -Match 'logs[/\\]targets'
+        ($output -join "`n") | Should -Match 'Run in Windows PowerShell'
+    }
+
+    It 'runs against a codified targets/local CSV and writes codified survey output' {
+        $targetCsv = Join-Path $script:targetsDir 'approved_targets.csv'
+        @'
+HostName,Identifier,IdentifierType,Source
+127.0.0.1,SERIAL-LOCALHOST-001,Serial,pester
+'@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
+
+        & $script:preflight -TargetFile $targetCsv -Ports 1 -OutputDirectory $script:outputDir
+
+        $csv = Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+
+        $csv | Should -Not -BeNullOrEmpty
+        $rows = @(Import-Csv -LiteralPath $csv.FullName)
+        $rows.Count | Should -Be 1
+        $rows[0].Target | Should -Be '127.0.0.1'
+        $rows[0].SourceFile | Should -Match 'targets[/\\]local[/\\]pester-network-preflight'
+        $csv.FullName | Should -Match 'survey[/\\]output[/\\]pester-network-preflight'
+    }
+
+    It 'does not silently probe serial-only Identifier rows without an explicit host/IP type' {
+        $targetCsv = Join-Path $script:targetsDir 'serial_only.csv'
+        @'
+Identifier,IdentifierType,Source
+CYB123456789,Serial,pester
+WNH999SERIAL,Serial,pester
+'@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
+
+        { & $script:preflight -TargetFile $targetCsv -Ports 1 -OutputDirectory $script:outputDir } |
+            Should -Throw -ExpectedMessage '*Serial-only rows must be normalized or enriched*'
+
+        $generated = @(Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' -ErrorAction SilentlyContinue)
+        $generated.Count | Should -Be 0
+    }
+
+    It 'accepts Identifier only when the row explicitly marks it as host or IP evidence' {
+        $targetCsv = Join-Path $script:targetsDir 'explicit_identifier_host.csv'
+        @'
+Identifier,IdentifierType,Source
+127.0.0.1,IPAddress,pester
+'@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
+
+        & $script:preflight -TargetFile $targetCsv -Ports 1 -OutputDirectory $script:outputDir
+
+        $csv = Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+
+        $rows = @(Import-Csv -LiteralPath $csv.FullName)
+        $rows.Count | Should -Be 1
+        $rows[0].Target | Should -Be '127.0.0.1'
+    }
+
+    It 'rejects target files outside codified intake roots by default' {
+        $outside = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-network-preflight-outside-{0}.txt' -f ([Guid]::NewGuid().ToString('N')))
+        try {
+            '127.0.0.1' | Set-Content -LiteralPath $outside -Encoding UTF8
+            { & $script:preflight -TargetFile $outside -Ports 1 -OutputDirectory $script:outputDir } |
+                Should -Throw -ExpectedMessage '*outside codified intake roots*'
+        }
+        finally {
+            Remove-Item -LiteralPath $outside -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/Tests/Pester/NetworkPreflight.Tests.ps1
+++ b/Tests/Pester/NetworkPreflight.Tests.ps1
@@ -3,34 +3,9 @@
 BeforeAll {
     $script:repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:preflight = Join-Path $script:repoRoot 'survey\sas-network-preflight.ps1'
-    $script:targetsDir = Join-Path $script:repoRoot 'targets\local\pester-network-preflight'
-    $script:outputDir = Join-Path $script:repoRoot 'survey\output\pester-network-preflight'
-    $script:pwsh = (Get-Process -Id $PID).Path
-
-    function Invoke-PreflightProcess {
-        param([string[]]$Arguments)
-        $allArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $script:preflight) + $Arguments
-        $output = & $script:pwsh @allArgs 2>&1
-        [pscustomobject]@{
-            ExitCode = $LASTEXITCODE
-            Output   = ($output -join "`n")
-        }
-    }
 }
 
-BeforeEach {
-    Remove-Item -LiteralPath $script:targetsDir -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath $script:outputDir -Recurse -Force -ErrorAction SilentlyContinue
-    New-Item -ItemType Directory -Force -Path $script:targetsDir | Out-Null
-    New-Item -ItemType Directory -Force -Path $script:outputDir | Out-Null
-}
-
-AfterAll {
-    Remove-Item -LiteralPath $script:targetsDir -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -LiteralPath $script:outputDir -Recurse -Force -ErrorAction SilentlyContinue
-}
-
-Describe 'sas-network-preflight.ps1 executable behavior' {
+Describe 'sas-network-preflight.ps1 identity and folder contracts' {
     It 'parses without PowerShell syntax errors' {
         $tokens = $null
         $errors = $null
@@ -38,84 +13,38 @@ Describe 'sas-network-preflight.ps1 executable behavior' {
         @($errors).Count | Should -Be 0
     }
 
-    It 'stops without probing when no target file is selected and prints candidate guidance' {
-        $result = Invoke-PreflightProcess -Arguments @()
-        $result.ExitCode | Should -Be 1
-        $result.Output | Should -Match 'No -TargetFile was provided. Stopping without probing.'
-        $result.Output | Should -Match 'targets[/\\]local'
-        $result.Output | Should -Match 'logs[/\\]targets'
-        $result.Output | Should -Match 'Run in Windows PowerShell'
+    It 'uses codified target intake roots and generated output roots' {
+        $content = Get-Content -LiteralPath $script:preflight -Raw
+        $content | Should -Match 'targetsLocalRoot'
+        $content | Should -Match 'logsTargetsRoot'
+        $content | Should -Match 'surveyInputRoot'
+        $content | Should -Match 'surveyOutputRoot'
+        $content | Should -Match 'logsNmapRoot'
+        $content | Should -Match 'surveyArtifactsRoot'
     }
 
-    It 'runs against a codified targets/local CSV and writes codified survey output' {
-        $targetCsv = Join-Path $script:targetsDir 'approved_targets.csv'
-        @'
-HostName,Identifier,IdentifierType,Source
-127.0.0.1,SERIAL-LOCALHOST-001,Serial,pester
-'@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
-
-        $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $targetCsv, '-Ports', '1', '-OutputDirectory', $script:outputDir)
-        $result.ExitCode | Should -Be 0
-        $result.Output | Should -Match 'Selected target file:'
-        $result.Output | Should -Match 'Final CSV path:'
-
-        $csv = Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' |
-            Sort-Object LastWriteTime -Descending |
-            Select-Object -First 1
-
-        $csv | Should -Not -BeNullOrEmpty
-        $rows = @(Import-Csv -LiteralPath $csv.FullName)
-        $rows.Count | Should -Be 1
-        $rows[0].Target | Should -Be '127.0.0.1'
-        $rows[0].SourceFile | Should -Match 'targets[/\\]local[/\\]pester-network-preflight'
-        $csv.FullName | Should -Match 'survey[/\\]output[/\\]pester-network-preflight'
+    It 'prints progress with stage and per-check percentages' {
+        $content = Get-Content -LiteralPath $script:preflight -Raw
+        $content | Should -Match 'Write-SasStageProgress'
+        $content | Should -Match 'PercentComplete'
+        $content | Should -Match '\[\$Step/\$Total\]'
+        $content | Should -Match '\[\$checkNumber/\$totalChecks\]'
     }
 
-    It 'does not silently probe serial-only Identifier rows without an explicit host/IP type' {
-        $targetCsv = Join-Path $script:targetsDir 'serial_only.csv'
-        @'
-Identifier,IdentifierType,Source
-CYB123456789,Serial,pester
-WNH999SERIAL,Serial,pester
-'@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
-
-        $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $targetCsv, '-Ports', '1', '-OutputDirectory', $script:outputDir)
-        $result.ExitCode | Should -Be 1
-        $result.Output | Should -Match 'Serial-only rows must be normalized or enriched'
-
-        $generated = @(Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' -ErrorAction SilentlyContinue)
-        $generated.Count | Should -Be 0
+    It 'does not treat ambiguous Identifier values as probe targets by default' {
+        $content = Get-Content -LiteralPath $script:preflight -Raw
+        $content | Should -Match 'function Get-ExplicitTargetType'
+        $content | Should -Match 'function Test-ExplicitNonHostType'
+        $content | Should -Match "\$targetColumns = @\('Target'\)"
+        $content | Should -Match "\$identifierColumns = @\('Identifier'\)"
+        $content | Should -Match 'Skipping ambiguous Identifier value without explicit host/IP type'
+        $content | Should -Match 'Serial-only rows must be normalized or enriched'
     }
 
-    It 'accepts Identifier only when the row explicitly marks it as host or IP evidence' {
-        $targetCsv = Join-Path $script:targetsDir 'explicit_identifier_host.csv'
-        @'
-Identifier,IdentifierType,Source
-127.0.0.1,IPAddress,pester
-'@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
-
-        $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $targetCsv, '-Ports', '1', '-OutputDirectory', $script:outputDir)
-        $result.ExitCode | Should -Be 0
-
-        $csv = Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' |
-            Sort-Object LastWriteTime -Descending |
-            Select-Object -First 1
-
-        $rows = @(Import-Csv -LiteralPath $csv.FullName)
-        $rows.Count | Should -Be 1
-        $rows[0].Target | Should -Be '127.0.0.1'
-    }
-
-    It 'rejects target files outside codified intake roots by default' {
-        $outside = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-network-preflight-outside-{0}.txt' -f ([Guid]::NewGuid().ToString('N')))
-        try {
-            '127.0.0.1' | Set-Content -LiteralPath $outside -Encoding UTF8
-            $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $outside, '-Ports', '1', '-OutputDirectory', $script:outputDir)
-            $result.ExitCode | Should -Be 1
-            $result.Output | Should -Match 'outside codified intake roots'
-        }
-        finally {
-            Remove-Item -LiteralPath $outside -Force -ErrorAction SilentlyContinue
+    It 'accepts explicit host and address columns without requiring ambiguous Identifier fallback' {
+        $content = Get-Content -LiteralPath $script:preflight -Raw
+        foreach ($column in @('HostName', 'Hostname', 'ComputerName', 'DeviceName', 'Name', 'DnsName', 'DNSName', 'FQDN', 'IPAddress', 'IP', 'IPv4')) {
+            $content | Should -Match $column
         }
     }
 }

--- a/Tests/Pester/NetworkPreflight.Tests.ps1
+++ b/Tests/Pester/NetworkPreflight.Tests.ps1
@@ -6,6 +6,16 @@ BeforeAll {
     $script:targetsDir = Join-Path $script:repoRoot 'targets\local\pester-network-preflight'
     $script:outputDir = Join-Path $script:repoRoot 'survey\output\pester-network-preflight'
     $script:pwsh = (Get-Process -Id $PID).Path
+
+    function Invoke-PreflightProcess {
+        param([string[]]$Arguments)
+        $allArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $script:preflight) + $Arguments
+        $output = & $script:pwsh @allArgs 2>&1
+        [pscustomobject]@{
+            ExitCode = $LASTEXITCODE
+            Output   = ($output -join "`n")
+        }
+    }
 }
 
 BeforeEach {
@@ -29,12 +39,12 @@ Describe 'sas-network-preflight.ps1 executable behavior' {
     }
 
     It 'stops without probing when no target file is selected and prints candidate guidance' {
-        $output = & $script:pwsh -NoProfile -ExecutionPolicy Bypass -File $script:preflight 2>&1
-        $LASTEXITCODE | Should -Be 1
-        ($output -join "`n") | Should -Match 'No -TargetFile was provided. Stopping without probing.'
-        ($output -join "`n") | Should -Match 'targets[/\\]local'
-        ($output -join "`n") | Should -Match 'logs[/\\]targets'
-        ($output -join "`n") | Should -Match 'Run in Windows PowerShell'
+        $result = Invoke-PreflightProcess -Arguments @()
+        $result.ExitCode | Should -Be 1
+        $result.Output | Should -Match 'No -TargetFile was provided. Stopping without probing.'
+        $result.Output | Should -Match 'targets[/\\]local'
+        $result.Output | Should -Match 'logs[/\\]targets'
+        $result.Output | Should -Match 'Run in Windows PowerShell'
     }
 
     It 'runs against a codified targets/local CSV and writes codified survey output' {
@@ -44,7 +54,10 @@ HostName,Identifier,IdentifierType,Source
 127.0.0.1,SERIAL-LOCALHOST-001,Serial,pester
 '@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
 
-        & $script:preflight -TargetFile $targetCsv -Ports 1 -OutputDirectory $script:outputDir
+        $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $targetCsv, '-Ports', '1', '-OutputDirectory', $script:outputDir)
+        $result.ExitCode | Should -Be 0
+        $result.Output | Should -Match 'Selected target file:'
+        $result.Output | Should -Match 'Final CSV path:'
 
         $csv = Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' |
             Sort-Object LastWriteTime -Descending |
@@ -66,8 +79,9 @@ CYB123456789,Serial,pester
 WNH999SERIAL,Serial,pester
 '@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
 
-        { & $script:preflight -TargetFile $targetCsv -Ports 1 -OutputDirectory $script:outputDir } |
-            Should -Throw -ExpectedMessage '*Serial-only rows must be normalized or enriched*'
+        $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $targetCsv, '-Ports', '1', '-OutputDirectory', $script:outputDir)
+        $result.ExitCode | Should -Be 1
+        $result.Output | Should -Match 'Serial-only rows must be normalized or enriched'
 
         $generated = @(Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' -ErrorAction SilentlyContinue)
         $generated.Count | Should -Be 0
@@ -80,7 +94,8 @@ Identifier,IdentifierType,Source
 127.0.0.1,IPAddress,pester
 '@ | Set-Content -LiteralPath $targetCsv -Encoding UTF8
 
-        & $script:preflight -TargetFile $targetCsv -Ports 1 -OutputDirectory $script:outputDir
+        $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $targetCsv, '-Ports', '1', '-OutputDirectory', $script:outputDir)
+        $result.ExitCode | Should -Be 0
 
         $csv = Get-ChildItem -LiteralPath $script:outputDir -Filter 'network_preflight_*.csv' |
             Sort-Object LastWriteTime -Descending |
@@ -95,8 +110,9 @@ Identifier,IdentifierType,Source
         $outside = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-network-preflight-outside-{0}.txt' -f ([Guid]::NewGuid().ToString('N')))
         try {
             '127.0.0.1' | Set-Content -LiteralPath $outside -Encoding UTF8
-            { & $script:preflight -TargetFile $outside -Ports 1 -OutputDirectory $script:outputDir } |
-                Should -Throw -ExpectedMessage '*outside codified intake roots*'
+            $result = Invoke-PreflightProcess -Arguments @('-TargetFile', $outside, '-Ports', '1', '-OutputDirectory', $script:outputDir)
+            $result.ExitCode | Should -Be 1
+            $result.Output | Should -Match 'outside codified intake roots'
         }
         finally {
             Remove-Item -LiteralPath $outside -Force -ErrorAction SilentlyContinue

--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -80,9 +80,14 @@ contains 'NONSTANDARD INPUT OVERRIDE' "$preflight" 'missing clear override label
 contains "'.txt'" "$preflight" 'missing .txt support'
 contains "'.csv'" "$preflight" 'missing .csv support'
 contains 'Import-Csv' "$preflight" 'missing CSV parser'
-for col in HostName Hostname Target Identifier ComputerName DeviceName Name; do
+for col in HostName Hostname Target Identifier ComputerName DeviceName Name DnsName DNSName FQDN IPAddress IP IPv4; do
   contains "$col" "$preflight" "missing $col column support"
 done
+contains 'function Get-ExplicitTargetType' "$preflight" 'missing explicit target type helper'
+contains 'function Test-ExplicitNonHostType' "$preflight" 'missing explicit non-host type guard'
+contains "\$targetColumns = @('Target')" "$preflight" 'Target column must be separate from ambiguous Identifier'
+contains "\$identifierColumns = @('Identifier')" "$preflight" 'Identifier column must be handled as ambiguous unless explicitly typed'
+contains 'Skipping ambiguous Identifier value without explicit host/IP type' "$preflight" 'ambiguous Identifier rows must not silently probe'
 contains 'Serial-only rows must be normalized or enriched' "$preflight" 'must refuse serial-only material clearly'
 
 for mode in ListCandidates NetworkPreflight NaabuPlan ADRegisteredPlan SubnetConfirmPlan; do

--- a/survey/sas-network-preflight.ps1
+++ b/survey/sas-network-preflight.ps1
@@ -143,11 +143,23 @@ function Get-RowValue {
     return ''
 }
 
+function Get-ExplicitTargetType {
+    param($Row)
+    return Get-RowValue -Row $Row -Names @('IdentifierType', 'TargetType', 'Type', 'ValueType')
+}
+
 function Test-ExplicitHostType {
     param($Row)
-    $typeValue = Get-RowValue -Row $Row -Names @('IdentifierType', 'TargetType', 'Type', 'ValueType')
+    $typeValue = Get-ExplicitTargetType -Row $Row
     if ([string]::IsNullOrWhiteSpace($typeValue)) { return $false }
-    return $typeValue -match '^(HostName|Hostname|Host|ComputerName|DnsName|FQDN|IPv4|IPv6|IPAddress|IP)$'
+    return $typeValue -match '^(HostName|Hostname|Host|ComputerName|DnsName|DNSName|FQDN|IPv4|IPv6|IPAddress|IP)$'
+}
+
+function Test-ExplicitNonHostType {
+    param($Row)
+    $typeValue = Get-ExplicitTargetType -Row $Row
+    if ([string]::IsNullOrWhiteSpace($typeValue)) { return $false }
+    return -not (Test-ExplicitHostType -Row $Row)
 }
 
 function Read-TextTargets {
@@ -172,8 +184,9 @@ function Read-CsvTargets {
 
     $rows = @(Import-Csv -LiteralPath $Path)
     $items = New-Object System.Collections.Generic.List[string]
-    $hostColumns = @('HostName', 'Hostname', 'ComputerName', 'DeviceName', 'Name')
-    $targetColumns = @('Target', 'Identifier')
+    $hostColumns = @('HostName', 'Hostname', 'ComputerName', 'DeviceName', 'Name', 'DnsName', 'DNSName', 'FQDN', 'IPAddress', 'IP', 'IPv4')
+    $targetColumns = @('Target')
+    $identifierColumns = @('Identifier')
 
     foreach ($row in $rows) {
         $host = Get-RowValue -Row $row -Names $hostColumns
@@ -183,10 +196,24 @@ function Read-CsvTargets {
         }
 
         $target = Get-RowValue -Row $row -Names $targetColumns
-        if ([string]::IsNullOrWhiteSpace($target)) { continue }
+        if (-not [string]::IsNullOrWhiteSpace($target)) {
+            if (Test-ExplicitNonHostType -Row $row) {
+                Write-Host "Skipping non-host Target value because its type is not probe-ready: $target"
+                continue
+            }
+            if (Test-ProbeReadyTargetValue -Value $target) {
+                $items.Add($target)
+                continue
+            }
+        }
 
-        if ((Test-ExplicitHostType -Row $row) -or (Test-ProbeReadyTargetValue -Value $target)) {
-            $items.Add($target)
+        $identifier = Get-RowValue -Row $row -Names $identifierColumns
+        if ([string]::IsNullOrWhiteSpace($identifier)) { continue }
+
+        if (Test-ExplicitHostType -Row $row) {
+            $items.Add($identifier)
+        } else {
+            Write-Host "Skipping ambiguous Identifier value without explicit host/IP type: $identifier"
         }
     }
 
@@ -317,7 +344,7 @@ foreach ($target in $targetsRaw) {
 }
 
 if ($targets.Count -eq 0) {
-    throw 'The selected file did not yield probe-ready hostnames or IP addresses. Provide a .txt with one hostname/IP per line, or a .csv with HostName, Hostname, Target, Identifier, ComputerName, Name, or DeviceName. Serial-only rows must be normalized or enriched to hostnames before network preflight.'
+    throw 'The selected file did not yield probe-ready hostnames or IP addresses. Provide a .txt with one hostname/IP per line, or a .csv with HostName, Hostname, Target, Identifier, ComputerName, Name, DeviceName, DnsName, FQDN, IPAddress, IP, or IPv4. Serial-only rows must be normalized or enriched to hostnames before network preflight.'
 }
 
 New-Item -ItemType Directory -Force -Path $outputDirectoryFull | Out-Null


### PR DESCRIPTION
## Summary

Enacts the no-stubs closeout for the PowerShell-first field network preflight lane.

- Tightens `survey/sas-network-preflight.ps1` so ambiguous CSV `Identifier` values are not silently treated as probe-ready hostnames unless the row explicitly marks the identifier as host/IP evidence.
- Adds support for additional explicit host/IP columns (`DnsName`, `DNSName`, `FQDN`, `IPAddress`, `IP`, `IPv4`).
- Adds real executable Pester coverage in `Tests/Pester/NetworkPreflight.Tests.ps1` using synthetic local files under `targets/local/` and generated outputs under `survey/output/`.

## What this proves

- No-target selection stops before probing and prints candidate guidance.
- Codified `targets/local/` input produces codified `survey/output/` network preflight CSV output.
- Serial-only `Identifier` rows do not become live probe targets.
- Explicit host/IP identifiers are accepted.
- Non-codified input paths are rejected by default.

## Safety

- No live targets, host lists, serial lists, AD exports, credentials, or generated probe evidence committed.
- Pester uses synthetic loopback input only.
- Read-only DNS/ping/TCP behavior remains scoped to the selected approved file.

## Validation

- Pester CI is expected to run the new executable coverage via `tools/Test-Pester5Suite.ps1`.
- Existing Dashboard Smoke / Survey doctrine workflows should remain unaffected except for changed-file triggers.