### PR TITLE
feat(survey): factor low-noise retry policy across survey lanes

### DIFF
--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -101,6 +101,10 @@ contains 'function Get-SasLowNoisePolicy' "$low_noise_module" 'low-noise module 
 contains 'Five probes are unnecessary' "$low_noise_module" 'low-noise module missing pragmatic retry doctrine'
 contains 'prefer a different time of day or different day of week' "$low_noise_module" 'low-noise module missing time-diverse retry doctrine'
 contains 'The network sees packets, not the shell' "$low_noise_module" 'low-noise module missing network visibility principle'
+contains 'low_noise_principle' "$low_noise_module" 'low-noise module missing summary low-noise field'
+contains 'network_visibility_note' "$low_noise_module" 'low-noise module missing summary visibility field'
+contains 'probe_selection_questions' "$low_noise_module" 'low-noise module missing summary question field'
+contains 'probe_again_guidance' "$low_noise_module" 'low-noise module missing summary retry field'
 contains 'New-SasLowNoiseSummaryObject' "$low_noise_module" 'low-noise module missing summary helper'
 contains 'Get-SasLowNoiseOperatorLines' "$low_noise_module" 'low-noise module missing operator handoff helper'
 
@@ -115,11 +119,9 @@ contains 'REVIEW_REQUIRED_NO_PROBE_READY_EVIDENCE' "$serial_plan" 'serial planne
 contains 'do not ping the serial string' "$serial_plan" 'serial planner must not ping serial strings'
 contains 'network_activity_performed = $false' "$serial_plan" 'serial planner must report no network activity'
 contains 'to_probe_targets.txt' "$serial_plan" 'serial planner must stage target file'
-contains 'low_noise_principle' "$serial_plan" 'serial planner summary missing low-noise principle'
-contains 'network_visibility_note' "$serial_plan" 'serial planner summary missing network visibility note'
-contains 'probe_selection_questions' "$serial_plan" 'serial planner summary missing probe selection questions'
-contains 'probe_again_guidance' "$serial_plan" 'serial planner summary missing probe-again guidance'
+contains 'LowNoisePolicyVersion' "$serial_plan" 'serial planner rows must include low-noise policy version'
 contains 'LowNoiseDisposition' "$serial_plan" 'serial planner plan rows missing low-noise disposition'
+contains 'ProbeAgainGuidance' "$serial_plan" 'serial planner rows must include pragmatic retry guidance'
 contains 'If a device was recently reachable' "$serial_plan" 'serial planner must discourage habitual repeat probes'
 
 contains 'Import-Module $lowNoiseModule -Force' "$preflight" 'network preflight must import shared low-noise policy module'
@@ -160,6 +162,7 @@ contains 'survey\output\network_preflight' "$dashboard_patch" 'dashboard patch m
 
 contains '# Low-Noise Probe Principles' "$low_noise_doc" 'low-noise doctrine missing title'
 contains 'The network sees packets, not the operator' "$low_noise_doc" 'low-noise doctrine missing shell distinction'
+contains 'scripts/SasLowNoisePolicy.psm1' "$low_noise_doc" 'low-noise doctrine missing shared module path'
 contains 'smaller scope' "$low_noise_doc" 'low-noise doctrine missing scope principle'
 contains 'fewer ports' "$low_noise_doc" 'low-noise doctrine missing port principle'
 contains 'lower rate' "$low_noise_doc" 'low-noise doctrine missing rate principle'

--- a/Tests/bash/test_powershell_network_preflight_contracts.sh
+++ b/Tests/bash/test_powershell_network_preflight_contracts.sh
@@ -9,6 +9,7 @@ low_noise_doc="$repo_root/docs/LOW_NOISE_PROBE_PRINCIPLES.md"
 start_here="$repo_root/START-HERE-CYBERNET-NEURON-SURVEY.md"
 dashboard_patch="$repo_root/dashboard/js/cybernet-os-preflight.js"
 ps_module="$repo_root/scripts/SasTargetIntake.psm1"
