### PR TITLE
feat(survey): encode serial protocol decision fields

### DIFF
--- a/Tests/survey/test_serial_network_preflight_contracts.py
+++ b/Tests/survey/test_serial_network_preflight_contracts.py
@@ -116,6 +116,35 @@ def test_serial_artifact_manifest_links_inputs_to_outputs():
         assert fragment in text, f"serial artifact provenance fragment missing: {fragment}"
 
 
+def test_serial_protocol_decision_fields_are_explicit():
+    text = read(SCRIPT)
+    required = [
+        "$protocolLayer = 'fallback_review'",
+        "$protocolDecision = 'no_network_probe'",
+        "$protocolReason = 'no_probe_ready_targets'",
+        "$primaryProtocolApplied = $false",
+        "$fallbackProtocolApplied = $true",
+        "$tertiaryManifestWritten = $true",
+        "$protocolLayer = 'primary_probe'",
+        "$protocolDecision = 'delegated_network_preflight'",
+        "$protocolReason = 'probe_ready_targets_present'",
+        "$protocolLayer = 'dry_run_plan'",
+        "$protocolReason = 'plan_only_requested_with_probe_ready_targets'",
+        "protocol_decision_record = $protocolDecisionRecord",
+        "protocol_layer = $protocolLayer",
+        "protocol_decision = $protocolDecision",
+        "protocol_reason = $protocolReason",
+        "primary_protocol_applied = $primaryProtocolApplied",
+        "fallback_protocol_applied = $fallbackProtocolApplied",
+        "tertiary_manifest_written = $tertiaryManifestWritten",
+        "Protocol layer:",
+        "Protocol decision:",
+        "Protocol reason:",
+    ]
+    for fragment in required:
+        assert fragment in text, f"serial protocol decision fragment missing: {fragment}"
+
+
 def test_serial_network_preflight_delegates_network_activity_to_existing_preflight():
     text = read(SCRIPT)
     assert "sas-network-preflight.ps1" in text
@@ -165,6 +194,7 @@ if __name__ == "__main__":
     test_serial_network_preflight_preserves_candidate_source_traceability()
     test_serial_network_preflight_groups_duplicate_serial_candidates()
     test_serial_artifact_manifest_links_inputs_to_outputs()
+    test_serial_protocol_decision_fields_are_explicit()
     test_serial_network_preflight_delegates_network_activity_to_existing_preflight()
     test_serial_network_preflight_has_no_ad_or_target_mutation()
     test_offline_runner_wires_serial_network_preflight_contract()

--- a/survey/sas-network-preflight-by-serial.ps1
+++ b/survey/sas-network-preflight-by-serial.ps1
@@ -436,6 +436,36 @@ if ($toProbe.Count -eq 0) {
   & $networkPreflightScript -TargetFile $toProbePath -Ports $Ports -OutputDirectory $networkOutputDirectory
 }
 
