### PR TITLE
docs(survey): add delta preflight evidence cache contract

### DIFF
--- a/docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
+++ b/docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
@@ -1,0 +1,515 @@
+# Delta Preflight Evidence Cache Sprint Contract
+
+## Purpose
+
+This document defines the implementation-ready sprint for a **delta preflight / local evidence cache** lane in SysAdminSuite.
+
+The goal is to prevent unnecessary network packets and technician rework by comparing a requested serial/target population against local, already ascertained artifacts before any ping or TCP preflight runs.
+
+The field question is not:
+
+```text
+Can we ping everything again?
+```
+
+The field question is:
+
+```text
+What do we already know locally, what is stale, what conflicts, and what still deserves packets?
+```
+
+## Replit harvest insights carried forward
+
+The Replit harvest history is useful, but it is not a direct merge source. Treat it as a product-insight archive and promote only reviewed logic into clean product branches.
+
+Standing insights to preserve:
+
+1. **Quarantine is reference, not product.** Do not merge `replit-harvest/` wholesale. Promote deliberately in small reviewed slices.
+2. **Offline/test mode comes first.** Live probing is trusted only after fixtures, contracts, and local artifact processing are stable.
+3. **PowerShell remains active Windows tooling.** Current Northwell field preflight is PowerShell-first. Do not collapse field guidance back into Replit/Linux defaults.
+4. **Runtime mismatch is not product failure.** Missing Windows tools in Replit/Linux are expected environment mismatch, not a reason to rewrite the field lane for Linux.
+5. **Survey before mutation. Report before action.** Delta planning performs no network activity and mutates no targets.
+6. **Generated operational artifacts stay local.** CSV/HTML/JSON/log outputs with live hostnames, serials, MACs, users, rooms, departments, or locations must never be committed.
+7. **Ping failure is not evidence failure.** A host can have DNS, AD, serial, MAC, or identity evidence even when ICMP fails. Preserve the path by which evidence was obtained.
+8. **Do not flatten evidence.** Keep separate evidence lanes for ping reachable, DNS only/no ping, identity observed/no ping, offline fixture, unreachable/off, conflicting evidence, and manual review.
+9. **Small chunks beat terminal-paste heroics.** Future implementation should be decomposed into small commits: fixtures, contracts, planner, dashboard/readme integration.
+
+## Product principle
+
+Network preflight should be the last-mile action, not the first pass.
+
+```text
+requested serial population
+  -> local evidence comparison
+  -> delta decision plan
+  -> reduced probe target file
+  -> network preflight only for the delta
+  -> reconciliation/report artifacts
+```
+
+## Non-goals
+
+This sprint must not create a new scanner.
+
+It must not:
+
+- ping the requested population itself
+- run Nmap / Naabu / Test-NetConnection
+- query live AD
+- collect credentials
+- mutate target machines
+- install software
+- create remote tasks
+- suppress telemetry
+- hide network activity
+- broaden scope beyond the approved source population
+
+It only plans what should be probed later.
+
+## Source/input roots
+
+The delta planner may read requested target/serial material from:
+
+```text
+targets/local/
+logs/targets/
+survey/input/   # normalized staging only
+```
+
+The planner must reject live input from arbitrary paths unless an explicit, clearly labeled nonstandard override exists.
+
+## Evidence roots
+
+The planner may read prior local evidence from codified ignored output roots:
+
+```text
+survey/output/network_preflight/
+survey/output/ad_registered_population/
+survey/output/ad_candidate_pool/
+survey/output/SysAdminSuite_Artifacts/
+survey/output/cybernet_progress_summary.csv
+survey/output/cybernet_progress_summary.json
+logs/nmap/
+survey/artifacts/
+```
+
+It should support explicit evidence file arguments as well as directory discovery.
+
+## Required output root
+
+The planner writes a self-contained local ignored run directory:
+
+```text
+survey/output/delta_preflight/<run_id>/
+```
+
+Required files:
+
+```text
+delta_preflight_plan.csv
+to_probe_targets.txt
+skipped_recent_evidence.csv
+review_required.csv
+delta_summary.json
+README.txt
+```
+
+No generated delta output is committed.
+
+## Evidence model
+
+The delta planner is a reconciliation layer over evidence, not a truth oracle.
+
+| Evidence | Meaning | Can skip ping? | Can confirm serial? |
+|---|---|---:|---:|
+| Recent network preflight reachable | Target recently responded to ping/TCP evidence | Yes, within TTL | No |
+| Recent network preflight silent | Target was recently silent/unreachable | Maybe, if retry not useful | No |
+| AD registered row | Directory registration / population evidence | Maybe, if paired with recent reachability | No |
+| AD candidate-pool row | Naming-convention candidate | No by itself | No |
+| Live identity row | Host reported serial/MAC/identity evidence | Usually yes | Yes, if serial matches |
+| Tracker row | Planned/deployed operational attribution | Maybe | No by itself |
+| Offline fixture | Test evidence only | No for live | No |
+
+## Freshness defaults
+
+Recommended defaults:
+
+```text
+ReachabilityTtlHours = 24
+IdentityTtlDays = 7
+```
+
+Interpretation:
+
+- Reachability older than the TTL becomes stale and can be probed again.
+- Identity evidence older than the TTL should warn, but should not be casually discarded.
+- Operator override can force reprobe, but the reason must appear in the plan.
+
+## Requested input schema
+
+The requested population can be serial-first, hostname-first, or already normalized.
+
+Recognized input columns:
+
+```text
+Serial
+ExpectedSerial
+Cybernet Serial
+Cybernet S/N
+Neuron Serial
+Neuron S/N
+HostName
+Hostname
+ComputerName
+ExpectedHostname
+Target
+Identifier
+DeviceType
+Site
+Source
+```
+
+Rules:
+
+1. Prefer explicit serial columns for population counting.
+2. Prefer explicit hostname columns for probe target selection.
+3. Treat ambiguous `Identifier` as probe-ready only if explicitly typed as hostname/IP by an existing normalized source.
+4. Serial-only rows are not pingable.
+5. A serial with exactly one validated hostname can become probe-ready.
+6. A serial with zero hostnames is review-required.
+7. A serial with multiple hostnames is review-required unless one is identity-confirmed.
+
+## Prior evidence parsing
+
+The planner should normalize prior evidence into an internal evidence table keyed by:
+
+```text
+NormalizedSerial
+NormalizedHostname
+NormalizedTarget
+NormalizedMac
+EvidenceSourceFile
+EvidenceTimestamp
+```
+
+Where possible, parse evidence timestamps from source columns such as:
+
+```text
+Timestamp
+GeneratedAt
+probed_at
+ProbedAt
+ObservedAt
+```
+
+If no timestamp exists, classify freshness as unknown and require either review or reprobe depending on the evidence class.
+
+## Decision statuses
+
+Every requested row must receive exactly one primary decision.
+
+```text
+PROBE_REQUIRED_NO_EVIDENCE
+PROBE_REQUIRED_STALE_EVIDENCE
+PROBE_REQUIRED_CONFLICTING_EVIDENCE
+PROBE_REQUIRED_OPERATOR_FORCED
+SKIP_RECENT_REACHABLE
+SKIP_RECENT_IDENTITY_CONFIRMED
+SKIP_ALREADY_TRACKED
+SKIP_RECENTLY_SILENT_WITHIN_COOLDOWN
+REVIEW_REQUIRED_SERIAL_ONLY
+REVIEW_REQUIRED_MULTIPLE_HOSTNAMES
+REVIEW_REQUIRED_AD_VARIANT_ONLY
+REVIEW_REQUIRED_PREFIX_SITE_MISMATCH
+REVIEW_REQUIRED_EVIDENCE_TIMESTAMP_UNKNOWN
+BLOCKED_NO_PROBE_READY_HOST
+```
+
+## Required plan schema
+
+`delta_preflight_plan.csv` must include:
+
+```text
+InputRowId
+InputSource
+Serial
+RequestedHostname
+ResolvedHostname
+CandidateHostnames
+ProbeTarget
+LastReachabilityStatus
+LastReachabilityTimestamp
+LastReachabilitySource
+LastIdentityStatus
+LastIdentityTimestamp
+LastIdentitySource
+ADCandidateStatus
+ADCandidateSource
+TrackerStatus
+Decision
+DecisionReason
+ReviewRequired
+EvidenceSourceFiles
+```
+
+## Probe target file contract
+
+`to_probe_targets.txt` must contain only probe-ready hostnames/IPs selected by the delta plan.
+
+Rules:
+
+- one target per line
+- no serial-only values
+- no duplicate targets
+- no AD variant-only targets unless operator-approved or explicitly classified as probe-eligible by the plan
+- no targets from review-required rows
+- comments may be included with `#`, but network preflight must ignore them
+
+## Summary contract
+
+`delta_summary.json` must include:
+
+```text
+run_id
+generated_at
+input_source
+input_rows
+total_serials
+probe_required_count
+skipped_recent_reachable_count
+skipped_identity_confirmed_count
+review_required_count
+blocked_count
+stale_evidence_count
+conflicting_evidence_count
+to_probe_targets_path
+plan_path
+review_required_path
+skipped_recent_evidence_path
+evidence_files_loaded
+reachability_ttl_hours
+identity_ttl_days
+network_activity_performed
+```
+
+`network_activity_performed` must always be `false` for the delta planner.
+
+## Replit-derived evidence-path guardrail
+
+Historical Replit/live-serial work exposed an important bug class:
+
+```text
+A device may provide identity evidence even when cmd ping cannot reach it.
+```
+
+The delta planner must never collapse that into `unreachable` or `reachable` alone. It must preserve how evidence was obtained:
+
+```text
+ping_reachable
+DNS_only_no_ping
+identity_observed_no_ping
+offline_fixture
+unreachable_or_silent
+manual_review_conflict
+```
+
+If identity evidence exists but reachability is silent, the row should be classified with a reason like:
+
+```text
+SKIP_RECENT_IDENTITY_CONFIRMED
+identity observed despite no recent ping; do not reprobe unless forced
+```
+
+or, if identity evidence is old:
+
+```text
+PROBE_REQUIRED_STALE_EVIDENCE
+identity evidence exists but freshness window expired; reprobe target if hostname is probe-ready
+```
+
+## Planner algorithm
+
+1. Load requested rows from an approved source.
+2. Normalize serials, hostnames, MACs, and target identifiers.
+3. Load prior evidence files from configured local evidence roots.
+4. Build an evidence index by serial, hostname, target, and MAC.
+5. For each requested row:
+   - resolve known hostnames
+   - attach prior reachability evidence
+   - attach prior identity evidence
+   - attach AD registered / candidate evidence
+   - attach tracker/progress evidence
+   - classify freshness
+   - choose one decision
+6. Write the full plan.
+7. Write `to_probe_targets.txt` from probe-required, probe-ready rows only.
+8. Write skipped/review sidecar CSVs.
+9. Write summary JSON.
+10. Print counts and next command.
+
+## PowerShell-first field flow
+
+Run in Windows PowerShell:
+
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-delta-preflight-plan.ps1 `
+  -InputFile .\targets\local\approved_serials_or_targets.csv `
+  -ReachabilityTtlHours 24 `
+  -IdentityTtlDays 7
+```
+
+Then run network preflight only on the reduced target file:
+
+```powershell
+.\survey\sas-network-preflight.ps1 `
+  -TargetFile .\survey\output\delta_preflight\<run_id>\to_probe_targets.txt `
+  -Ports 135,445,3389,9100
+```
+
+The dashboard should show this as:
+
+```text
+1. Load approved source.
+2. Compare local evidence.
+3. Review skipped / probe / review counts.
+4. Probe only the generated delta target file.
+5. Feed new evidence back into reconciliation.
+```
+
+## Runtime doctrine
+
+Current field path is PowerShell-first.
+
+Replit/Linux is not the runtime target for this lane. If future tests run in Replit/Linux and Windows tools are missing, classify that as environment mismatch, not product failure.
+
+Do not reintroduce Git Bash / MINGW64 as the field path for this PowerShell lane.
+
+## Implementation surfaces
+
+Preferred files for the implementation sprint:
+
+```text
+survey/sas-delta-preflight-plan.ps1
+scripts/SasDeltaEvidenceCache.psm1
+Tests/Pester/DeltaPreflight.Tests.ps1
+Tests/bash/test_delta_preflight_contracts.sh
+docs/FIELD_NETWORK_PREFLIGHT.md
+survey/fixtures/delta_preflight_requested.sample.csv
+survey/fixtures/delta_preflight_evidence.sample.csv
+```
+
+Keep fixtures synthetic only.
+
+## Required tests
+
+Tests must prove:
+
+1. Recent reachable evidence skips a target.
+2. Stale reachable evidence requires reprobe.
+3. Identity-confirmed serial skips ping unless forced.
+4. Serial-only row is review-required.
+5. Multiple-hostname serial is review-required.
+6. AD variant-only row is review-required, not probe-confirmed.
+7. Prefix/site mismatch is review-required.
+8. Conflicting identity/reachability evidence requires review or reprobe.
+9. `to_probe_targets.txt` contains only probe-ready hostnames/IPs.
+10. Duplicate probe targets are deduplicated.
+11. Planner performs no network commands.
+12. Planner writes all outputs under `survey/output/delta_preflight/`.
+13. No live target/evidence files are committed.
+14. Replit/Linux runtime mismatch is not treated as product failure.
+15. PowerShell remains the field lane for this workflow.
+
+## Static forbidden patterns
+
+The delta planner and field docs must not introduce:
+
+```text
+Name -like '*'
+nslookup as default live field command for this lane
+ping as planner behavior
+Test-NetConnection as planner behavior
+nmap as planner behavior
+naabu as planner behavior
+/tmp live paths
+C:\Temp live workflow
+Git Bash / MINGW64 as field default
+```
+
+Network commands belong in network preflight, not in the delta planner.
+
+## Acceptance criteria
+
+The implementation sprint is complete when:
+
+- Requested serial/target files can be compared to local evidence without sending packets.
+- The planner emits a reduced `to_probe_targets.txt` for network preflight.
+- Recent, useful evidence skips rework.
+- Stale or conflicting evidence is surfaced clearly.
+- Serial-only and ambiguous-hostname rows are review-required.
+- Ping failure does not erase identity/AD/DNS evidence.
+- Dashboard or runbook flow makes delta planning the step before network preflight.
+- Tests prove no network activity occurs in the planner.
+
+## Copy-ready next-agent prompt
+
+```text
+You are continuing SysAdminSuite.
+
+Current doctrine to implement:
+- docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
+- docs/FIELD_NETWORK_PREFLIGHT.md
+- docs/CYBERNET_XLSX_TARGET_INGESTION.md
+- docs/AD_REGISTERED_POPULATION.md
+- docs/AD_COMPUTER_CANDIDATE_POOL_SPRINT.md
+
+Mission:
+Implement a PowerShell-first delta preflight planner that compares requested serials/targets against local evidence before any ping/TCP packets are sent.
+
+Do not create a new scanner.
+Do not run network commands in the planner.
+Do not use generic fuzzy logic.
+Do not commit live evidence.
+Do not treat Replit/Linux runtime mismatch as product failure.
+Do not collapse PowerShell field tooling into Bash/Linux defaults.
+
+Required entrypoint:
+- survey/sas-delta-preflight-plan.ps1
+
+Required outputs:
+- survey/output/delta_preflight/<run_id>/delta_preflight_plan.csv
+- survey/output/delta_preflight/<run_id>/to_probe_targets.txt
+- survey/output/delta_preflight/<run_id>/skipped_recent_evidence.csv
+- survey/output/delta_preflight/<run_id>/review_required.csv
+- survey/output/delta_preflight/<run_id>/delta_summary.json
+
+Default TTLs:
+- ReachabilityTtlHours = 24
+- IdentityTtlDays = 7
+
+Decision statuses:
+- PROBE_REQUIRED_NO_EVIDENCE
+- PROBE_REQUIRED_STALE_EVIDENCE
+- PROBE_REQUIRED_CONFLICTING_EVIDENCE
+- PROBE_REQUIRED_OPERATOR_FORCED
+- SKIP_RECENT_REACHABLE
+- SKIP_RECENT_IDENTITY_CONFIRMED
+- SKIP_ALREADY_TRACKED
+- SKIP_RECENTLY_SILENT_WITHIN_COOLDOWN
+- REVIEW_REQUIRED_SERIAL_ONLY
+- REVIEW_REQUIRED_MULTIPLE_HOSTNAMES
+- REVIEW_REQUIRED_AD_VARIANT_ONLY
+- REVIEW_REQUIRED_PREFIX_SITE_MISMATCH
+- REVIEW_REQUIRED_EVIDENCE_TIMESTAMP_UNKNOWN
+- BLOCKED_NO_PROBE_READY_HOST
+
+Validation:
+- Pester suite
+- offline survey tests
+- bash/static contracts
+- dashboard smoke if dashboard copy changes
+
+Merge policy:
+merge_when_green.
+```