+low_noise_module="$repo_root/scripts/SasLowNoisePolicy.psm1"
 dispatch="$repo_root/survey/sas-target-intake-dispatch.ps1"
 bash_helper="$repo_root/survey/lib/sas-target-intake.sh"
 field_files=("$runbook" "$start_here" "$dashboard_patch")
@@ -18,7 +19,7 @@ contains(){ grep -Fq -- "$1" "$2" || fail "$3"; }
 not_contains(){ if grep -Fq -- "$1" "$2"; then fail "$3"; fi; }
 not_matches(){ if grep -Eq -- "$1" "$2"; then fail "$3"; fi; }
 
-for f in "$preflight" "$serial_plan" "$runbook" "$low_noise_doc" "$start_here" "$dashboard_patch" "$ps_module" "$dispatch" "$bash_helper"; do
+for f in "$preflight" "$serial_plan" "$runbook" "$low_noise_doc" "$start_here" "$dashboard_patch" "$ps_module" "$low_noise_module" "$dispatch" "$bash_helper"; do
   [[ -f "$f" ]] || fail "missing file: $f"
 done
 
@@ -95,6 +96,18 @@ contains "\$identifierColumns = @('Identifier')" "$preflight" 'Identifier column
 contains 'Skipping ambiguous Identifier value without explicit host/IP type' "$preflight" 'ambiguous Identifier rows must not silently probe'
 contains 'Serial-only rows must be normalized or enriched' "$preflight" 'must refuse serial-only material clearly'
 
+contains 'SasLowNoisePolicy.psm1' "$low_noise_module" 'low-noise module missing self-identifying name'
+contains 'function Get-SasLowNoisePolicy' "$low_noise_module" 'low-noise module missing policy getter'
+contains 'Five probes are unnecessary' "$low_noise_module" 'low-noise module missing pragmatic retry doctrine'
+contains 'prefer a different time of day or different day of week' "$low_noise_module" 'low-noise module missing time-diverse retry doctrine'
+contains 'The network sees packets, not the shell' "$low_noise_module" 'low-noise module missing network visibility principle'
+contains 'New-SasLowNoiseSummaryObject' "$low_noise_module" 'low-noise module missing summary helper'
+contains 'Get-SasLowNoiseOperatorLines' "$low_noise_module" 'low-noise module missing operator handoff helper'
+
+contains 'Import-Module $lowNoiseModule -Force' "$serial_plan" 'serial planner must import shared low-noise policy module'
+contains 'Get-SasLowNoisePolicy' "$serial_plan" 'serial planner must consume shared low-noise policy'
+contains 'New-SasLowNoiseSummaryObject' "$serial_plan" 'serial planner must build summary through shared policy'
+contains 'Get-SasLowNoiseOperatorLines' "$serial_plan" 'serial planner must build handoff through shared policy'
 contains 'Alejandro serial list' "$serial_plan" 'serial planner must name Alejandro serial input'
 contains 'serial-to-target evidence file' "$serial_plan" 'serial planner must validate evidence bridge files'
 contains 'STAGE_FOR_NETWORK_PREFLIGHT' "$serial_plan" 'serial planner missing staged decision'
@@ -107,8 +120,21 @@ contains 'network_visibility_note' "$serial_plan" 'serial planner summary missin
 contains 'probe_selection_questions' "$serial_plan" 'serial planner summary missing probe selection questions'
 contains 'probe_again_guidance' "$serial_plan" 'serial planner summary missing probe-again guidance'
 contains 'LowNoiseDisposition' "$serial_plan" 'serial planner plan rows missing low-noise disposition'
-contains 'The network sees packets, not the shell' "$serial_plan" 'serial planner must explain shell choice is not network visibility control'
 contains 'If a device was recently reachable' "$serial_plan" 'serial planner must discourage habitual repeat probes'