+$protocolLayer = 'fallback_review'
+$protocolDecision = 'no_network_probe'
+$protocolReason = 'no_probe_ready_targets'
+$primaryProtocolApplied = $false
+$fallbackProtocolApplied = $true
+
+if ($networkActivityPerformed) {
+  $protocolLayer = 'primary_probe'
+  $protocolDecision = 'delegated_network_preflight'
+  $protocolReason = 'probe_ready_targets_present'
+  $primaryProtocolApplied = $true
+  $fallbackProtocolApplied = $false
+} elseif ($PlanOnly -and $toProbe.Count -gt 0) {
+  $protocolLayer = 'dry_run_plan'
+  $protocolDecision = 'no_network_probe'
+  $protocolReason = 'plan_only_requested_with_probe_ready_targets'
+  $primaryProtocolApplied = $false
+  $fallbackProtocolApplied = $false
+}
+
+$tertiaryManifestWritten = $true
+$protocolDecisionRecord = [ordered]@{
+  protocol_layer = $protocolLayer
+  protocol_decision = $protocolDecision
+  protocol_reason = $protocolReason
+  primary_protocol_applied = $primaryProtocolApplied
+  fallback_protocol_applied = $fallbackProtocolApplied
+  tertiary_manifest_written = $tertiaryManifestWritten
+}
+
 $summary = [ordered]@{
   run_id = $runId
   generated_at = (Get-Date).ToUniversalTime().ToString('o')
@@ -452,6 +482,12 @@ $summary = [ordered]@{
   ports = $Ports
   plan_only = [bool]$PlanOnly
   network_activity_performed = $networkActivityPerformed
+  protocol_layer = $protocolLayer
+  protocol_decision = $protocolDecision
+  protocol_reason = $protocolReason
+  primary_protocol_applied = $primaryProtocolApplied
+  fallback_protocol_applied = $fallbackProtocolApplied
+  tertiary_manifest_written = $tertiaryManifestWritten
   doctrine = 'serials_resolve_to_exactly_one_hostname_or_ip_before_network_preflight'
 }
 $summary | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
@@ -466,6 +502,7 @@ $generatedArtifacts = @(
 $artifactManifest = [ordered]@{
   protocol_version = 'serial-artifact-provenance/v1'
   artifact_chain_invariant = 'serial_input_hashes_plus_enrichment_hashes_produce_staged_probe_targets_or_review_required_rows_before_any_network_preflight_artifact'
+  protocol_decision_record = $protocolDecisionRecord
   run_id = $runId
   generated_at = (Get-Date).ToUniversalTime().ToString('o')
   repo_root = $repoRoot
@@ -483,6 +520,12 @@ $artifactManifest = [ordered]@{
     plan_only = [bool]$PlanOnly
     ports = $Ports
     network_activity_performed = $networkActivityPerformed
+    protocol_layer = $protocolLayer
+    protocol_decision = $protocolDecision
+    protocol_reason = $protocolReason
+    primary_protocol_applied = $primaryProtocolApplied
+    fallback_protocol_applied = $fallbackProtocolApplied
+    tertiary_manifest_written = $tertiaryManifestWritten
     delegated_network_preflight_script = Join-Path $PSScriptRoot 'sas-network-preflight.ps1'
   }
   safety = [ordered]@{
@@ -494,5 +537,8 @@ $artifactManifest = [ordered]@{
 }
 $artifactManifest | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $artifactManifestPath -Encoding UTF8
 
+Write-Host ("- Protocol layer: {0}" -f $protocolLayer)
+Write-Host ("- Protocol decision: {0}" -f $protocolDecision)
+Write-Host ("- Protocol reason: {0}" -f $protocolReason)
 Write-Host ("- Summary JSON: {0}" -f $summaryPath)
 Write-Host ("- Artifact manifest: {0}" -f $artifactManifestPath)


### PR DESCRIPTION
## Summary

Encodes the active serial preflight protocol branch directly into the run outputs instead of leaving it to inference from `network_activity_performed`.

Adds these fields to `serial_network_preflight_summary.json` and `artifact_manifest.json`:

- `protocol_layer`
- `protocol_decision`
- `protocol_reason`
- `primary_protocol_applied`
- `fallback_protocol_applied`
- `tertiary_manifest_written`

Also adds a `protocol_decision_record` object in the artifact manifest.

## Branches encoded

- `primary_probe`: probe-ready targets exist and the wrapper delegated to `sas-network-preflight.ps1`
- `fallback_review`: no probe-ready targets exist, so review artifacts are the active path
- `dry_run_plan`: probe-ready targets exist, but `-PlanOnly` was requested

## Safety

- No live serial lists, hostnames, MACs, AD exports, credentials, or generated network artifacts are committed.
- Does not change target selection or probing behavior.
- Still delegates network activity to existing read-only network preflight only.

## Validation

Updates the static serial network preflight contract to require explicit protocol decision fields and runtime printouts.