--- a/docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
+++ b/docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
@@ -42,7 +42,7 @@ Network preflight should be the last-mile action, not the first pass.
 requested serial population
   -> local evidence comparison
   -> delta decision plan
-  -> reduced probe target file
+  -> reduced staged target file
   -> network preflight only for the delta
   -> reconciliation/report artifacts
 ```
@@ -95,26 +95,31 @@ survey/artifacts/
 
 It should support explicit evidence file arguments as well as directory discovery.
 
-## Required output root
+## Required output and staging roots
 
-The planner writes a self-contained local ignored run directory:
+The planner writes human/machine reports to a self-contained local ignored run directory:
 
 ```text
 survey/output/delta_preflight/<run_id>/
 ```
 
-Required files:
+Required report files:
 
 ```text
 delta_preflight_plan.csv
-to_probe_targets.txt
 skipped_recent_evidence.csv
 review_required.csv
 delta_summary.json
 README.txt
 ```
 
-No generated delta output is committed.
+The planner must stage the runnable reduced target file under the normalized input root because `survey/sas-network-preflight.ps1` currently accepts codified source/staging roots, not generated report roots:
+
+```text
+survey/input/delta_preflight/<run_id>/to_probe_targets.txt
+```
+
+No generated delta report, staged target, or live operational evidence is committed.
 
 ## Evidence model
 
@@ -254,7 +259,7 @@ EvidenceSourceFiles
 
 ## Probe target file contract
 
-`to_probe_targets.txt` must contain only probe-ready hostnames/IPs selected by the delta plan.
+`survey/input/delta_preflight/<run_id>/to_probe_targets.txt` must contain only probe-ready hostnames/IPs selected by the delta plan.
 
 Rules:
 
@@ -291,6 +296,8 @@ reachability_ttl_hours
 identity_ttl_days
 network_activity_performed
 ```
