### PR TITLE
docs(survey): codify low-noise probe principles

### DIFF
--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -5,6 +5,7 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 preflight="$repo_root/survey/sas-network-preflight.ps1"
 serial_plan="$repo_root/survey/sas-serial-preflight-plan.ps1"
 runbook="$repo_root/docs/FIELD_NETWORK_PREFLIGHT.md"
+low_noise_doc="$repo_root/docs/LOW_NOISE_PROBE_PRINCIPLES.md"
 start_here="$repo_root/START-HERE-CYBERNET-NEURON-SURVEY.md"
 dashboard_patch="$repo_root/dashboard/js/cybernet-os-preflight.js"
 ps_module="$repo_root/scripts/SasTargetIntake.psm1"
@@ -17,7 +18,7 @@ contains(){ grep -Fq -- "$1" "$2" || fail "$3"; }
 not_contains(){ if grep -Fq -- "$1" "$2"; then fail "$3"; fi; }
 not_matches(){ if grep -Eq -- "$1" "$2"; then fail "$3"; fi; }
 
-for f in "$preflight" "$serial_plan" "$runbook" "$start_here" "$dashboard_patch" "$ps_module" "$dispatch" "$bash_helper"; do
+for f in "$preflight" "$serial_plan" "$runbook" "$low_noise_doc" "$start_here" "$dashboard_patch" "$ps_module" "$dispatch" "$bash_helper"; do
   [[ -f "$f" ]] || fail "missing file: $f"
 done
 
@@ -101,6 +102,13 @@ contains 'REVIEW_REQUIRED_NO_PROBE_READY_EVIDENCE' "$serial_plan" 'serial planne
 contains 'do not ping the serial string' "$serial_plan" 'serial planner must not ping serial strings'
 contains 'network_activity_performed = $false' "$serial_plan" 'serial planner must report no network activity'
 contains 'to_probe_targets.txt' "$serial_plan" 'serial planner must stage target file'
+contains 'low_noise_principle' "$serial_plan" 'serial planner summary missing low-noise principle'
+contains 'network_visibility_note' "$serial_plan" 'serial planner summary missing network visibility note'
+contains 'probe_selection_questions' "$serial_plan" 'serial planner summary missing probe selection questions'
+contains 'probe_again_guidance' "$serial_plan" 'serial planner summary missing probe-again guidance'
+contains 'LowNoiseDisposition' "$serial_plan" 'serial planner plan rows missing low-noise disposition'
+contains 'The network sees packets, not the shell' "$serial_plan" 'serial planner must explain shell choice is not network visibility control'
+contains 'If a device was recently reachable' "$serial_plan" 'serial planner must discourage habitual repeat probes'
 contains 'SerialPreflightPlan' "$dispatch" 'dispatcher missing SerialPreflightPlan mode'
 contains 'sas-serial-preflight-plan.ps1' "$dispatch" 'dispatcher missing serial planner entrypoint'
 
@@ -115,9 +123,24 @@ contains 'Export or copy the approved spreadsheet' "$runbook" 'runbook missing s
 contains 'Alejandro serial list flow' "$runbook" 'runbook missing Alejandro serial flow'
 contains 'approved serial-to-host/IP evidence' "$runbook" 'runbook missing serial evidence bridge rule'
 contains 'Serial-only rows go to review, not packets' "$runbook" 'runbook must route serial-only rows to review'
+contains 'Low-noise probe posture' "$runbook" 'runbook missing low-noise probe posture section'
+contains 'The network sees packets, not the shell' "$runbook" 'runbook missing network visibility principle'
+contains 'Which exact ports answer the survey question?' "$runbook" 'runbook missing low-noise probe selection questions'
+contains 'Five probes are unnecessary' "$runbook" 'runbook missing pragmatic repeat-probe guidance'
 contains 'Run the PowerShell network preflight' "$runbook" 'runbook missing PowerShell preflight step'
 contains 'Review the generated CSV under `survey/output/network_preflight/`' "$runbook" 'runbook missing output review step'
 contains '.\survey\sas-network-preflight.ps1' "$dashboard_patch" 'dashboard patch missing PowerShell preflight entrypoint'
 contains 'survey\output\network_preflight' "$dashboard_patch" 'dashboard patch missing generated output folder'