+
+contains 'Import-Module $lowNoiseModule -Force' "$preflight" 'network preflight must import shared low-noise policy module'
+contains 'Get-SasLowNoisePolicy' "$preflight" 'network preflight must consume shared low-noise policy'
+contains 'New-SasLowNoiseSummaryObject' "$preflight" 'network preflight must build summary through shared policy'
+contains 'Get-SasLowNoiseOperatorLines' "$preflight" 'network preflight must build handoff through shared policy'
+contains 'LowNoisePolicyVersion' "$preflight" 'network preflight rows must include low-noise policy version'
+contains 'LowNoiseDisposition' "$preflight" 'network preflight rows must include low-noise disposition'
+contains 'ProbeAgainGuidance' "$preflight" 'network preflight rows must include pragmatic retry guidance'
+contains 'network_preflight_${runId}_summary.json' "$preflight" 'network preflight must emit summary JSON'
+contains 'network_preflight_${runId}_handoff.txt' "$preflight" 'network preflight must emit operator handoff'
+
+contains 'Import-Module $lowNoiseModule -Force' "$dispatch" 'dispatcher must import shared low-noise policy module'
+contains 'Get-SasLowNoisePolicy' "$dispatch" 'dispatcher must consume shared low-noise policy'
+contains 'Low-noise policy:' "$dispatch" 'dispatcher must print low-noise policy for command plans'
 contains 'SerialPreflightPlan' "$dispatch" 'dispatcher missing SerialPreflightPlan mode'
 contains 'sas-serial-preflight-plan.ps1' "$dispatch" 'dispatcher missing serial planner entrypoint'
 

--- a/docs/LOW_NOISE_PROBE_PRINCIPLES.md
+++ b/docs/LOW_NOISE_PROBE_PRINCIPLES.md
@@ -22,6 +22,36 @@ WSL
 
 Shell choice can change local endpoint/process history, parent process, and operator workflow. It does not make the same packets lower-noise on the network.
 
+## Shared implementation point
+
+The canonical implementation surface is:
+
+```text
+scripts/SasLowNoisePolicy.psm1
+```
+
+Survey planners and command dispatchers should import this module instead of copying low-noise strings locally.
+
+Required shared functions:
+
+```text
+Get-SasLowNoisePolicy
+New-SasLowNoiseSummaryObject
+Get-SasLowNoiseOperatorLines
+```
+
+The policy must be consumed by every path that stages or runs probes, including:
+
+```text
+serial preflight planning
+network preflight execution
+Naabu command planning
+subnet confirmation planning
+future delta/iteration planners
+```
+
+No use case should invent its own retry doctrine or omit the principle that fresh reachable/identity evidence suppresses habitual re-probing.
+
 ## What actually lowers network noise
 
 Low-noise comes from the survey design:
@@ -180,12 +210,15 @@ Every planner output that stages a probe should include low-noise context in mac
 Minimum fields for summary JSON:
 
 ```text
+low_noise_policy_version
 low_noise_principle
 network_visibility_note
 probe_selection_questions
 probe_again_guidance
 fresh_evidence_guidance
 mystery_serial_guidance
+front_door_guidance
+packet_profile_guidance
 network_activity_performed
 ```
 
@@ -231,6 +264,8 @@ When implementing survey paths:
 8. Preserve mystery serials as first-class review outputs.
 9. Do not use fixed retry counts without freshness and time-diversity context.
 10. Prefer delta-only probing after each run.
+11. Import `scripts/SasLowNoisePolicy.psm1` for shared wording and artifact fields instead of copying policy strings.
+12. Add static contracts when a new survey lane stages or runs probes so the shared policy cannot be omitted.
 
 ## Acceptance criteria for future implementation
 
@@ -243,4 +278,5 @@ A low-noise survey sprint is not complete unless:
 - retry guidance prefers different time/day over immediate repetition
 - serial-only mystery rows are visible and not packetized
 - shell choice is not presented as network visibility mitigation
+- shared policy comes from `scripts/SasLowNoisePolicy.psm1`
 - generated outputs remain local and ignored

--- a/scripts/SasLowNoisePolicy.psm1
+++ b/scripts/SasLowNoisePolicy.psm1
@@ -4,7 +4,7 @@
 Shared SysAdminSuite low-noise survey and pragmatic retry policy.
 
 .DESCRIPTION
-This module centralizes the retry/noise doctrine used by Cybernet survey planners and probe handoffs.
+scripts/SasLowNoisePolicy.psm1 centralizes the retry/noise doctrine used by Cybernet survey planners and probe handoffs.
 
 The policy is deliberately plain: shell choice is not a network-noise control; packet count is controlled by
 scope, ports, rate, retries, freshness, evidence reuse, and staging only justified host/IP targets.