+
+`to_probe_targets_path` must point to the staged `survey/input/delta_preflight/<run_id>/to_probe_targets.txt` file.
 
 `network_activity_performed` must always be `false` for the delta planner.
 
@@ -341,8 +348,8 @@ identity evidence exists but freshness window expired; reprobe target if hostnam
    - attach tracker/progress evidence
    - classify freshness
    - choose one decision
-6. Write the full plan.
-7. Write `to_probe_targets.txt` from probe-required, probe-ready rows only.
+6. Write the full plan under `survey/output/delta_preflight/<run_id>/`.
+7. Stage `to_probe_targets.txt` under `survey/input/delta_preflight/<run_id>/` from probe-required, probe-ready rows only.
 8. Write skipped/review sidecar CSVs.
 9. Write summary JSON.
 10. Print counts and next command.
@@ -359,11 +366,11 @@ Set-Location <SysAdminSuite repo root>
   -IdentityTtlDays 7
 ```
 
-Then run network preflight only on the reduced target file:
+Then run network preflight only on the staged reduced target file:
 
 ```powershell
 .\survey\sas-network-preflight.ps1 `
-  -TargetFile .\survey\output\delta_preflight\<run_id>\to_probe_targets.txt `
+  -TargetFile .\survey\input\delta_preflight\<run_id>\to_probe_targets.txt `
   -Ports 135,445,3389,9100
 ```
 
@@ -373,7 +380,7 @@ The dashboard should show this as:
 1. Load approved source.
 2. Compare local evidence.
 3. Review skipped / probe / review counts.
-4. Probe only the generated delta target file.
+4. Probe only the staged delta target file.
 5. Feed new evidence back into reconciliation.
 ```
 
@@ -416,7 +423,7 @@ Tests must prove:
 9. `to_probe_targets.txt` contains only probe-ready hostnames/IPs.
 10. Duplicate probe targets are deduplicated.
 11. Planner performs no network commands.
-12. Planner writes all outputs under `survey/output/delta_preflight/`.
+12. Planner writes reports under `survey/output/delta_preflight/` and stages runnable target files under `survey/input/delta_preflight/`.
 13. No live target/evidence files are committed.
 14. Replit/Linux runtime mismatch is not treated as product failure.
 15. PowerShell remains the field lane for this workflow.
@@ -444,7 +451,7 @@ Network commands belong in network preflight, not in the delta planner.
 The implementation sprint is complete when:
 
 - Requested serial/target files can be compared to local evidence without sending packets.
-- The planner emits a reduced `to_probe_targets.txt` for network preflight.
+- The planner emits a reduced staged `to_probe_targets.txt` for network preflight.
 - Recent, useful evidence skips rework.
 - Stale or conflicting evidence is surfaced clearly.
 - Serial-only and ambiguous-hostname rows are review-required.
@@ -463,6 +470,7 @@ Current doctrine to implement:
 - docs/CYBERNET_XLSX_TARGET_INGESTION.md
 - docs/AD_REGISTERED_POPULATION.md
 - docs/AD_COMPUTER_CANDIDATE_POOL_SPRINT.md
+- docs/go_naabu_packet_pipeline.plan.md
 
 Mission:
 Implement a PowerShell-first delta preflight planner that compares requested serials/targets against local evidence before any ping/TCP packets are sent.
@@ -477,12 +485,14 @@ Do not collapse PowerShell field tooling into Bash/Linux defaults.
 Required entrypoint:
 - survey/sas-delta-preflight-plan.ps1
 
-Required outputs:
+Required report outputs:
 - survey/output/delta_preflight/<run_id>/delta_preflight_plan.csv
-- survey/output/delta_preflight/<run_id>/to_probe_targets.txt
 - survey/output/delta_preflight/<run_id>/skipped_recent_evidence.csv
 - survey/output/delta_preflight/<run_id>/review_required.csv
 - survey/output/delta_preflight/<run_id>/delta_summary.json
+
+Required staged handoff output:
+- survey/input/delta_preflight/<run_id>/to_probe_targets.txt
 
 Default TTLs:
 - ReachabilityTtlHours = 24

--- a/docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
+++ b/docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
@@ -18,6 +18,22 @@ The field question is:
 What do we already know locally, what is stale, what conflicts, and what still deserves packets?
 ```
 
+## Top focus: adjust the next gap
+
+The next implementation gap is **evidence strength ranking**.
+
+Before adding more probing, SysAdminSuite must rank each serial row's strongest evidence and choose the correct handoff:
+
+```text
+confirmed identity
+skip recent evidence
+probe stale or missing evidence
+review ambiguous/candidate evidence
+block rows with no probe-ready target
+```
+
+See [`SERIAL_EVIDENCE_STRENGTH_RANKING.md`](SERIAL_EVIDENCE_STRENGTH_RANKING.md). The delta planner must use that ranking before it stages any target file.
+
 ## Replit harvest insights carried forward
 
 The Replit harvest history is useful, but it is not a direct merge source. Treat it as a product-insight archive and promote only reviewed logic into clean product branches.
@@ -40,6 +56,8 @@ Network preflight should be the last-mile action, not the first pass.
 
 ```text
 requested serial population
+  -> spreadsheet-backed normalization
+  -> evidence strength ranking
   -> local evidence comparison
   -> delta decision plan
   -> reduced staged target file
@@ -134,6 +152,8 @@ The delta planner is a reconciliation layer over evidence, not a truth oracle.
 | Live identity row | Host reported serial/MAC/identity evidence | Usually yes | Yes, if serial matches |
 | Tracker row | Planned/deployed operational attribution | Maybe | No by itself |
 | Offline fixture | Test evidence only | No for live | No |
+
+The detailed ranking order is defined in [`SERIAL_EVIDENCE_STRENGTH_RANKING.md`](SERIAL_EVIDENCE_STRENGTH_RANKING.md).
 
 ## Freshness defaults
 
@@ -242,6 +262,11 @@ RequestedHostname
 ResolvedHostname
 CandidateHostnames
 ProbeTarget
+EvidenceStrengthTier
+StrongestEvidencePath
+SerialIdentityConfirmed
+ProbeWorthiness
+PreferredNextHandoff
 LastReachabilityStatus
 LastReachabilityTimestamp
 LastReachabilitySource
@@ -341,11 +366,12 @@ identity evidence exists but freshness window expired; reprobe target if hostnam
 3. Load prior evidence files from configured local evidence roots.
 4. Build an evidence index by serial, hostname, target, and MAC.
 5. For each requested row:
-   - resolve known hostnames
-   - attach prior reachability evidence
-   - attach prior identity evidence
-   - attach AD registered / candidate evidence
-   - attach tracker/progress evidence
+   - attach all evidence paths
+   - compute `EvidenceStrengthTier`
+   - compute `StrongestEvidencePath`
+   - compute `SerialIdentityConfirmed`
+   - compute `ProbeWorthiness`
+   - compute `PreferredNextHandoff`
    - classify freshness
    - choose one decision
 6. Write the full plan under `survey/output/delta_preflight/<run_id>/`.
@@ -378,10 +404,11 @@ The dashboard should show this as:
 
 ```text
 1. Load approved source.