+
+contains '# Low-Noise Probe Principles' "$low_noise_doc" 'low-noise doctrine missing title'
+contains 'The network sees packets, not the operator' "$low_noise_doc" 'low-noise doctrine missing shell distinction'
+contains 'smaller scope' "$low_noise_doc" 'low-noise doctrine missing scope principle'
+contains 'fewer ports' "$low_noise_doc" 'low-noise doctrine missing port principle'
+contains 'lower rate' "$low_noise_doc" 'low-noise doctrine missing rate principle'
+contains 'fewer retries' "$low_noise_doc" 'low-noise doctrine missing retry principle'
+contains 'Is this a CDN/WAF/load-balanced/front-door target?' "$low_noise_doc" 'low-noise doctrine missing front-door question'
+contains 'five probes are unnecessary' "$low_noise_doc" 'low-noise doctrine missing pragmatic retry guidance'
+contains 'low_noise_principle' "$low_noise_doc" 'low-noise doctrine missing artifact context fields'
+contains 'Do not use stealth, bypass, or no-trace language.' "$low_noise_doc" 'low-noise doctrine must reject evasion language'
 
 echo 'PASS: PowerShell network preflight contracts'

--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -139,7 +139,7 @@ contains 'fewer ports' "$low_noise_doc" 'low-noise doctrine missing port princip
 contains 'lower rate' "$low_noise_doc" 'low-noise doctrine missing rate principle'
 contains 'fewer retries' "$low_noise_doc" 'low-noise doctrine missing retry principle'
 contains 'Is this a CDN/WAF/load-balanced/front-door target?' "$low_noise_doc" 'low-noise doctrine missing front-door question'
-contains 'five probes are unnecessary' "$low_noise_doc" 'low-noise doctrine missing pragmatic retry guidance'
+contains 'Five probes are unnecessary' "$low_noise_doc" 'low-noise doctrine missing pragmatic retry guidance'
 contains 'low_noise_principle' "$low_noise_doc" 'low-noise doctrine missing artifact context fields'
 contains 'Do not use stealth, bypass, or no-trace language.' "$low_noise_doc" 'low-noise doctrine must reject evasion language'
 

--- a/docs/FIELD_NETWORK_PREFLIGHT.md
+++ b/docs/FIELD_NETWORK_PREFLIGHT.md
@@ -94,6 +94,41 @@ Rules:
 - Serial-only rows go to review, not packets.
 - The planner performs no network activity. It only stages a reduced target file.
 
+## Low-noise probe posture
+
+See [`LOW_NOISE_PROBE_PRINCIPLES.md`](LOW_NOISE_PROBE_PRINCIPLES.md) for the full doctrine.
+
+The network sees packets, not the shell. Running a packet tool from CMD rather than PowerShell does not materially reduce network visibility when the same targets, ports, packet types, rates, and retries are used.
+
+Before any probe is staged or run, the workflow should answer:
+
+```text
+Should this target be probed at all?
+Which exact host/IP should be probed?
+Which exact ports answer the survey question?
+At what rate?
+How many retries?
+Is this already fresh in local evidence?
+Is this a CDN/WAF/load-balanced/front-door target?
+Is this a mystery serial that needs review, not packets?
+```
+
+Low-noise work comes from:
+
+```text
+smaller scope
+fewer ports
+lower rate
+fewer retries
+smarter evidence reuse
+avoiding broad scans
+avoiding immediate repeat probes when a better time/day would be more informative
+```
+
+A fixed retry count is not the goal. Five probes are unnecessary when a device is already recently reachable or identity-confirmed. If a retry is justified, prefer a different time of day and/or different day of week over immediate repetition.
+
+The serial preflight planner must carry this context into its artifacts so the operator can see why packets were or were not justified.
+
 ## Dashboard controls gap
 
 The runbook and backend now support serial-first planning, but the dashboard controls must also expose that path.