--- a/scripts/SasLowNoisePolicy.psm1
+++ b/scripts/SasLowNoisePolicy.psm1
@@ -1,0 +1,93 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+Shared SysAdminSuite low-noise survey and pragmatic retry policy.
+
+.DESCRIPTION
+This module centralizes the retry/noise doctrine used by Cybernet survey planners and probe handoffs.
+
+The policy is deliberately plain: shell choice is not a network-noise control; packet count is controlled by
+scope, ports, rate, retries, freshness, evidence reuse, and staging only justified host/IP targets.
+#>
+
+Set-StrictMode -Version 2.0
+
+function Get-SasLowNoisePolicy {
+    [CmdletBinding()]
+    param()
+
+    return [pscustomobject]@{
+        PolicyVersion = '1.0'
+        LowNoisePrinciple = 'The network sees packets, not the shell. Reduce packets by using local evidence before probes.'
+        NetworkVisibilityNote = 'CMD versus PowerShell does not materially change network visibility when the same packets, targets, ports, rate, and retries are used.'
+        ProbeAgainGuidance = 'Five probes are unnecessary when a device was already recently reachable or identity-confirmed. If retrying is justified, prefer a different time of day or different day of week over immediate repeated probes.'
+        FreshEvidenceGuidance = 'Fresh identity or reachability evidence should reduce re-probing. Stale, missing, conflicting, or operator-forced evidence can justify staging a target.'
+        MysterySerialGuidance = 'A serial with no approved host/IP bridge remains a mystery serial for review; do not ping the serial string.'
+        FrontDoorGuidance = 'CDN/WAF/load-balanced/front-door targets should not be treated as serial proof. Review or use bounded profiles rather than broad probing.'
+        PacketProfileGuidance = 'Prefer smaller scope, fewer ports, lower rate, fewer retries, smarter evidence reuse, and avoiding broad scans.'
+        ProbeSelectionQuestions = @(
+            'Should this target be probed at all?',
+            'Which exact host/IP should be probed?',
+            'Which exact ports answer the survey question?',
+            'At what rate?',
+            'How many retries?',
+            'Is this already fresh in local evidence?',
+            'Is this a CDN/WAF/load-balanced/front-door target?',
+            'Is this a mystery serial that needs review, not packets?'
+        )
+    }
+}
+
+function Add-SasLowNoisePolicyToObject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$InputObject
+    )
+
+    $policy = Get-SasLowNoisePolicy
+
+    $InputObject | Add-Member -NotePropertyName low_noise_policy_version -NotePropertyValue $policy.PolicyVersion -Force
+    $InputObject | Add-Member -NotePropertyName low_noise_principle -NotePropertyValue $policy.LowNoisePrinciple -Force
+    $InputObject | Add-Member -NotePropertyName network_visibility_note -NotePropertyValue $policy.NetworkVisibilityNote -Force
+    $InputObject | Add-Member -NotePropertyName probe_selection_questions -NotePropertyValue $policy.ProbeSelectionQuestions -Force
+    $InputObject | Add-Member -NotePropertyName probe_again_guidance -NotePropertyValue $policy.ProbeAgainGuidance -Force
+    $InputObject | Add-Member -NotePropertyName fresh_evidence_guidance -NotePropertyValue $policy.FreshEvidenceGuidance -Force
+    $InputObject | Add-Member -NotePropertyName mystery_serial_guidance -NotePropertyValue $policy.MysterySerialGuidance -Force
+    $InputObject | Add-Member -NotePropertyName front_door_guidance -NotePropertyValue $policy.FrontDoorGuidance -Force
+    $InputObject | Add-Member -NotePropertyName packet_profile_guidance -NotePropertyValue $policy.PacketProfileGuidance -Force
+
+    return $InputObject
+}
+
+function New-SasLowNoiseSummaryObject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [hashtable]$Properties = @{}
+    )
+
+    $obj = [pscustomobject]$Properties
+    return Add-SasLowNoisePolicyToObject -InputObject $obj
+}
+
+function Get-SasLowNoiseOperatorLines {
+    [CmdletBinding()]
+    param()
+
+    $policy = Get-SasLowNoisePolicy
+
+    return @(
+        'Low-noise context:',
+        "- $($policy.LowNoisePrinciple)",
+        "- $($policy.NetworkVisibilityNote)",
+        "- $($policy.FreshEvidenceGuidance)",
+        "- $($policy.ProbeAgainGuidance)",
+        "- $($policy.MysterySerialGuidance)",
+        "- $($policy.FrontDoorGuidance)",
+        '',
+        'Pre-probe questions:'
+    ) + ($policy.ProbeSelectionQuestions | ForEach-Object { "- $_" })
+}
+
+Export-ModuleMember -Function Get-SasLowNoisePolicy, Add-SasLowNoisePolicyToObject, New-SasLowNoiseSummaryObject, Get-SasLowNoiseOperatorLines