-2. Compare local evidence.
-3. Review skipped / probe / review counts.
-4. Probe only the staged delta target file.
-5. Feed new evidence back into reconciliation.
+2. Rank evidence strength.
+3. Compare local evidence.
+4. Review skipped / probe / review counts.
+5. Probe only the staged delta target file.
+6. Feed new evidence back into reconciliation.
 ```
 
 ## Runtime doctrine
@@ -427,6 +454,9 @@ Tests must prove:
 13. No live target/evidence files are committed.
 14. Replit/Linux runtime mismatch is not treated as product failure.
 15. PowerShell remains the field lane for this workflow.
+16. Evidence strength ranking follows `SERIAL_EVIDENCE_STRENGTH_RANKING.md`.
+17. Reachability-only and packet-only evidence never set `SerialIdentityConfirmed = true`.
+18. The staged target file is generated only from rows with probe-worthy ranking.
 
 ## Static forbidden patterns
 
@@ -451,12 +481,13 @@ Network commands belong in network preflight, not in the delta planner.
 The implementation sprint is complete when:
 
 - Requested serial/target files can be compared to local evidence without sending packets.
+- Each serial receives an evidence strength tier and strongest evidence path.
 - The planner emits a reduced staged `to_probe_targets.txt` for network preflight.
 - Recent, useful evidence skips rework.
 - Stale or conflicting evidence is surfaced clearly.
 - Serial-only and ambiguous-hostname rows are review-required.
 - Ping failure does not erase identity/AD/DNS evidence.
-- Dashboard or runbook flow makes delta planning the step before network preflight.
+- Dashboard or runbook flow makes evidence ranking and delta planning the step before network preflight.
 - Tests prove no network activity occurs in the planner.
 
 ## Copy-ready next-agent prompt
@@ -465,6 +496,7 @@ The implementation sprint is complete when:
 You are continuing SysAdminSuite.
 
 Current doctrine to implement:
+- docs/SERIAL_EVIDENCE_STRENGTH_RANKING.md
 - docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
 - docs/FIELD_NETWORK_PREFLIGHT.md
 - docs/CYBERNET_XLSX_TARGET_INGESTION.md
@@ -472,8 +504,18 @@ Current doctrine to implement:
 - docs/AD_COMPUTER_CANDIDATE_POOL_SPRINT.md
 - docs/go_naabu_packet_pipeline.plan.md
 
+Top focus:
+Implement evidence strength ranking before adding any new packet path.
+
 Mission:
 Implement a PowerShell-first delta preflight planner that compares requested serials/targets against local evidence before any ping/TCP packets are sent.
+
+For every serial row, compute:
+- EvidenceStrengthTier
+- StrongestEvidencePath
+- SerialIdentityConfirmed
+- ProbeWorthiness
+- PreferredNextHandoff
 
 Do not create a new scanner.
 Do not run network commands in the planner.
@@ -481,6 +523,7 @@ Do not use generic fuzzy logic.
 Do not commit live evidence.
 Do not treat Replit/Linux runtime mismatch as product failure.
 Do not collapse PowerShell field tooling into Bash/Linux defaults.
+Do not treat ping, TCP, Naabu, DNS, AD candidate, or subnet inference as serial proof.
 
 Required entrypoint:
 - survey/sas-delta-preflight-plan.ps1
@@ -497,22 +540,6 @@ Required staged handoff output:
 Default TTLs:
 - ReachabilityTtlHours = 24
 - IdentityTtlDays = 7
-
-Decision statuses:
-- PROBE_REQUIRED_NO_EVIDENCE
-- PROBE_REQUIRED_STALE_EVIDENCE
-- PROBE_REQUIRED_CONFLICTING_EVIDENCE
-- PROBE_REQUIRED_OPERATOR_FORCED
-- SKIP_RECENT_REACHABLE
-- SKIP_RECENT_IDENTITY_CONFIRMED
-- SKIP_ALREADY_TRACKED
-- SKIP_RECENTLY_SILENT_WITHIN_COOLDOWN
-- REVIEW_REQUIRED_SERIAL_ONLY
-- REVIEW_REQUIRED_MULTIPLE_HOSTNAMES
-- REVIEW_REQUIRED_AD_VARIANT_ONLY
-- REVIEW_REQUIRED_PREFIX_SITE_MISMATCH
-- REVIEW_REQUIRED_EVIDENCE_TIMESTAMP_UNKNOWN
-- BLOCKED_NO_PROBE_READY_HOST
 
 Validation:
 - Pester suite

--- a/docs/FIELD_NETWORK_PREFLIGHT.md
+++ b/docs/FIELD_NETWORK_PREFLIGHT.md
@@ -28,9 +28,38 @@ Do not type demo hostnames manually for live work. Do not use `C:\Temp` as the l
 
 1. Export or copy the approved spreadsheet, AD export, tracker tab, or target source to `targets/local/` or `logs/targets/`.
 2. If the source is not already a `.txt` or `.csv` with probe-ready hostnames/IPs, normalize it first.
-3. Run the PowerShell network preflight against the selected target file.
-4. Review the generated CSV under `survey/output/network_preflight/`.
-5. Load the CSV into the dashboard through **Load Evidence**.
+3. Run the delta preflight planner to compare the requested population against local evidence.
+4. Review skipped / probe / review counts from `survey/output/delta_preflight/<run_id>/`.
+5. Run the PowerShell network preflight only against `to_probe_targets.txt` from the delta plan.
+6. Review the generated CSV under `survey/output/network_preflight/`.
+7. Load the CSV into the dashboard through **Load Evidence**.
+
+## Delta preflight first
+
+Before sending new ping/TCP packets, compare the requested serial/target population against local evidence.
+
+See [`DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md`](DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md) for the implementation contract.
+
+The planner is a no-network step. It should answer:
+
+```text
+What do we already know locally?
+What evidence is still fresh?
+What is stale or conflicting?
+What still deserves packets?
+```
+
+Expected future planner output:
+
+```text
+survey/output/delta_preflight/<run_id>/delta_preflight_plan.csv
+survey/output/delta_preflight/<run_id>/to_probe_targets.txt
+survey/output/delta_preflight/<run_id>/skipped_recent_evidence.csv
+survey/output/delta_preflight/<run_id>/review_required.csv
+survey/output/delta_preflight/<run_id>/delta_summary.json
+```
+
+Only `to_probe_targets.txt` should feed the network preflight.
 
 ## Spreadsheet source on X:\
 
@@ -41,7 +70,8 @@ Preferred path:
 1. Export the approved spreadsheet or target tab to CSV.
 2. Place the CSV under `targets/local/` or `logs/targets/`.
 3. Normalize if needed.
-4. Run the PowerShell preflight against the selected CSV.
+4. Run the delta preflight planner.
+5. Run the PowerShell preflight against the planner's `to_probe_targets.txt`.
 
 ## Select a target file
 
@@ -57,6 +87,13 @@ With no `-TargetFile`, the script lists candidate `.txt` and `.csv` files from `
 ## Run the network preflight
 
 Run in Windows PowerShell:
+
+```powershell
+Set-Location <SysAdminSuite repo root>
+.\survey\sas-network-preflight.ps1 -TargetFile .\survey\output\delta_preflight\<run_id>\to_probe_targets.txt -Ports 135,445,3389,9100
+```
+
+Direct approved source roots are still accepted when the delta planner is not available yet:
 
 ```powershell
 Set-Location <SysAdminSuite repo root>
@@ -102,6 +139,22 @@ Also accepted when probe-ready or explicitly typed as a hostname/IP:
 
 Serial-only rows are not network targets. If a CSV only contains serials, enrich or normalize it to hostnames first.
 
+## Evidence interpretation
+
+Ping/TCP preflight is reachability evidence only.
+
+Do not treat ping failure as proof that no useful evidence exists. Preserve separate paths for:
+
+- ping reachable
+- DNS only / no ping
+- identity observed / no ping
+- AD registered
+- AD candidate only
+- offline fixture
+- unreachable or silent
+- conflicting evidence
+- manual review
+
 ## Outputs
 
 Default output folder:
@@ -121,3 +174,5 @@ Generated outputs are local and ignored. Do not commit live target lists, serial
 ## Safety boundary
 
 This preflight is read-only. It does not add credentials, mutate targets, install software, create remote tasks, or broaden scope beyond the selected approved target file.
+
+The delta planner that precedes this step must also be read-only and must perform no network activity.

--- a/docs/FIELD_NETWORK_PREFLIGHT.md
+++ b/docs/FIELD_NETWORK_PREFLIGHT.md
@@ -30,9 +30,10 @@ Do not type demo hostnames manually for live work. Do not use `C:\Temp` as the l
 2. If the source is not already a `.txt` or `.csv` with probe-ready hostnames/IPs, normalize it first.
 3. Run the delta preflight planner to compare the requested population against local evidence.
 4. Review skipped / probe / review counts from `survey/output/delta_preflight/<run_id>/`.
-5. Run the PowerShell network preflight only against `to_probe_targets.txt` from the delta plan.
-6. Review the generated CSV under `survey/output/network_preflight/`.
-7. Load the CSV into the dashboard through **Load Evidence**.
+5. Use the planner-staged target file under `survey/input/delta_preflight/<run_id>/to_probe_targets.txt`.
+6. Run the PowerShell network preflight only against that staged `to_probe_targets.txt` file.
+7. Review the generated CSV under `survey/output/network_preflight/`.
+8. Load the CSV into the dashboard through **Load Evidence**.
 
 ## Delta preflight first
 
@@ -49,17 +50,22 @@ What is stale or conflicting?
 What still deserves packets?
 ```
 
-Expected future planner output:
+Expected future planner report output:
 
 ```text
 survey/output/delta_preflight/<run_id>/delta_preflight_plan.csv
-survey/output/delta_preflight/<run_id>/to_probe_targets.txt
 survey/output/delta_preflight/<run_id>/skipped_recent_evidence.csv
 survey/output/delta_preflight/<run_id>/review_required.csv
 survey/output/delta_preflight/<run_id>/delta_summary.json
 ```
 
-Only `to_probe_targets.txt` should feed the network preflight.
+Expected future staged preflight handoff file:
+
+```text
+survey/input/delta_preflight/<run_id>/to_probe_targets.txt
+```
+
+Only the staged `survey/input/.../to_probe_targets.txt` file should feed the network preflight unless the preflight script is explicitly updated later to trust generated delta output roots.
 
 ## Spreadsheet source on X:\
 