--- a/docs/LOW_NOISE_PROBE_PRINCIPLES.md
+++ b/docs/LOW_NOISE_PROBE_PRINCIPLES.md
@@ -1,0 +1,246 @@
+# Low-Noise Probe Principles
+
+## Purpose
+
+This document codifies low-noise principles for SysAdminSuite survey work.
+
+The goal is not to hide authorized activity. The goal is to reduce unnecessary packets, avoid repeated work, and make every probe explainable from the request through the action and resulting artifacts.
+
+## Core principle
+
+The network sees packets, not the operator's shell.
+
+If a tool sends the same SYN, CONNECT, ICMP, or UDP probes to the same targets and ports at the same rate, the network-facing visibility is materially the same whether the process was launched from:
+
+```text
+CMD
+Windows PowerShell
+Windows Terminal
+Git Bash
+WSL
+```
+
+Shell choice can change local endpoint/process history, parent process, and operator workflow. It does not make the same packets lower-noise on the network.
+
+## What actually lowers network noise
+
+Low-noise comes from the survey design:
+
+```text
+smaller scope
+fewer ports
+lower rate
+fewer retries
+smarter evidence reuse
+avoiding broad scans
+avoiding targets that do not deserve packets yet
+```
+
+Before staging or running any probe, SysAdminSuite should answer:
+
+```text
+Should this target be probed at all?
+Which exact host/IP should be probed?
+Which exact ports answer the survey question?
+At what rate?
+How many retries?
+Is this already fresh in local evidence?
+Is this a CDN/WAF/load-balanced/front-door target?
+Is this a mystery serial that needs review, not packets?
+```
+
+## Request-to-artifact path
+
+Every probe-worthy action should be explainable as a chain:
+
+```text
+request
+  -> source artifact
+  -> local evidence review
+  -> target selection reason
+  -> low-noise profile
+  -> action handoff
+  -> timestamped output artifact
+  -> delta/review classification
+```
+
+If a row cannot explain that chain, it should not silently become a network target.
+
+## Serial-first implication
+
+Serials remain the anchor for Cybernet work.
+
+A serial-only row is not low priority. It is a mystery row that answers the operational question:
+
+```text
+Where did this serial go?
+```
+
+But a serial string is not a network endpoint. Do not ping it. Do not pass it to packet tools. Route it to review until an approved bridge exists.
+
+Valid bridges include:
+
+```text
+approved workstation identity evidence
+approved tracker/export enrichment
+approved hostname evidence
+approved IP evidence
+approved MAC/IP evidence
+approved DNS/AD/export evidence
+prior local probe artifact with a valid host/IP target
+```
+
+## Probe-again pragmatism
+
+A fixed number of repeat probes is not inherently meaningful.
+
+Five probes are unnecessary when a device is already recently reachable or identity-confirmed. Re-probing a fresh success may be safe, but it is usually lower value than preserving the success and waiting for a meaningful reason or a better time window.
+
+Prefer:
+
+```text
+probe at a different time of day
+probe on a different day of week
+probe only when evidence is stale, missing, conflicting, or operator-forced
+```
+
+Avoid:
+
+```text
+five retries in the same narrow time window
+re-probing already fresh reachable rows by default
+all-port profiles as the default
+UDP by default
+scan-all-IPs by default
+```
+
+## Attempt diversity
+
+Repeated non-response is more meaningful when it is time-diverse.
+
+Recommended dimensions:
+
+```text
+morning / midday / afternoon / evening / overnight
+weekday / weekend
+same day / different dates
+same network path / different approved vantage if applicable
+```
+
+A row should not become `PERSISTENTLY_SILENT_TIME_DIVERSE` merely because the same command retried several times in one narrow window.
+
+## Fresh evidence handling
+
+Fresh useful evidence should reduce packets.
+
+Recommended skip logic:
+
+```text
+identity-confirmed and fresh -> skip probe by default
+reachable and fresh -> skip probe by default
+recently silent but not diverse -> retry later, not immediately forever
+serial-only no bridge -> review, not packets
+candidate-only AD/DNS/hostname evidence -> review or enrich before packets
+CDN/WAF/front-door target -> review or bounded profile, not broad probing
+```
+
+## CDN/WAF/front-door handling
+
+Cloud firewalls, WAFs, CDNs, and load balancers can produce misleading results.
+
+They may answer on common ports while not representing the Cybernet device being investigated.
+
+Rules:
+
+```text
+Do not treat front-door reachability as serial proof.
+Do not broaden scope because a hostname resolves to multiple public IPs.
+Use CDN/WAF exclusion behavior where the selected tool supports it and the target profile indicates it is appropriate.
+Route suspicious front-door evidence to review.
+```
+
+## Packet profile doctrine
+
+Packet tools should run only from staged reduced target files, not directly from raw source artifacts.
+
+Default profiles should be small and explainable:
+
+```text
+selected Windows/Cybernet candidate ports
+selected web signal ports only when useful
+selected UDP only when it answers a specific question
+```
+
+All-port behavior, UDP profiles, scan-all-IPs behavior, and broad subnet activity must be explicitly gated and reasoned.
+
+## Artifact context requirement
+
+Every planner output that stages a probe should include low-noise context in machine-readable and human-readable artifacts.
+
+Minimum fields for summary JSON:
+
+```text
+low_noise_principle
+network_visibility_note
+probe_selection_questions
+probe_again_guidance
+fresh_evidence_guidance
+mystery_serial_guidance
+network_activity_performed
+```
+
+Minimum handoff text:
+
+```text
+The network sees packets, not the shell.
+This planner performed no network activity.
+Only bridged hostnames/IPs were staged.
+Fresh reachable/identity evidence should reduce re-probing.
+Prefer retrying stale or silent rows at a different time/day instead of repeating immediately.
+Mystery serials require review, not packets.
+```
+
+## Output classification implications
+
+Artifacts should explain why each row is in its bucket.
+
+Recommended reasons:
+
+```text
+skipped_identity_fresh
+skipped_reachable_fresh
+staged_bridge_exists
+review_no_probe_ready_bridge
+review_front_door_or_cdn
+retry_later_for_time_diversity
+review_persistent_silence
+review_mystery_serial
+```
+
+## Developer / agent requirements
+
+When implementing survey paths:
+
+1. Put local evidence lookup before packet actions.
+2. Make target staging a deliberate artifact, not an implicit side effect.
+3. Put low-noise rationale into JSON summaries and operator handoffs.
+4. Do not treat shell choice as network-noise control.
+5. Do not reduce local console output and call that network-noise reduction.
+6. Do not use stealth, bypass, or no-trace language.
+7. Preserve monitoring transparency and authorized-activity assumptions.
+8. Preserve mystery serials as first-class review outputs.
+9. Do not use fixed retry counts without freshness and time-diversity context.
+10. Prefer delta-only probing after each run.
+
+## Acceptance criteria for future implementation
+
+A low-noise survey sprint is not complete unless:
+
+- staged target files are reduced from source population by local evidence
+- summary JSON explains low-noise rationale
+- operator handoff explains why packets are or are not justified
+- fresh evidence suppresses unnecessary re-probing
+- retry guidance prefers different time/day over immediate repetition
+- serial-only mystery rows are visible and not packetized
+- shell choice is not presented as network visibility mitigation
+- generated outputs remain local and ignored