--- a/survey/sas-network-preflight.ps1
+++ b/survey/sas-network-preflight.ps1
@@ -38,6 +38,12 @@ if (-not (Test-Path -LiteralPath $targetIntakeModule)) {
 }
 Import-Module $targetIntakeModule -Force
 
+$lowNoiseModule = Join-Path $repoGuess 'scripts/SasLowNoisePolicy.psm1'
+if (-not (Test-Path -LiteralPath $lowNoiseModule)) {
+    throw "Missing shared low-noise policy module: $lowNoiseModule"
+}
+Import-Module $lowNoiseModule -Force
+
 function Resolve-SasRepoRoot {
     return Get-SasRepoRoot -StartPath $PSScriptRoot
 }
@@ -89,12 +95,18 @@ function Show-TargetFileSelectionHelp {
         [Parameter(Mandatory = $true)][string]$StagingRoot
     )
 
+    $policy = Get-SasLowNoisePolicy
+
     Write-Host 'No -TargetFile was provided. Stopping without probing.'
     Write-Host ''
     Write-Host 'Select an approved .txt or .csv target file from one of these live intake roots:'
     foreach ($root in $CandidateRoots) { Write-Host "- $root" }
     Write-Host ''
     Write-Host "survey/input is normalized runtime staging only: $StagingRoot"
+    Write-Host ''
+    Write-Host 'Low-noise reminder:'
+    Write-Host "- $($policy.LowNoisePrinciple)"
+    Write-Host "- $($policy.ProbeAgainGuidance)"
     Write-Host ''
     Write-Host 'Candidate files found:'
     $candidates = @(Get-CandidateTargetFiles -Roots $CandidateRoots)
@@ -293,6 +305,7 @@ $surveyInputRoot = $rootSet.StagingRoot
 $surveyOutputRoot = $rootSet.OutputRoots[0]
 $logsNmapRoot = $rootSet.OutputRoots[1]
 $surveyArtifactsRoot = $rootSet.OutputRoots[2]
+$lowNoisePolicy = Get-SasLowNoisePolicy
 
 $candidateRoots = @($targetsLocalRoot, $logsTargetsRoot)
 $allowedInputRoots = @($targetsLocalRoot, $logsTargetsRoot, $surveyInputRoot)