@@ -71,7 +77,7 @@ Preferred path:
 2. Place the CSV under `targets/local/` or `logs/targets/`.
 3. Normalize if needed.
 4. Run the delta preflight planner.
-5. Run the PowerShell preflight against the planner's `to_probe_targets.txt`.
+5. Run the PowerShell preflight against the planner's staged `survey/input/delta_preflight/<run_id>/to_probe_targets.txt`.
 
 ## Select a target file
 
@@ -90,7 +96,7 @@ Run in Windows PowerShell:
 
 ```powershell
 Set-Location <SysAdminSuite repo root>
-.\survey\sas-network-preflight.ps1 -TargetFile .\survey\output\delta_preflight\<run_id>\to_probe_targets.txt -Ports 135,445,3389,9100
+.\survey\sas-network-preflight.ps1 -TargetFile .\survey\input\delta_preflight\<run_id>\to_probe_targets.txt -Ports 135,445,3389,9100
 ```
 
 Direct approved source roots are still accepted when the delta planner is not available yet:

--- a/docs/FIELD_NETWORK_PREFLIGHT.md
+++ b/docs/FIELD_NETWORK_PREFLIGHT.md
@@ -45,7 +45,7 @@ The staged text file is a runtime handoff artifact, not a replacement source of 
 
 ## Field flow
 
-1. Start from the approved spreadsheet/workbook, deployment tracker tab, AD export, or other approved source of record.
+1. Export or copy the approved spreadsheet/workbook, deployment tracker tab, AD export, or other approved source of record into an approved local intake path when required by the selected ingestion engine.
 2. Run the appropriate SysAdminSuite ingestion/normalization engine. Do not manually retype targets into `.txt` files for live work.
 3. Confirm the generated manifest, progress summary, and gap/review files under `survey/output/`.
 4. Run the delta preflight planner to compare the requested population against local evidence.

--- a/docs/FIELD_NETWORK_PREFLIGHT.md
+++ b/docs/FIELD_NETWORK_PREFLIGHT.md
@@ -24,16 +24,36 @@ CMD is only acceptable for simple Windows launcher commands, such as double-clic
 
 Do not type demo hostnames manually for live work. Do not use `C:\Temp` as the live workflow. Use approved target files from `targets/local/` or `logs/targets/` first. Use `survey/input/` only when a prior SysAdminSuite step produced normalized staging.
 
+## Spreadsheet-first doctrine
+
+The deployment spreadsheet/workbook remains the primary field artifact when it defines the Cybernet / Neuron population.
+
+The repo should not expect technicians to hand-build `.txt` files from that workbook. A SysAdminSuite ingestion/normalization step must convert the approved workbook or exported tab into the machine-readable artifacts needed by later lanes.
+
+Expected engine path:
+
+```text
+approved workbook / exported tracker tab
+  -> XLSX/CSV ingestion and normalization engine
+  -> manifest / progress / gap reports under survey/output/
+  -> probe-ready staged target file under survey/input/
+  -> delta preflight planner
+  -> network preflight only for the reduced staged target file
+```
+
+The staged text file is a runtime handoff artifact, not a replacement source of truth. If the spreadsheet and staged targets disagree, the spreadsheet-backed manifest and delta plan must explain the mismatch.
+
 ## Field flow
 
-1. Export or copy the approved spreadsheet, AD export, tracker tab, or target source to `targets/local/` or `logs/targets/`.
-2. If the source is not already a `.txt` or `.csv` with probe-ready hostnames/IPs, normalize it first.
-3. Run the delta preflight planner to compare the requested population against local evidence.
-4. Review skipped / probe / review counts from `survey/output/delta_preflight/<run_id>/`.
-5. Use the planner-staged target file under `survey/input/delta_preflight/<run_id>/to_probe_targets.txt`.
-6. Run the PowerShell network preflight only against that staged `to_probe_targets.txt` file.
-7. Review the generated CSV under `survey/output/network_preflight/`.
-8. Load the CSV into the dashboard through **Load Evidence**.
+1. Start from the approved spreadsheet/workbook, deployment tracker tab, AD export, or other approved source of record.
+2. Run the appropriate SysAdminSuite ingestion/normalization engine. Do not manually retype targets into `.txt` files for live work.
+3. Confirm the generated manifest, progress summary, and gap/review files under `survey/output/`.
+4. Run the delta preflight planner to compare the requested population against local evidence.
+5. Review skipped / probe / review counts from `survey/output/delta_preflight/<run_id>/`.
+6. Use the planner-staged target file under `survey/input/delta_preflight/<run_id>/to_probe_targets.txt`.
+7. Run the PowerShell network preflight only against that staged `to_probe_targets.txt` file.
+8. Review the generated CSV under `survey/output/network_preflight/`.
+9. Load the CSV into the dashboard through **Load Evidence**.
 
 ## Delta preflight first
 