--- a/survey/sas-serial-preflight-plan.ps1
+++ b/survey/sas-serial-preflight-plan.ps1
@@ -13,6 +13,11 @@ The common field path is:
 - approved evidence exports under targets/local/, logs/targets/, survey/output/, logs/nmap/, or survey/artifacts/
 - generated to_probe_targets.txt under survey/input/serial_preflight/<run_id>/
 - sas-network-preflight.ps1 consumes that generated target file
+
+Low-noise principle:
+The network sees packets, not the operator shell. This planner reduces noise by staging fewer justified
+host/IP targets before any probe runs; it does not rely on CMD, PowerShell, or silent console output to
+change network visibility.
 #>
 
 [CmdletBinding()]
@@ -287,6 +292,22 @@ $review = New-Object System.Collections.Generic.List[object]
 $targets = New-Object System.Collections.Generic.List[string]
 $seenTargets = @{}
 
+$lowNoisePrinciple = 'Reduce packets by using local evidence before probes; the network sees packets, not the shell.'
+$networkVisibilityNote = 'CMD versus PowerShell does not materially change network visibility when the same packets, targets, ports, rate, and retries are used.'
+$probeAgainGuidance = 'Do not repeat fixed probe counts by habit. If a device was already recently reachable or identity-confirmed, skip by default; if retrying silent/stale rows, prefer a different time of day or different day of week.'
+$freshEvidenceGuidance = 'Fresh identity or reachability evidence should reduce re-probing. Stale, missing, conflicting, or operator-forced evidence can justify staging a target.'
+$mysterySerialGuidance = 'A serial with no approved host/IP bridge remains a mystery serial for review; do not ping the serial string.'
+$probeSelectionQuestions = @(
+    'Should this target be probed at all?',
+    'Which exact host/IP should be probed?',
+    'Which exact ports answer the survey question?',
+    'At what rate?',
+    'How many retries?',
+    'Is this already fresh in local evidence?',
+    'Is this a CDN/WAF/load-balanced/front-door target?',
+    'Is this a mystery serial that needs review, not packets?'
+)
+
 foreach ($serial in $serialRows) {
     $matches = @($evidenceRows | Where-Object { $_.NormalizedSerial -eq $serial.NormalizedSerial })
     $probeMatches = @($matches | Where-Object { -not [string]::IsNullOrWhiteSpace($_.ProbeTarget) -and (Test-ProbeReadyTargetValue -Value $_.ProbeTarget) })
@@ -295,10 +316,11 @@ foreach ($serial in $serialRows) {
 
     if ($null -ne $selected) {
         $decision = 'STAGE_FOR_NETWORK_PREFLIGHT'
-        $reason = 'serial has approved local evidence that bridges to a probe-ready hostname/IP'
+        $reason = 'serial has approved local evidence that bridges to a probe-ready hostname/IP; stage only this reduced host/IP target, not the serial string'
         $probeTarget = [string]$selected.ProbeTarget
         $evidencePath = [string]$selected.EvidencePath
         $evidenceSource = [string]$selected.EvidenceSourceFile
+        $lowNoiseDisposition = 'staged_bridge_exists'
         $key = $probeTarget.ToLowerInvariant()
         if (-not $seenTargets.ContainsKey($key)) {
             $seenTargets[$key] = $true
@@ -310,6 +332,7 @@ foreach ($serial in $serialRows) {
         $probeTarget = ''
         $evidencePath = if ($matches.Count -gt 0) { 'evidence_without_probe_ready_target' } else { 'serial_only_population' }
         $evidenceSource = if ($matches.Count -gt 0) { (($matches | ForEach-Object { $_.EvidenceSourceFile } | Sort-Object -Unique) -join ';') } else { '' }
+        $lowNoiseDisposition = 'review_mystery_serial_or_missing_bridge'
     }
 
     $planRow = [pscustomobject]@{
@@ -322,6 +345,8 @@ foreach ($serial in $serialRows) {
         EvidenceSourceFile = $evidenceSource
         Decision = $decision
         DecisionReason = $reason
+        LowNoiseDisposition = $lowNoiseDisposition
+        ProbeAgainGuidance = $probeAgainGuidance
         NetworkActivityPerformed = $false
     }
     $plan.Add($planRow)
@@ -352,6 +377,12 @@ $summary = [pscustomobject]@{
     to_probe_targets_path = $targetPath
     operator_handoff_path = $handoffPath
     next_network_preflight_command = $nextCommand
+    low_noise_principle = $lowNoisePrinciple
+    network_visibility_note = $networkVisibilityNote
+    probe_selection_questions = $probeSelectionQuestions
+    probe_again_guidance = $probeAgainGuidance
+    fresh_evidence_guidance = $freshEvidenceGuidance
+    mystery_serial_guidance = $mysterySerialGuidance
     network_activity_performed = $false
 }
 $summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
@@ -368,11 +399,22 @@ $summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $summaryPath -Enco
     "Review: $reviewPath",
     "Staged target file: $targetPath",
     '',
+    'Low-noise context:',
+    "- $lowNoisePrinciple",
+    "- $networkVisibilityNote",
+    "- $freshEvidenceGuidance",
+    "- $probeAgainGuidance",
+    "- $mysterySerialGuidance",
+    '',
+    'Pre-probe questions:',
+    ($probeSelectionQuestions | ForEach-Object { "- $_" }),
+    '',
     'Run in Windows PowerShell:',
     $nextCommand,
     '',
     'Planner network activity performed: false',
-    'Do not ping serial strings. Ping only the generated hostname/IP target file.'
+    'Do not ping serial strings. Ping only the generated hostname/IP target file.',
+    'If a device was recently reachable, do not repeat probes by habit; retry later only when evidence is stale, missing, conflicting, or operator-forced.'
 ) | Set-Content -LiteralPath $handoffPath -Encoding UTF8
 
 Write-Host "Serial preflight plan complete: $resolvedRunId"
@@ -380,6 +422,11 @@ Write-Host "Serials read: $($serialRows.Count)"
 Write-Host "Probe-ready targets staged: $($targets.Count)"
 Write-Host "Review-required serials: $($review.Count)"
 Write-Host "Staged target file: $targetPath"
+Write-Host ''
+Write-Host 'Low-noise context:'
+Write-Host "- $lowNoisePrinciple"
+Write-Host "- $networkVisibilityNote"
+Write-Host "- $probeAgainGuidance"
 Write-Host ''
 Write-Host 'Run in Windows PowerShell:'
 Write-Host $nextCommand

--- a/survey/sas-serial-preflight-plan.ps1
+++ b/survey/sas-serial-preflight-plan.ps1
@@ -292,7 +292,7 @@ $review = New-Object System.Collections.Generic.List[object]
 $targets = New-Object System.Collections.Generic.List[string]
 $seenTargets = @{}
 
-$lowNoisePrinciple = 'Reduce packets by using local evidence before probes; the network sees packets, not the shell.'
+$lowNoisePrinciple = 'The network sees packets, not the shell. Reduce packets by using local evidence before probes.'
 $networkVisibilityNote = 'CMD versus PowerShell does not materially change network visibility when the same packets, targets, ports, rate, and retries are used.'
 $probeAgainGuidance = 'Do not repeat fixed probe counts by habit. If a device was already recently reachable or identity-confirmed, skip by default; if retrying silent/stale rows, prefer a different time of day or different day of week.'
 $freshEvidenceGuidance = 'Fresh identity or reachability evidence should reduce re-probing. Stale, missing, conflicting, or operator-forced evidence can justify staging a target.'


### PR DESCRIPTION
## Summary

Codifies low-noise Cybernet survey principles and carries them into generated serial preflight artifacts.

## What changed

- Added `docs/LOW_NOISE_PROBE_PRINCIPLES.md`
- Updated `docs/FIELD_NETWORK_PREFLIGHT.md` with low-noise probe posture
- Updated `survey/sas-serial-preflight-plan.ps1` so generated artifacts include:
  - `low_noise_principle`
  - `network_visibility_note`
  - `probe_selection_questions`
  - `probe_again_guidance`
  - `fresh_evidence_guidance`
  - `mystery_serial_guidance`
  - `LowNoiseDisposition` per plan row
- Updated static survey contracts so the low-noise context cannot disappear silently

## Principles captured

- The network sees packets, not the shell.
- CMD versus PowerShell does not materially reduce network visibility when targets, ports, packet types, rate, and retries are the same.
- Low noise comes from smaller scope, fewer ports, lower rate, fewer retries, smarter evidence reuse, and avoiding broad scans.
- Before probing, ask whether the target deserves packets, which host/IP, which ports, what rate/retries, whether evidence is already fresh, whether the target is CDN/WAF/front-door, and whether the row is a mystery serial that needs review.
- Five probes are unnecessary when the device was already recently reachable or identity-confirmed.
- If retrying is justified, prefer a different time of day and/or day of week over immediate repeated probes.

## Safety

This is authorized low-noise survey guidance, not evasion guidance. The docs explicitly reject stealth, bypass, and no-trace language. No live serials, hostnames, IPs, MACs, AD exports, credentials, or generated evidence committed.

## Validation expectation

- Dashboard Smoke
- Pester
- Survey/static contracts if triggered

Merge policy: merge_when_green.