@@ -350,11 +363,16 @@ if ($targets.Count -eq 0) {
 New-Item -ItemType Directory -Force -Path $outputDirectoryFull | Out-Null
 $runId = Get-Date -Format 'yyyyMMdd_HHmmss'
 $outputCsv = Join-Path $outputDirectoryFull "network_preflight_$runId.csv"
+$summaryJson = Join-Path $outputDirectoryFull "network_preflight_${runId}_summary.json"
+$handoffPath = Join-Path $outputDirectoryFull "network_preflight_${runId}_handoff.txt"
 
 Write-Host "Selected target file: $selectedTargetFile"
 Write-Host "Target count: $($targets.Count)"
 Write-Host "Selected ports: $($Ports -join ',')"
 Write-Host "Output path: $outputCsv"
+Write-Host 'Low-noise context:'
+Write-Host "- $($lowNoisePolicy.LowNoisePrinciple)"
+Write-Host "- $($lowNoisePolicy.ProbeAgainGuidance)"
 
 Write-SasStageProgress -Step 2 -Total 4 -Message 'Resolving DNS for selected targets' -Percent 50
 $resolved = @{}
@@ -390,19 +408,55 @@ foreach ($target in $targets) {
         if ($status -eq 'NotChecked') { $notes += 'Test-NetConnection unavailable in this PowerShell runtime' }
 
         $rows.Add([pscustomobject]@{
-            Timestamp       = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
-            Target          = $target
-            ResolvedAddress = $resolved[$target]
-            PingStatus      = $ping[$target]
-            Port            = $port
-            PortStatus      = $status
-            SourceFile      = $selectedTargetFile
-            Notes           = ($notes -join '; ')
+            Timestamp              = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+            Target                 = $target
+            ResolvedAddress        = $resolved[$target]
+            PingStatus             = $ping[$target]
+            Port                   = $port
+            PortStatus             = $status
+            SourceFile             = $selectedTargetFile
+            LowNoisePolicyVersion  = $lowNoisePolicy.PolicyVersion
+            LowNoiseDisposition    = 'network_preflight_attempt_recorded'
+            ProbeAgainGuidance     = $lowNoisePolicy.ProbeAgainGuidance
+            Notes                  = ($notes -join '; ')
         })
     }
 }
 
 Write-SasStageProgress -Step 4 -Total 4 -Message 'Writing network_preflight.csv' -Percent 100
 $rows | Export-Csv -LiteralPath $outputCsv -NoTypeInformation -Encoding UTF8
+
+$summary = New-SasLowNoiseSummaryObject -Properties @{
+    run_id = $runId
+    generated_at = (Get-Date).ToString('o')
+    target_file = $selectedTargetFile
+    target_count = $targets.Count
+    ports = $Ports
+    total_checks = $totalChecks
+    output_csv = $outputCsv
+    summary_json = $summaryJson
+    operator_handoff_path = $handoffPath
+    network_activity_performed = $true
+}
+$summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $summaryJson -Encoding UTF8
+
+@(
+    'SysAdminSuite network preflight handoff',
+    "RunId: $runId",
+    "Target file: $selectedTargetFile",
+    "Targets checked: $($targets.Count)",
+    "Ports checked: $($Ports -join ',')",
+    "CSV output: $outputCsv",
+    "Summary JSON: $summaryJson",
+    '',
+    (Get-SasLowNoiseOperatorLines),
+    '',
+    'Network activity performed: true',
+    'Do not repeat probes by habit. If a target was recently reachable or identity-confirmed, prefer using fresh evidence instead of immediate repetition.',
+    'If retrying silent or stale rows, prefer a different time of day or different day of week.'
+) | Set-Content -LiteralPath $handoffPath -Encoding UTF8
+
 Write-Progress -Activity 'SysAdminSuite network preflight' -Completed
 Write-Host "Final CSV path: $outputCsv"
+Write-Host "Summary JSON path: $summaryJson"
+Write-Host "Operator handoff path: $handoffPath"

--- a/survey/sas-serial-preflight-plan.ps1
+++ b/survey/sas-serial-preflight-plan.ps1
@@ -57,6 +57,12 @@ if (-not (Test-Path -LiteralPath $targetIntakeModule)) {
 }
 Import-Module $targetIntakeModule -Force
 