@@ -73,10 +93,10 @@ Do not probe a spreadsheet directly from `X:\` unless an existing tested ingesti
 
 Preferred path:
 
-1. Export the approved spreadsheet or target tab to CSV.
-2. Place the CSV under `targets/local/` or `logs/targets/`.
-3. Normalize if needed.
-4. Run the delta preflight planner.
+1. Use the approved workbook or export the approved tab only if the ingestion engine requires CSV.
+2. Place the workbook/export under `targets/local/` or reference its approved local path directly if the ingester supports explicit workbook arguments.
+3. Run the workbook/CSV ingestion engine; do not manually create target text files.
+4. Run the delta preflight planner against the normalized manifest.
 5. Run the PowerShell preflight against the planner's staged `survey/input/delta_preflight/<run_id>/to_probe_targets.txt`.
 
 ## Select a target file

--- a/docs/ITERATIVE_COMMAND_DELTA_RUNS.md
+++ b/docs/ITERATIVE_COMMAND_DELTA_RUNS.md
@@ -1,0 +1,349 @@
+# Iterative Command Delta Runs
+
+## Purpose
+
+This document codifies the workflow gap where technicians run the same approved command profile repeatedly and then have to manually interpret large output files.
+
+SysAdminSuite should make repeated runs useful by comparing the current structured artifact against the last comparable artifact and producing a clear delta:
+
+```text
+what changed
+what stayed the same
+what should be skipped
+what still needs action
+```
+
+The goal is to reduce rework, repeated interpretation, and unnecessary follow-up packets.
+
+## Core principle
+
+Do not treat every run as a blank slate.
+
+```text
+same approved source
+  -> same normalized input
+  -> same command profile
+  -> new local artifact
+  -> compare to previous comparable artifact
+  -> delta report
+  -> next action handoff
+```
+
+The output should tell the operator what is different, not force them to rediscover the whole result set.
+
+## Relationship to other survey docs
+
+This doctrine supports:
+
+- `CYBERNET_XLSX_TARGET_INGESTION.md`
+- `FIELD_NETWORK_PREFLIGHT.md`
+- `DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md`
+- `SERIAL_EVIDENCE_STRENGTH_RANKING.md`
+- `go_naabu_packet_pipeline.plan.md`
+
+The spreadsheet/workbook remains the source artifact when it defines the field population. Iterative command outputs are local artifacts and handoffs, not replacements for the spreadsheet.
+
+## Non-goals
+
+This document does not define a new scanner.
+
+It must not introduce:
+
+- unbounded retry loops
+- automatic repeated live probing
+- live network commands inside comparison logic
+- target mutation
+- credential collection
+- telemetry suppression
+- committed live outputs
+- generic text diff as the authority
+
+The delta runner compares structured local artifacts. Command execution remains in the existing approved lane for that profile.
+
+## Command profile identity
+
+Each repeatable command profile needs a stable identity so SysAdminSuite can decide whether two runs are comparable.
+
+Required identity fields:
+
+```text
+CommandProfileName
+CommandProfileVersion
+InputSourceFingerprint
+InputManifestFingerprint
+EffectiveParametersFingerprint
+ToolVersion
+RunId
+PreviousComparableRunId
+ScopeSource
+GeneratedAt
+```
+
+Comparability rule:
+
+```text
+Runs are comparable only when the command profile, normalized input fingerprint, and effective parameters match, or when the profile explicitly declares a compatible comparison rule.
+```
+
+A different spreadsheet, different normalized manifest, different port profile, different evidence root, or different TTL setting may require a separate baseline.
+
+## Output roots
+
+Run comparison reports are generated local artifacts.
+
+```text
+survey/output/command_delta/<profile>/<run_id>/
+```
+
+Required files:
+
+```text
+current_normalized.csv
+previous_normalized.csv
+delta_added.csv
+delta_removed.csv
+delta_changed.csv
+delta_unchanged.csv
+delta_summary.json
+next_actions.csv
+operator_handoff.txt
+README.txt
+```
+
+Generated next-action handoff inputs go under `survey/input/` when another tool needs to consume them:
+
+```text
+survey/input/command_delta/<profile>/<run_id>/<next_handoff>.txt
+```
+
+No generated comparison output or live operational evidence should be committed.
+
+## Structured comparison, not raw diff
+
+The comparison engine must normalize artifacts before comparing them.
+
+Compare by structured keys such as:
+
+```text
+NormalizedSerial
+NormalizedHostname
+NormalizedIP
+NormalizedMAC
+EvidenceClass
+EvidenceStatus
+EvidenceTimestamp
+EvidenceSourceFile
+Decision
+```
+
+Raw text line differences are not authoritative because CSV column order, timestamps, banner text, and formatting noise can change without changing operational meaning.
+
+## Delta statuses
+
+Recommended status values:
+
+```text
+NO_CHANGE
+NEW_EVIDENCE
+LOST_EVIDENCE
+CHANGED_STATUS
+NEW_REACHABLE
+LOST_REACHABILITY
+NEW_IDENTITY_CONFIRMED
+IDENTITY_CONFLICT
+STALE_REQUIRES_RECHECK
+SKIP_REWORK
+RETRY_REQUIRED
+REVIEW_REQUIRED
+```
+
+Each changed row must include a plain-language reason.
+
+## Summary contract
+
+`delta_summary.json` should include:
+
+```text
+run_id
+previous_comparable_run_id
+command_profile_name
+command_profile_version
+input_source_fingerprint
+input_manifest_fingerprint
+effective_parameters_fingerprint
+tool_version
+current_artifact_path
+previous_artifact_path
+added_count
+removed_count
+changed_count
+unchanged_count
+review_required_count
+retry_required_count
+skip_rework_count
+next_actions_path
+operator_handoff_path
+network_activity_performed_by_comparison
+```
+
+`network_activity_performed_by_comparison` must be `false`. The comparison phase reads artifacts only.
+
+## Next-action contract
+
+`next_actions.csv` should explain what to do next, not just what changed.
+
+Recommended columns:
+
+```text
+ActionId
+ActionType
+Serial
+Hostname
+IP
+EvidenceClass
+PreviousStatus
+CurrentStatus
+DeltaStatus
+Reason
+RecommendedHandoff
+Priority
+```
+
+Recommended `ActionType` values:
+
+```text
+SKIP_NO_CHANGE
+SKIP_IDENTITY_CONFIRMED
+RETRY_STALE
+RETRY_LOST_REACHABILITY
+REVIEW_CONFLICT
+REVIEW_NEW_CANDIDATE
+HANDOFF_TO_IDENTITY
+HANDOFF_TO_DELTA_PREFLIGHT
+HANDOFF_TO_NETWORK_PREFLIGHT
+HANDOFF_TO_PACKET_PROFILE
+```
+
+## Applicable command profiles
+
+The iterative delta mechanism should support these lanes first:
+
+| Profile | Comparison purpose |
+|---|---|
+| XLSX ingestion / tracker diff | Show newly tracked, newly untracked, remaining, ambiguous, and resolved serials |
+| Delta preflight planner | Show changed decisions, newly probe-worthy rows, and skipped rework |
+| Network preflight | Show newly reachable, lost reachability, stable silence, and stale rows |
+| AD candidate pool | Show new candidate matches, disappeared candidates, and conflicts |
+| Packet pipeline | Show service-level changes without treating them as serial proof |
+| Reconciliation report | Show movement between confirmed, remaining, drift, conflict, and review buckets |
+
+## Operator handoff text
+
+`operator_handoff.txt` should be readable without opening the raw CSV first.
+
+It should include:
+
+```text
+Command profile name
+Current run id
+Previous comparable run id
+Input source summary
+Counts added / removed / changed / unchanged
+Skip-rework count
+Retry-required count
+Review-required count
+Next recommended command or dashboard step
+Paths to delta CSVs
+```
+
+It should not contain live credentials, secrets, or unnecessary raw dumps.
+
+## Rework reduction rules
+
+The comparison engine should prefer skip decisions when evidence is stable and fresh.
+
+Examples:
+
+- Stable identity-confirmed serials should not be pinged again unless forced.
+- Stable reachable targets within TTL should not be re-probed by default.
+- Stable serial-only rows should remain review-required until new bridging evidence appears.
+- Stable AD-variant-only candidates should not become probe targets without review.
+- Lost reachability should produce a delta, not erase prior identity evidence.
+
+## Implementation surfaces
+
+Preferred future files:
+
+```text
+survey/sas-command-delta-plan.ps1
+scripts/SasCommandDelta.psm1
+Tests/Pester/CommandDelta.Tests.ps1
+Tests/bash/test_iterative_command_delta_contracts.sh
+docs/ITERATIVE_COMMAND_DELTA_RUNS.md
+```
+
+The first implementation can be planner-only and artifact-only. It does not need to execute the underlying command profile itself.
+
+## Required tests
+
+Future tests must prove:
+
+1. Same profile and same input fingerprint finds the previous comparable run.
+2. Different input fingerprint does not compare as the same run.
+3. Unchanged rows are marked `NO_CHANGE`.
+4. New evidence appears in `delta_added.csv`.
+5. Removed evidence appears in `delta_removed.csv`.
+6. Status changes appear in `delta_changed.csv`.
+7. Identity-confirmed new serials produce `NEW_IDENTITY_CONFIRMED`.
+8. Lost reachability does not erase identity evidence.
+9. `next_actions.csv` contains only rows needing action or explicit skip explanation.
+10. Generated next handoff files contain only rows requiring action.
+11. The comparison phase performs no network commands.
+12. No live target, serial, MAC, IP, or generated operational artifact is committed.
+
+## Copy-ready next-agent prompt
+
+```text
+You are continuing SysAdminSuite.
+
+Top focus:
+Implement iterative command delta planning so repeated approved command profiles compare current artifacts against the previous comparable run and output the differences.
+
+Read first:
+- docs/ITERATIVE_COMMAND_DELTA_RUNS.md
+- docs/SERIAL_EVIDENCE_STRENGTH_RANKING.md
+- docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
+- docs/FIELD_NETWORK_PREFLIGHT.md
+
+Mission:
+Create a local artifact comparison planner for repeated command profiles. The planner must normalize current and previous outputs, compare structured evidence rows, and emit delta reports plus next-action handoffs.
+
+Do not create a new scanner.
+Do not run network commands in the comparison phase.
+Do not commit live generated artifacts.
+Do not treat raw text diff as authoritative.
+Do not treat reachability or packet output as serial proof.
+
+Required outputs:
+- survey/output/command_delta/<profile>/<run_id>/delta_added.csv
+- survey/output/command_delta/<profile>/<run_id>/delta_removed.csv
+- survey/output/command_delta/<profile>/<run_id>/delta_changed.csv
+- survey/output/command_delta/<profile>/<run_id>/delta_unchanged.csv
+- survey/output/command_delta/<profile>/<run_id>/delta_summary.json
+- survey/output/command_delta/<profile>/<run_id>/next_actions.csv
+- survey/output/command_delta/<profile>/<run_id>/operator_handoff.txt
+
+Required behavior:
+- identify comparable prior run by command profile and input/parameter fingerprints
+- rank evidence using the serial evidence ranking doctrine
+- explain skip/retry/review decisions
+- stage next-action handoff files under survey/input only when another tool needs them
+
+Validation:
+- Pester suite
+- bash/static contracts
+- offline survey tests if touched
+
+Merge policy:
+merge_when_green.
+```

--- a/docs/SERIAL_EVIDENCE_STRENGTH_RANKING.md
+++ b/docs/SERIAL_EVIDENCE_STRENGTH_RANKING.md
@@ -1,0 +1,231 @@
+# Serial Evidence Strength Ranking
+
+## Purpose
+
+This document codifies the next gap in the Cybernet / Neuron survey workflow: before probing, skipping, or reconciling a serial, SysAdminSuite must rank the strength of the available evidence and choose the correct handoff.
+
+The spreadsheet/workbook remains the primary field artifact when it defines the device population. Generated text, JSON, and CSV files are runtime handoffs and reports, not replacements for the workbook.
+
+## Core principle
+
+A serial can move through multiple evidence bridges:
+
+```text
+Serial
+  -> spreadsheet / tracker population evidence
+  -> hostname evidence
+  -> IP evidence
+  -> subnet/location evidence
+  -> MAC evidence
+  -> AD/DNS evidence
+  -> packet reachability evidence
+  -> approved identity evidence
+  -> reconciliation artifact
+```
+
+Those bridges are not equal. The workflow must never treat reachability as identity, AD candidate evidence as proof, or subnet inference as scan authorization.
+
+## Evidence strength ranking
+
+| Rank | Evidence path | Strength | Confirms serial identity? | Good for |
+|---:|---|---|---:|---|
+| 1 | Approved identity collection: serial observed from host via approved WMI/CIM/SCCM/MDM/vendor inventory | Strongest | Yes, when serial matches requested population | Marking a serial identity-confirmed |
+| 2 | Serial + MAC + current IP from approved inventory/DHCP/ARP/switch/exported evidence | Strong | Usually not alone | Locating a probable device and subnet, prioritizing probe |
+| 3 | Spreadsheet/workbook or deployment tracker row | Population authority | No | Defining scope, denominator, intended site/device assignment |
+| 4 | Exact AD computer registration plus DNS hostname/IP | Medium-high | No | Registration/routing evidence, target candidate generation |
+| 5 | AD computer candidate from naming-convention variant | Medium / review | No | Finding possible typo/naming candidates |
+| 6 | DNS A/reverse lookup or prior hostname-to-IP association | Medium | No | IP/subnet bridge, routing clue |
+| 7 | Ping/TCP reachable from network preflight | Medium-low | No | Alive/reachable signal only |
+| 8 | Packet pipeline open-port evidence | Medium-low | No | Service reachability hint only |
+| 9 | Silent/no response/no open profile ports | Weak negative | No | Retry/review/cooldown decision, not absence proof |
+| 10 | Offline fixture/test evidence | Test-only | No | CI and parser validation only |
+
+## Decision rules
+
+1. **Identity proof outranks reachability.** If a serial was recently identity-confirmed by an approved source, do not ping it again unless the operator forces reprobe.
+2. **Spreadsheet population outranks ad hoc target files.** If generated targets disagree with the workbook-backed manifest, the manifest and delta plan must explain the mismatch.
+3. **IP/subnet evidence is a bridge, not proof.** `Serial -> IP -> subnet` is a valid operational path, but it requires an evidence bridge from serial to IP.
+4. **Reachability is not identity.** Ping, TCP, Naabu, and similar packet evidence can show that something responded at a network location; they cannot prove which serial responded.
+5. **AD candidate evidence is review evidence.** A naming-convention variant can justify exact AD lookup or review, not automatic serial confirmation.
+6. **Silence is not absence.** ICMP or TCP silence may be firewall, power, VLAN, routing, or policy. Preserve other evidence paths.
+7. **Subnet inference narrows review.** It does not authorize broader scanning by itself.
+
+## Canonical serial-to-artifact handoffs
+
+### 1. Workbook population handoff
+
+```text
+approved workbook / tracker tab
+  -> ingestion / normalization engine
+  -> survey/output/cybernet_*.csv and summary artifacts
+  -> survey/input/<lane>/<run_id>/staged targets when needed
+```
+
+Use when the spreadsheet defines the serial population.
+
+Required artifacts:
+
+```text
+survey/output/cybernet_alejandro_unique_serials.csv
+survey/output/cybernet_tracker_unique_serials.csv
+survey/output/cybernet_alejandro_untracked.csv
+survey/output/cybernet_progress_summary.json
+survey/output/cybernet_progress_summary.csv
+```
+
+### 2. Serial to IP/subnet handoff
+
+```text
+Serial
+  -> approved bridge to IP or MAC/IP evidence
+  -> subnet/location inference
+  -> staged probe target only if probe-worthy
+  -> reachability artifact
+```
+
+Valid bridge sources include approved identity CSVs, tracker enrichment, AD/DNS exports, DHCP/ARP/switch exports, or prior local evidence. A serial-only row cannot be converted to IP without one of these bridges.
+
+Required outputs:
+
+```text
+survey/output/delta_preflight/<run_id>/delta_preflight_plan.csv
+survey/input/delta_preflight/<run_id>/to_probe_targets.txt
+survey/output/network_preflight/network_preflight_<timestamp>.csv
+```
+
+### 3. Serial to hostname/DNS/IP handoff
+
+```text
+Serial
+  -> exactly one validated hostname
+  -> DNS/IP
+  -> subnet
+  -> reachability check if evidence is stale or missing
+```
+
+Use when the workbook/tracker/AD evidence provides a single validated hostname. Multiple hostnames remain review-required.
+
+### 4. Serial to AD candidate handoff
+
+```text
+Serial + expected hostname/site
+  -> AD computer candidate pool
+  -> exact AD lookup only
+  -> candidate/review artifact
+```
+
+Candidate-pool evidence does not confirm the serial.
+
+Required output:
+
+```text
+survey/output/ad_candidate_pool/<run_id>/ad_computer_candidates.csv
+```
+
+### 5. Serial to packet-pipeline handoff
+
+```text
+Serial-backed reduced target set
+  -> survey/input/delta_preflight/<run_id>/to_probe_targets.txt
+  -> approved packet profile
+  -> survey/output/packet_pipeline/<run_id>/packet artifacts
+```
+
+Packet evidence is reachability/service evidence only.
+
+## Delta planner scoring model
+
+The delta planner should compute an evidence strength tier for every requested serial row.
+
+Recommended tiers:
+
+```text
+IDENTITY_CONFIRMED
+PROBABLE_DEVICE_LOCATION
+POPULATION_ONLY
+REGISTERED_AD_TARGET
+AD_VARIANT_REVIEW
+DNS_OR_SUBNET_ONLY
+REACHABILITY_ONLY
+PACKET_SERVICE_ONLY
+NEGATIVE_OR_SILENT
+TEST_ONLY
+```
+
+Required `delta_preflight_plan.csv` additions:
+
+```text
+EvidenceStrengthTier
+StrongestEvidencePath
+SerialIdentityConfirmed
+ProbeWorthiness
+PreferredNextHandoff
+```
+
+Recommended `ProbeWorthiness` values:
+
+```text
+skip_identity_confirmed
+skip_recent_reachability
+probe_stale_or_missing
+review_required
+blocked_no_probe_ready_target
+operator_forced
+```
+
+Recommended `PreferredNextHandoff` values:
+
+```text
+identity_reconciliation
+delta_network_preflight
+ad_candidate_review
+subnet_location_review
+packet_pipeline_profile
+spreadsheet_gap_review
+```
+
+## Minimal next-gap implementation contract
+
+The next implementation sprint should not start by adding another network probe.
+
+It should first add evidence ranking to the delta planner:
+
+1. Load workbook-backed manifest rows.
+2. Load local evidence artifacts.
+3. Attach all evidence paths by serial, hostname, MAC, IP, and AD candidate.
+4. Rank the strongest evidence per serial.
+5. Decide whether the serial is confirmed, skipped, probe-worthy, or review-required.
+6. Emit staged target files only for probe-worthy rows.
+7. Preserve reason strings for every skip/review/probe decision.
+
+## Copy-ready handoff snippet
+
+```text
+Top focus: implement evidence strength ranking before adding more probing.
+
+The spreadsheet/workbook remains the primary artifact for serial population. Runtime text files are generated handoffs only.
+
+For every serial row, compute:
+- EvidenceStrengthTier
+- StrongestEvidencePath
+- SerialIdentityConfirmed
+- ProbeWorthiness
+- PreferredNextHandoff
+
+Ranking order:
+1. approved identity collection matching serial
+2. serial + MAC + current IP from approved exported evidence
+3. workbook/tracker population row
+4. exact AD registration plus DNS/IP
+5. AD candidate-pool naming variant
+6. DNS/IP/subnet association
+7. ping/TCP reachability
+8. packet-pipeline open-port evidence
+9. silent/no-response evidence
+10. offline fixture/test evidence
+
+Do not treat ping, TCP, Naabu, DNS, AD candidate, or subnet inference as serial proof.
+Do not hand-build live target text files from the spreadsheet.
+Use ingestion engines to convert the workbook/export into manifests, reports, and staged target files.
+Probe only rows whose evidence ranking says probing is still worthwhile.
+```

--- a/docs/go_naabu_packet_pipeline.plan.md
+++ b/docs/go_naabu_packet_pipeline.plan.md
@@ -1,0 +1,312 @@
+# Go / Naabu Packet Pipeline Plan
+
+## Purpose
+
+Define a low-noise, low-waste packet pipeline for Cybernet survey work after the delta planner has reduced the target set.
+
+This is not the first step in the workflow. The packet pipeline runs only after SysAdminSuite has already answered:
+
+```text
+What do we already know locally?
+What targets still need packets?
+What evidence is stale, conflicting, or missing?
+```
+
+The packet pipeline exists to spend packets deliberately, not to rediscover the whole network.
+
+## Workflow position
+
+```text
+approved serial / target source
+  -> delta preflight planner
+  -> staged reduced targets under survey/input/
+  -> packet pipeline, only when packet evidence is still justified
+  -> local survey/output artifacts
+  -> reconciliation / dashboard evidence load
+```
+
+Naabu is one execution lane after delta planning. It is not a replacement for serial identity proof, AD registration evidence, DNS evidence, subnet/location inference, or approved identity transport.
+
+## Safety and posture
+
+Allowed:
+
+- read-only reachability validation against approved reduced targets
+- local-only output under ignored `survey/output/` or `logs/nmap/`
+- explicit operator scope control
+- quiet local CLI output where useful for pipeline parsing
+- no target-side file writes or target mutation
+
+Forbidden:
+
+- broad scanning outside the approved reduced target set
+- using packet output as serial identity proof
+- treating subnet inference as scan authorization
+- collecting credentials
+- creating remote tasks
+- installing software
+- suppressing telemetry or attempting to hide activity
+- committing live hostnames, IPs, serials, MACs, or scan output
+
+Normal network, endpoint, firewall, and infrastructure monitoring may record authorized traffic. That is expected. Silent local output is for parseable pipeline data, not evasion.
+
+## Runtime note
+
+Naabu is a packet-survey toolchain lane. It may require Linux, WSL, or another approved admin runtime. It is not the default Windows PowerShell field preflight path.
+
+PowerShell remains the Northwell field workflow for `survey/sas-network-preflight.ps1`.
+
+## Input and output roots
+
+Input target files must come from approved/codified roots:
+
+```text
+targets/local/
+logs/targets/
+survey/input/   # normalized or generated staging only
+```
+
+The delta planner should stage the runnable reduced target list here:
+
+```text
+survey/input/delta_preflight/<run_id>/to_probe_targets.txt
+```
+
+Generated packet-pipeline outputs go here:
+
+```text
+survey/output/packet_pipeline/<run_id>/
+logs/nmap/
+survey/artifacts/
+```
+
+Recommended packet-pipeline outputs:
+
+```text
+naabu_open_ports.txt
+naabu_results.json
+cybernet_enrichment.json
+packet_pipeline_summary.json
+pipeline_stderr.txt
+README.txt
+```
+
+## Output format doctrine
+
+Use JSON for durable machine artifacts.
+
+Use raw text only when piping because simple target/port lines are easier to pass to the next local enrichment step.
+
+The production enrichment adapter should be named around Cybernet survey intent, such as `cybernet-detect`. If a generic HTTP enrichment tool is used during experimentation, treat it as a placeholder and keep production docs centered on Cybernet enrichment.
+
+## Flag vocabulary to verify before implementation
+
+The implementation sprint must verify the installed Naabu version and exact flag support before emitting field commands.
+
+User-supplied principles to preserve if supported by the installed tool:
+
+| Concept | Candidate flag / behavior | Use |
+|---|---|---|
+| Silent local output | `silent` mode | Parseable local pipeline output, not evasion |
+| JSON output | `json` output mode | Durable local artifacts |
+| CDN/cloud exclusion | `exclude CDN` style behavior | Avoid wasting packets on shared/cloud front doors where appropriate |
+| Scan all resolved IPs | scan-all-IPs behavior | Opt-in for approved hostnames/domains only |
+| Exhaustive ports | all-ports behavior | Explicitly gated, not default |
+| UDP probing | UDP profile behavior | Opt-in only when it answers a Cybernet survey question |
+| Host discovery signal | SYN-style host/alive signal | Reachability hint only, not identity proof |
+
+Do not assume flag names are stable. Contract tests should check profile intent, not hard-code unverified external CLI behavior without a version check.
+
+## CDN / cloud / firewall fronting
+
+Some IPs or hostnames may point to cloud firewalls, CDN edges, load balancers, or shared front doors. Probing those broadly wastes time and can produce misleading results.
+
+Rules:
+
+- CDN/cloud exclusion should be default for external/cloud-looking targets when supported.
+- Front-door results are not proof that a Cybernet device is alive.
+- Do not broaden scope just because a domain resolves to multiple public IPs.
+- If a target appears CDN/cloud-fronted, classify it as review-required or route it to the correct internal evidence path.
+
+## Scan-all-IPs behavior
+
+Domains and load-balanced names can resolve to multiple IPs.
+
+Rules:
+
+- Scan-all-IPs behavior is opt-in, not default.
+- Only use it for approved hostnames/domains.
+- Combine with CDN/cloud exclusion when appropriate.
+- Do not apply it to arbitrary public domains.
+- Record the operator reason in `packet_pipeline_summary.json`.
+
+## Port profile doctrine
+
+Default profiles should be narrow and tied to the survey question.
+
+Suggested profiles:
+
+```text
+web_signal: 80,443
+windows_identity_candidate: 135,445,3389
+cybernet_device_candidate: 9100 plus project-approved Cybernet ports
+```
+
+### Exhaustive ports are gated
+
+All-ports behavior is not the low-waste default.
+
+Use it only behind an explicit profile such as:
+
+```text
+profile = approved_exhaustive_ports
+reason = operator-approved exception
+scope = reduced target list only
+```
+
+If used, record the reason in `packet_pipeline_summary.json`.
+
+## Host discovery / alive signal
+
+When the goal is a quick IP-host alive signal rather than a port inventory, use a minimal approved alive-signal profile where supported.
+
+Interpretation:
+
+- This is reachability evidence only.
+- It is not Cybernet identity proof.
+- It can help decide whether a target deserves deeper approved identity transport.
+
+## UDP profile
+
+UDP is not default. Include UDP only when it answers a Cybernet survey question.
+
+Examples where UDP may be useful:
+
+```text
+DNS evidence, when scoped and relevant
+SNMP evidence, only if approved and expected in the environment
+```
+
+Rules:
+
+- UDP requires explicit profile selection.
+- Record why UDP was used.
+- Do not treat UDP silence as proof a device is absent.
+
+## Pipeline composition
+
+Prefer single-purpose local pipeline steps:
+
+```text
+reduced target file
+  -> packet reachability tool with quiet parseable output
+  -> Cybernet enrichment adapter
+  -> local JSON/CSV artifact
+```
+
+The pipeline should avoid banners and human-format noise because the next local tool needs parseable input.
+
+This is local output hygiene. It is not log suppression, target stealth, or monitoring bypass.
+
+## Summary JSON
+
+`packet_pipeline_summary.json` should include:
+
+```text
+run_id
+generated_at
+input_target_file
+target_count
+profile_name
+ports_requested
+udp_enabled
+cdn_exclusion_enabled
+scan_all_ips_enabled
+silent_mode_enabled
+json_output_path
+text_output_path
+pipeline_output_path
+operator_reason
+network_activity_performed
+scope_source
+```
+
+`network_activity_performed` is `true` for this packet lane because packets are intentionally sent. That distinguishes it from the delta planner, where `network_activity_performed` must remain `false`.
+
+## Required profile names
+
+Recommended profile names:
+
+```text
+alive_web_signal
+windows_identity_candidate
+cybernet_candidate_ports
+udp_dns_snmp_review
+approved_exhaustive_ports
+domain_all_ips_review
+```
+
+## Future implementation surfaces
+
+Preferred implementation files:
+
+```text
+Config/cybernet-naabu-profiles.json
+survey/sas-naabu-packet-pipeline.sh
+survey/sas-naabu-packet-plan.ps1
+Tests/bash/test_go_naabu_packet_pipeline_contracts.sh
+docs/go_naabu_packet_pipeline.plan.md
+```
+
+The PowerShell plan wrapper may generate command lines and validate scope. The packet execution wrapper may remain Bash/WSL/Linux only if Naabu requires it, but Northwell field docs must clearly distinguish that from the PowerShell network preflight lane.
+
+## Required tests
+
+Tests must prove:
+
+1. Packet execution uses only reduced staged target files under `survey/input/`.
+2. Generated outputs stay under `survey/output/packet_pipeline/` or approved ignored output roots.
+3. Silent local output is enabled in generated packet commands.
+4. JSON output is supported for durable artifacts.
+5. Raw text output is allowed only for local pipeline chaining.
+6. CDN/cloud exclusion is enabled for relevant profiles where supported.
+7. All-ports behavior is rejected unless `approved_exhaustive_ports` is explicitly selected.
+8. UDP profiles are opt-in and reasoned.
+9. Scan-all-IPs behavior is opt-in and allowed only for approved hostname/domain scope.
+10. Packet output is never treated as serial identity proof.
+11. No live target, serial, MAC, or packet output fixture is committed.
+
+## Copy-ready next-agent prompt
+
+```text
+You are continuing SysAdminSuite.
+
+Implement the Go / Naabu packet pipeline plan from:
+- docs/go_naabu_packet_pipeline.plan.md
+- docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md
+- docs/FIELD_NETWORK_PREFLIGHT.md
+
+Mission:
+Create a low-noise, low-waste packet pipeline that runs only after the delta preflight planner emits a reduced target file under survey/input/delta_preflight/<run_id>/to_probe_targets.txt.
+
+Rules:
+- Do not scan outside approved reduced target files.
+- Do not treat packet reachability as serial proof.
+- Keep packet tool output quiet for parseable local output.
+- Prefer JSON for durable artifacts.
+- Use raw text only for local pipeline chaining.
+- Use CDN/cloud exclusion where supported and relevant.
+- Gate exhaustive all-ports behavior behind explicit operator approval.
+- Gate UDP profiles behind explicit profile selection and reason.
+- Gate scan-all-IPs behavior behind explicit approved hostname/domain scope.
+- Keep outputs local and ignored.
+- Do not add credentials, target mutation, remote tasks, or telemetry suppression.
+
+Validation:
+- bash/static contracts
+- offline survey tests
+- Pester only for PowerShell command planning, if applicable
+
+Merge policy:
+merge_when_green.
+```


### PR DESCRIPTION
## Summary

Adds a documentation sprint contract for the delta preflight / local evidence-cache lane.

This augments the network-preflight doctrine with Replit-harvest product insights:

- Replit/quarantine is reference material, not a direct merge source
- promote reviewed logic in small clean slices
- offline/test mode before live probing
- PowerShell remains active Windows field tooling
- Replit/Linux runtime mismatch is not product failure
- ping failure must not erase DNS/AD/identity evidence
- preserve separate evidence paths instead of flattening everything into reachable/unreachable

## Files

- `docs/DELTA_PREFLIGHT_EVIDENCE_CACHE_SPRINT.md`
- `docs/FIELD_NETWORK_PREFLIGHT.md`

## Safety

Docs only. No live target files, serial lists, AD exports, credentials, or generated evidence committed.

## Validation expectation

Docs-only PR. Existing workflows may run depending on path triggers.