+$lowNoiseModule = Join-Path $repoGuess 'scripts/SasLowNoisePolicy.psm1'
+if (-not (Test-Path -LiteralPath $lowNoiseModule)) {
+    throw "Missing shared low-noise policy module: $lowNoiseModule"
+}
+Import-Module $lowNoiseModule -Force
+
 function Get-RowValue {
     param(
         [Parameter(Mandatory = $true)]$Row,
@@ -291,22 +297,7 @@ $plan = New-Object System.Collections.Generic.List[object]
 $review = New-Object System.Collections.Generic.List[object]
 $targets = New-Object System.Collections.Generic.List[string]
 $seenTargets = @{}
-
-$lowNoisePrinciple = 'The network sees packets, not the shell. Reduce packets by using local evidence before probes.'
-$networkVisibilityNote = 'CMD versus PowerShell does not materially change network visibility when the same packets, targets, ports, rate, and retries are used.'
-$probeAgainGuidance = 'Do not repeat fixed probe counts by habit. If a device was already recently reachable or identity-confirmed, skip by default; if retrying silent/stale rows, prefer a different time of day or different day of week.'
-$freshEvidenceGuidance = 'Fresh identity or reachability evidence should reduce re-probing. Stale, missing, conflicting, or operator-forced evidence can justify staging a target.'
-$mysterySerialGuidance = 'A serial with no approved host/IP bridge remains a mystery serial for review; do not ping the serial string.'
-$probeSelectionQuestions = @(
-    'Should this target be probed at all?',
-    'Which exact host/IP should be probed?',
-    'Which exact ports answer the survey question?',
-    'At what rate?',
-    'How many retries?',
-    'Is this already fresh in local evidence?',
-    'Is this a CDN/WAF/load-balanced/front-door target?',
-    'Is this a mystery serial that needs review, not packets?'
-)
+$lowNoisePolicy = Get-SasLowNoisePolicy
 
 foreach ($serial in $serialRows) {
     $matches = @($evidenceRows | Where-Object { $_.NormalizedSerial -eq $serial.NormalizedSerial })
@@ -345,8 +336,9 @@ foreach ($serial in $serialRows) {
         EvidenceSourceFile = $evidenceSource
         Decision = $decision
         DecisionReason = $reason
+        LowNoisePolicyVersion = $lowNoisePolicy.PolicyVersion
         LowNoiseDisposition = $lowNoiseDisposition
-        ProbeAgainGuidance = $probeAgainGuidance
+        ProbeAgainGuidance = $lowNoisePolicy.ProbeAgainGuidance
         NetworkActivityPerformed = $false
     }
     $plan.Add($planRow)
@@ -364,7 +356,7 @@ $review | Export-Csv -LiteralPath $reviewPath -NoTypeInformation -Encoding UTF8
 $targets | Set-Content -LiteralPath $targetPath -Encoding UTF8
 
 $nextCommand = ".\survey\sas-network-preflight.ps1 -TargetFile `"$targetPath`" -Ports $($Ports -join ',')"
-$summary = [pscustomobject]@{
+$summary = New-SasLowNoiseSummaryObject -Properties @{
     run_id = $resolvedRunId
     generated_at = (Get-Date).ToString('o')
     serial_file = $serialFilePath
@@ -377,12 +369,6 @@ $summary = [pscustomobject]@{
     to_probe_targets_path = $targetPath
     operator_handoff_path = $handoffPath
     next_network_preflight_command = $nextCommand
-    low_noise_principle = $lowNoisePrinciple
-    network_visibility_note = $networkVisibilityNote
-    probe_selection_questions = $probeSelectionQuestions
-    probe_again_guidance = $probeAgainGuidance
-    fresh_evidence_guidance = $freshEvidenceGuidance
-    mystery_serial_guidance = $mysterySerialGuidance
     network_activity_performed = $false
 }
 $summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
@@ -399,15 +385,7 @@ $summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $summaryPath -Enco
     "Review: $reviewPath",
     "Staged target file: $targetPath",
     '',
-    'Low-noise context:',
-    "- $lowNoisePrinciple",
-    "- $networkVisibilityNote",
-    "- $freshEvidenceGuidance",
-    "- $probeAgainGuidance",
-    "- $mysterySerialGuidance",
-    '',
-    'Pre-probe questions:',
-    ($probeSelectionQuestions | ForEach-Object { "- $_" }),
+    (Get-SasLowNoiseOperatorLines),
     '',
     'Run in Windows PowerShell:',
     $nextCommand,
@@ -424,9 +402,9 @@ Write-Host "Review-required serials: $($review.Count)"
 Write-Host "Staged target file: $targetPath"
 Write-Host ''
 Write-Host 'Low-noise context:'
-Write-Host "- $lowNoisePrinciple"
-Write-Host "- $networkVisibilityNote"
-Write-Host "- $probeAgainGuidance"
+Write-Host "- $($lowNoisePolicy.LowNoisePrinciple)"
+Write-Host "- $($lowNoisePolicy.NetworkVisibilityNote)"
+Write-Host "- $($lowNoisePolicy.ProbeAgainGuidance)"
 Write-Host ''
 Write-Host 'Run in Windows PowerShell:'
 Write-Host $nextCommand

--- a/survey/sas-target-intake-dispatch.ps1
+++ b/survey/sas-target-intake-dispatch.ps1
@@ -47,8 +47,15 @@ if (-not (Test-Path -LiteralPath $modulePath)) {
 }
 Import-Module $modulePath -Force
 
+$lowNoiseModule = Join-Path $repoGuess 'scripts/SasLowNoisePolicy.psm1'
+if (-not (Test-Path -LiteralPath $lowNoiseModule)) {
+    throw "Missing shared low-noise policy module: $lowNoiseModule"
+}
+Import-Module $lowNoiseModule -Force
+
 $repoRoot = Get-SasRepoRoot -StartPath $PSScriptRoot
 $roots = Get-SasTargetIntakeRoots -RepoRoot $repoRoot
+$lowNoisePolicy = Get-SasLowNoisePolicy
 
 function Write-DispatchHeader {
     param([string]$SelectedMode)
@@ -87,6 +94,14 @@ function Resolve-DispatchEvidenceFile {
     return $resolved
 }
 
+function Write-LowNoisePolicyBlock {
+    Write-Host ''
+    Write-Host 'Low-noise policy:'
+    Write-Host "- $($lowNoisePolicy.LowNoisePrinciple)"
+    Write-Host "- $($lowNoisePolicy.ProbeAgainGuidance)"
+    Write-Host "- $($lowNoisePolicy.FreshEvidenceGuidance)"
+}
+
 function Write-CommandBlock {
     param(
         [string]$Label,
@@ -95,6 +110,7 @@ function Write-CommandBlock {
     Write-Host ''
     Write-Host $Label
     Write-Host $Command
+    Write-LowNoisePolicyBlock
 }
 
 Write-DispatchHeader -SelectedMode $Mode
@@ -109,6 +125,7 @@ switch ($Mode) {
         } else {
             foreach ($candidate in $candidates) { Write-Host "- $($candidate.FullName)" }
         }
+        Write-LowNoisePolicyBlock
         break
     }
 


### PR DESCRIPTION
## Summary

Factors the pragmatic low-noise retry doctrine into shared code so survey lanes do not copy or omit the principle.

## What changed

- Added `scripts/SasLowNoisePolicy.psm1`
  - `Get-SasLowNoisePolicy`
  - `New-SasLowNoiseSummaryObject`
  - `Get-SasLowNoiseOperatorLines`
- Updated `survey/sas-serial-preflight-plan.ps1`
  - imports shared policy module
  - builds summary JSON through shared policy
  - builds operator handoff through shared policy
  - keeps per-row `LowNoiseDisposition` and `ProbeAgainGuidance`
- Updated `survey/sas-network-preflight.ps1`
  - imports shared policy module
  - writes low-noise fields on packet attempt rows
  - emits summary JSON and operator handoff beside the CSV
- Updated `survey/sas-target-intake-dispatch.ps1`
  - imports shared policy module
  - prints low-noise policy context for all dispatch modes, including NetworkPreflight, SerialPreflightPlan, NaabuPlan, ADRegisteredPlan, and SubnetConfirmPlan
- Updated `docs/LOW_NOISE_PROBE_PRINCIPLES.md`
  - names `scripts/SasLowNoisePolicy.psm1` as the canonical implementation surface
- Updated static contracts to require the shared policy across lanes

## Principle being enforced

- Five probes are unnecessary when a device was already recently reachable or identity-confirmed.
- If retrying is justified, prefer a different time of day or different day of week over immediate repeated probes.
- The network sees packets, not the shell.
- Fresh evidence should reduce habitual re-probing.

## Safety

This is authorized low-noise survey guidance and artifact hygiene. It does not add credential collection, target mutation, telemetry suppression, stealth behavior, or broad scan behavior.

No live serials, hostnames, IPs, MACs, AD exports, credentials, or generated evidence committed.

## Validation expectation

- Dashboard Smoke
- Pester
- Survey doctrine

Merge policy: merge_when_green.