### PR TITLE
Add SysAdminSuite AI harness workflow layer

### DIFF
--- a/.archon/workflows/sas-docs-only.yaml
+++ b/.archon/workflows/sas-docs-only.yaml
@@ -1,0 +1,30 @@
+name: sas-docs-only
+description: Documentation-only SysAdminSuite workflow with local-data guardrails.
+inputs:
+  - request_summary
+  - doc_paths
+phases:
+  - id: load-context
+    actions:
+      - read AGENTS.md
+      - read CLAUDE.md
+      - read CODEBASE_MAP.md
+      - read relevant source-of-truth docs only
+  - id: guard-local-data
+    actions:
+      - avoid live target CSVs, workbooks, host lists, serial lists, MAC exports, scan output, dashboards, ZIP bundles, and local evidence
+      - use generic local reference wording only
+  - id: edit-docs
+    actions:
+      - keep wording authorized, read-only, low-noise, scoped, bounded, local evidence, dry-run, and validation-first
+      - avoid changing runtime behavior
+  - id: validate
+    actions:
+      - run a docs/static validator when available
+      - for AI layer docs, run tools/validate-ai-layer.ps1
+  - id: summarize
+    actions:
+      - describe documentation changes
+      - state runtime behavior was intentionally not changed
+validation:
+  ai_layer: pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1

--- a/.archon/workflows/sas-survey-change.yaml
+++ b/.archon/workflows/sas-survey-change.yaml
@@ -1,0 +1,48 @@
+name: sas-survey-change
+description: SysAdminSuite survey change workflow with authorized, read-only, low-noise, scoped validation.
+inputs:
+  - request_summary
+  - touched_paths
+phases:
+  - id: load-doctrine
+    actions:
+      - read AGENTS.md
+      - read CLAUDE.md
+      - read CODEBASE_MAP.md
+      - read survey/README.md
+      - read docs/OPERATIONAL_POSTURE.md
+  - id: classify-scope
+    actions:
+      - confirm whether change is docs/config, survey script, dashboard, mapping, or validation
+      - confirm no live target material is needed
+  - id: plan
+    actions:
+      - choose smallest Bash-first change
+      - preserve PowerShell files unless explicitly requested
+      - define local evidence paths if artifacts are generated
+  - id: implement
+    actions:
+      - edit only scoped files
+      - keep survey probes read-only toward targets
+  - id: validate
+    actions:
+      - run scoped validation only
+      - do not require network access
+      - do not run live probes unless explicitly authorized outside this workflow
+  - id: summarize
+    actions:
+      - list files changed
+      - list intentionally unchanged runtime behavior
+      - list validation command and result
+artifacts:
+  allowed:
+    - tracked docs
+    - tracked config
+    - synthetic fixtures
+  local_only:
+    - survey/output/
+    - survey/artifacts/
+    - logs/nmap/
+    - logs/targets/
+validation:
+  default: pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1

--- a/.archon/workflows/sas-validate-pr.yaml
+++ b/.archon/workflows/sas-validate-pr.yaml
@@ -26,6 +26,7 @@ phases:
       - include intentionally unchanged areas
       - include exact validation commands and results
 validation:
+  ai_layer: pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1
   no_live_data: required
   scoped_checks: required
   exact_results: required

--- a/.archon/workflows/sas-validate-pr.yaml
+++ b/.archon/workflows/sas-validate-pr.yaml
@@ -1,0 +1,31 @@
+name: sas-validate-pr
+description: Pre-PR validation workflow for SysAdminSuite changes.
+inputs:
+  - changed_files
+phases:
+  - id: inspect-diff
+    actions:
+      - run git status --short
+      - inspect staged and unstaged diffs
+      - confirm no protected local data is included
+  - id: choose-validation
+    actions:
+      - use .claude/skills/scoped-validation/SKILL.md
+      - select the smallest checks covering changed paths
+  - id: run-validation
+    actions:
+      - run selected checks without network access unless the task explicitly requires it
+      - do not run live probes for docs/config-only changes
+  - id: review-results
+    actions:
+      - record pass, warning, or fail accurately
+      - separate environment limitations from product failures
+  - id: final-summary
+    actions:
+      - include summary of files changed
+      - include intentionally unchanged areas
+      - include exact validation commands and results
+validation:
+  no_live_data: required
+  scoped_checks: required
+  exact_results: required

--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -1,0 +1,20 @@
+# SysAdminSuite Explorer Agent
+
+Purpose: answer specific repo questions with minimal context and no code edits.
+
+## Rules
+
+- Read `AGENTS.md`, `CLAUDE.md`, and `CODEBASE_MAP.md` first.
+- Prefer targeted file reads and `rg` over broad scans.
+- Do not open or summarize live/local data paths.
+- Do not modify files.
+- Report exact files reviewed and commands used.
+- Preserve Bash-first guidance and PowerShell file preservation rules.
+- For survey questions, apply low-noise survey discipline and distinguish local smoke evidence from network-feature validation.
+
+## Output format
+
+- Answer
+- Files reviewed
+- Commands used
+- Uncertainties or follow-up checks

--- a/.claude/skills/live-data-guard/SKILL.md
+++ b/.claude/skills/live-data-guard/SKILL.md
@@ -1,0 +1,24 @@
+# Live Data Guard Skill
+
+Use this skill before reading, creating, moving, staging, or committing files that may contain operator-local or live environment data.
+
+## Protected material
+
+Do not commit live target CSVs, workbooks, host lists, serial lists, MAC exports, scan output, Nmap/Naabu logs, dashboards, ZIP bundles, local evidence, user-profile paths, or local reference-tree paths/names.
+
+## Allowed tracked material
+
+- Synthetic fixtures, samples, examples, and templates in approved tracked locations.
+- Documentation that describes generic local paths without revealing operator-local folder names.
+- Validators that inspect file names and content without opening live artifacts.
+
+## Required checks
+
+1. Review `.claudeignore`, `.gitignore`, `docs/LOCAL_REFERENCE_POLICY.md`, and `targets/README.md` when local data may be nearby.
+2. Use `git status --short` before committing.
+3. Inspect the diff for local paths, usernames, hostnames, and live artifact names.
+4. Keep evidence in local ignored paths such as `survey/output/`, `survey/artifacts/`, `logs/nmap/`, or `logs/targets/`.
+
+## Preferred wording
+
+Use authorized, read-only, local evidence, scoped, bounded, dry-run, and validation-first.

--- a/.claude/skills/scoped-validation/SKILL.md
+++ b/.claude/skills/scoped-validation/SKILL.md
@@ -1,0 +1,33 @@
+# Scoped Validation Skill
+
+Use this skill whenever an AI-assisted change needs validation.
+
+## Steps
+
+1. Classify the touched files.
+2. Prefer the smallest deterministic check that covers the change.
+3. Do not run live probes or require network access for documentation/config-only changes.
+4. For AI harness changes, run:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1
+```
+
+5. If `pwsh` is unavailable, report that limitation clearly and do not claim the validator passed.
+
+## Scope matrix
+
+| Change type | Preferred validation |
+|---|---|
+| AI harness docs/config | `tools/validate-ai-layer.ps1` |
+| Bash survey scripts | Relevant `tests/bash/` contract test plus static shell checks when available |
+| PowerShell tooling | Existing Pester or targeted script validation requested by the user |
+| .NET dashboard/managed code | `dotnet test` for the relevant solution/project |
+| Docs only outside harness | Link check or targeted static review when available |
+
+## Guardrails
+
+- Keep validation scoped and bounded.
+- Do not invent a pass result.
+- Separate local smoke tests from network-feature validation.
+- Preserve local evidence in ignored paths only.

--- a/.claude/skills/survey-low-noise/SKILL.md
+++ b/.claude/skills/survey-low-noise/SKILL.md
@@ -1,0 +1,21 @@
+# Survey Low-Noise Skill
+
+Use this skill for survey, preflight, packet-probe, Naabu/Nmap, target-intake, or dashboard probe changes.
+
+## Doctrine
+
+- Treat AD-derived or approved manifests as the population authority.
+- Treat Naabu/Nmap output as reachability evidence only.
+- Use suite wrappers: `survey/sas-run-naabu-pipeline.sh` or `survey/sas-run-packet-probe.sh`.
+- Keep `-silent` on Naabu pipelines.
+- Keep `-ec` on reachability profiles unless the profile documents why CDN edges are intentionally in scope.
+- Require explicit gates for UDP, all-port, public-target, or subnet host-discovery profiles.
+- Write artifacts only to local ignored output paths.
+- Classify guest-network failures as `ENVIRONMENT_BLOCKED_GUEST_NETWORK`, not product failure.
+
+## Change process
+
+1. Read `docs/OPERATIONAL_POSTURE.md`, `survey/README.md`, and the relevant survey docs.
+2. Make the smallest Bash-first change.
+3. Do not edit PowerShell files unless the user explicitly asked for PowerShell work.
+4. Validate with scoped, non-live checks unless the user requested an approved field run.

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,27 @@
+# SysAdminSuite local/live data guardrails
+targets/local/
+logs/targets/
+survey/input/
+survey/output/
+survey/artifacts/
+logs/nmap/
+Mapping/Output/GuiRuns/
+mapping/Output/GuiRuns/
+runs/
+*.xlsx
+*.xlsm
+*.xls
+*.csv
+!targets/sanitized/**/*.csv
+!**/*.sample.csv
+!**/*.example.csv
+!**/*.fixture.csv
+*.zip
+*.7z
+*.pcap
+*.pcapng
+*.nessus
+*.nmap
+*.gnmap
+*.jsonl
+*.har

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# SysAdminSuite AI Harness Guide
+
+## Source of truth
+
+Read `AGENTS.md`, `docs/HARNESS_COMPLETION_PLAN.md`, and `docs/ENGLISH_LOG_ARTIFACT_CONTRACT.md` before planning AI-assisted work. Do not duplicate those planning docs; use this file as the agent/workflow front door.
+
+## Operating rules
+
+- Keep SysAdminSuite Bash-first for Northwell-targeted field work.
+- Preserve all `.ps1`, `.psm1`, and `.psd1` files unless the user explicitly asks for PowerShell changes.
+- Treat survey and dashboard probes as authorized, read-only validation that writes local evidence only.
+- Keep changes scoped, bounded, dry-run friendly, and validation-first.
+- Keep live target material, workbooks, host lists, serial lists, MAC exports, scan output, ZIP bundles, dashboards, and local evidence out of commits.
+- Use `.claudeignore`, `.gitignore`, `docs/LOCAL_REFERENCE_POLICY.md`, and `targets/README.md` before opening or staging local data.
+- Use low-noise survey discipline and the suite wrappers for reachability validation.
+- For dashboard field users, keep the double-click launcher as the default front door.
+
+## Required workflow loop
+
+1. Classify the request: docs/config only, survey harness, runtime code, dashboard, mapping, or validation.
+2. Load the smallest relevant context using `CODEBASE_MAP.md`.
+3. Run the live-data guard before reading, generating, or staging artifacts.
+4. Make the smallest safe change.
+5. Run scoped validation. Prefer static validators for docs/config changes.
+6. Summarize what changed, what was intentionally not changed, and the exact validation command.
+
+## Harness skills
+
+- `.claude/skills/scoped-validation/SKILL.md` — choose bounded checks for a change.
+- `.claude/skills/live-data-guard/SKILL.md` — keep local data and operator evidence out of AI context and commits.
+- `.claude/skills/survey-low-noise/SKILL.md` — preserve low-noise survey doctrine.
+
+## Safety vocabulary
+
+Preferred wording: authorized, read-only, low-noise, scoped, bounded, local evidence, dry-run, validation-first, operator-approved, local ignored paths.

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -1,0 +1,39 @@
+# SysAdminSuite Codebase Map
+
+Use this map to load only the files needed for a task.
+
+## Repo doctrine
+
+- `AGENTS.md` — agent rules, Bash-first hierarchy, PowerShell preservation, low-noise survey doctrine, and local reference guardrails.
+- `README.md` — user entrypoint, repo layout, runtime policy, and local source folder policy.
+- `docs/HARNESS_COMPLETION_PLAN.md` — source of truth for AI harness completion sequencing.
+- `docs/ENGLISH_LOG_ARTIFACT_CONTRACT.md` — source of truth for future English report/run-context artifacts.
+- `docs/OPERATIONAL_POSTURE.md` — lane model for survey, dashboard probes, deployment, mapping, and teardown.
+- `docs/LOCAL_REFERENCE_POLICY.md` — rules for gitignored operator-local reference material.
+
+## Survey and low-noise files
+
+- `survey/README.md` — Bash-on-Windows survey entrypoints and field command standards.
+- `survey/naabu_profiles.json` — doctrine source for approved Naabu profiles.
+- `Config/cybernet-naabu-profiles.json` — generated runtime profile config.
+- `survey/sas-run-naabu-pipeline.sh` and `survey/sas-run-packet-probe.sh` — preferred packet-probe wrappers.
+- `docs/LOW_NOISE_SURVEY_DOCTRINE.md` — narrative low-noise policy.
+- `docs/SURVEY_LANES.md` and `targets/README.md` — local target intake and tracked fixture boundaries.
+
+## Dashboard and user entry
+
+- `docs/DASHBOARD_ENTRYPOINT.md` — canonical field and IT/developer launcher guidance.
+- `START-HERE-SysAdminSuite-Dashboard.bat` — field-user dashboard launcher.
+- `Launch-SysAdminSuiteDashboard.Host.bat` — IT/developer dashboard launcher.
+
+## Validation and tests
+
+- `tools/validate-ai-layer.ps1` — static validator for this AI harness layer.
+- `tests/bash/` — Bash contract and smoke tests.
+- `Tests/Pester/` — PowerShell test suite for existing Windows tooling.
+- `SysAdminSuite.sln` and `managed-tests/` — .NET validation surface.
+
+## Local data boundaries
+
+- `targets/local/`, `logs/targets/`, `survey/input/`, `survey/output/`, `survey/artifacts/`, `logs/nmap/`, and `Mapping/Output/GuiRuns/` are local/evidence areas unless a tracked sample path explicitly says otherwise.
+- Tracked examples belong under approved sanitized, fixture, sample, or template paths.

--- a/docs/AI_LAYER.md
+++ b/docs/AI_LAYER.md
@@ -1,0 +1,45 @@
+# SysAdminSuite AI Harness Layer
+
+## Purpose
+
+The SysAdminSuite AI harness layer gives future AI-assisted changes a clear repo front door, scoped workflow templates, local-data guardrails, and repeatable validation. It implements the next small slice from `docs/HARNESS_COMPLETION_PLAN.md` without duplicating the English report renderer or run-context implementation planned there.
+
+## Added harness surfaces
+
+| Path | Role |
+|---|---|
+| `CLAUDE.md` | Agent-facing repo rules and workflow loop |
+| `CODEBASE_MAP.md` | Minimal context map for targeted file loading |
+| `.claudeignore` | AI context exclusions for local/live data and evidence |
+| `.claude/skills/scoped-validation/SKILL.md` | Bounded validation selection guidance |
+| `.claude/skills/live-data-guard/SKILL.md` | Guardrails for local data and operator evidence |
+| `.claude/skills/survey-low-noise/SKILL.md` | Survey doctrine for low-noise reachability validation |
+| `.claude/agents/explorer.md` | Read-only explorer role for specific repo questions |
+| `.archon/workflows/*.yaml` | Lightweight workflow templates for survey, docs, and PR validation |
+| `tools/validate-ai-layer.ps1` | Offline static validator for the AI harness layer |
+
+## Operating boundaries
+
+This layer is documentation, configuration, and validation only. It does not change survey runtime scripts, probing logic, Nmap/Naabu behavior, AD lookup behavior, dashboard UI behavior, printer mapping runtime behavior, or PowerShell runtime scripts.
+
+AI-assisted work should remain authorized, read-only where survey or dashboard probes are involved, low-noise, scoped, bounded, local-evidence oriented, dry-run friendly, and validation-first.
+
+## Local data boundary
+
+The harness must not pull live target material into prompts or commits. Protected material includes workbooks, live target CSVs, host lists, serial lists, MAC exports, scan output, Nmap/Naabu logs, dashboard exports, ZIP bundles, local evidence, user-profile paths, and operator-local reference paths or names.
+
+Use tracked synthetic fixtures or samples when examples are needed. Keep operational evidence in ignored local paths documented by `.claudeignore`, `.gitignore`, `targets/README.md`, and `docs/LOCAL_REFERENCE_POLICY.md`.
+
+## Validation
+
+Run the AI layer validator after changing these files:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1
+```
+
+The validator is offline and static. It checks required files, required safety phrases, excluded local/evidence paths, workflow YAML presence, and unsafe wording in harness docs.
+
+## Follow-up from PR #140
+
+The later implementation should build the English report renderer and run-context artifacts described in `docs/ENGLISH_LOG_ARTIFACT_CONTRACT.md`. That future slice should render reports from structured JSON and artifact registries instead of making narrative text a separate source of truth.

--- a/tools/validate-ai-layer.ps1
+++ b/tools/validate-ai-layer.ps1
@@ -1,0 +1,150 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $repoRoot
+
+$requiredFiles = @(
+  'CLAUDE.md',
+  'CODEBASE_MAP.md',
+  '.claudeignore',
+  '.claude/skills/scoped-validation/SKILL.md',
+  '.claude/skills/live-data-guard/SKILL.md',
+  '.claude/skills/survey-low-noise/SKILL.md',
+  '.claude/agents/explorer.md',
+  '.archon/workflows/sas-survey-change.yaml',
+  '.archon/workflows/sas-docs-only.yaml',
+  '.archon/workflows/sas-validate-pr.yaml',
+  'docs/AI_LAYER.md',
+  'tools/validate-ai-layer.ps1'
+)
+
+$workflowFiles = @(
+  '.archon/workflows/sas-survey-change.yaml',
+  '.archon/workflows/sas-docs-only.yaml',
+  '.archon/workflows/sas-validate-pr.yaml'
+)
+
+$harnessDocs = @(
+  'CLAUDE.md',
+  'CODEBASE_MAP.md',
+  '.claude/skills/scoped-validation/SKILL.md',
+  '.claude/skills/live-data-guard/SKILL.md',
+  '.claude/skills/survey-low-noise/SKILL.md',
+  '.claude/agents/explorer.md',
+  '.archon/workflows/sas-survey-change.yaml',
+  '.archon/workflows/sas-docs-only.yaml',
+  '.archon/workflows/sas-validate-pr.yaml',
+  'docs/AI_LAYER.md'
+)
+
+$requiredSafetyPhrases = @(
+  'authorized',
+  'read-only',
+  'low-noise',
+  'scoped',
+  'bounded',
+  'local evidence',
+  'dry-run',
+  'validation-first'
+)
+
+$requiredIgnoreEntries = @(
+  'targets/local/',
+  'logs/targets/',
+  'survey/input/',
+  'survey/output/',
+  'survey/artifacts/',
+  'logs/nmap/',
+  'Mapping/Output/GuiRuns/',
+  'runs/',
+  '*.xlsx',
+  '*.zip'
+)
+
+$unsafeTerms = @(
+  'ste' + 'alth',
+  'eva' + 'sion',
+  'hi' + 'ding',
+  'by' + 'passing logs',
+  'defe' + 'ating monitoring',
+  'keeping q' + 'uiet',
+  'avoiding det' + 'ection'
+)
+
+$failures = New-Object System.Collections.Generic.List[string]
+$passes = 0
+
+function Add-Pass($Message) {
+  $script:passes++
+  Write-Host "[PASS] $Message"
+}
+
+function Add-Fail($Message) {
+  $script:failures.Add($Message) | Out-Null
+  Write-Host "[FAIL] $Message"
+}
+
+Write-Host 'SYSADMIN AI LAYER VALIDATION'
+
+foreach ($file in $requiredFiles) {
+  if (Test-Path -LiteralPath $file -PathType Leaf) {
+    Add-Pass "required file exists: $file"
+  } else {
+    Add-Fail "missing required file: $file"
+  }
+}
+
+foreach ($file in $workflowFiles) {
+  if (Test-Path -LiteralPath $file -PathType Leaf) {
+    $content = Get-Content -LiteralPath $file -Raw
+    if ($content -match '(?m)^name:' -and $content -match '(?m)^phases:' -and $content -match '(?m)^validation:') {
+      Add-Pass "workflow has required sections: $file"
+    } else {
+      Add-Fail "workflow missing name/phases/validation section: $file"
+    }
+  }
+}
+
+$combinedHarnessText = ''
+foreach ($file in $harnessDocs) {
+  if (Test-Path -LiteralPath $file -PathType Leaf) {
+    $combinedHarnessText += "`n" + (Get-Content -LiteralPath $file -Raw)
+  }
+}
+
+foreach ($phrase in $requiredSafetyPhrases) {
+  if ($combinedHarnessText.IndexOf($phrase, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+    Add-Pass "required safety phrase present: $phrase"
+  } else {
+    Add-Fail "required safety phrase missing: $phrase"
+  }
+}
+
+foreach ($term in $unsafeTerms) {
+  if ($combinedHarnessText.IndexOf($term, [System.StringComparison]::OrdinalIgnoreCase) -ge 0) {
+    Add-Fail "unsafe wording found in harness docs: $term"
+  } else {
+    Add-Pass "unsafe wording absent from harness docs: $term"
+  }
+}
+
+if (Test-Path -LiteralPath '.claudeignore' -PathType Leaf) {
+  $ignoreText = Get-Content -LiteralPath '.claudeignore' -Raw
+  foreach ($entry in $requiredIgnoreEntries) {
+    if ($ignoreText -match [regex]::Escape($entry)) {
+      Add-Pass ".claudeignore includes: $entry"
+    } else {
+      Add-Fail ".claudeignore missing: $entry"
+    }
+  }
+}
+
+if ($failures.Count -gt 0) {
+  Write-Host "Result: $passes passed, $($failures.Count) failed"
+  exit 1
+}
+
+Write-Host "Result: $passes passed, 0 failed"
+exit 0


### PR DESCRIPTION
### Motivation

- Provide a small, deterministic AI harness layer (Helpline/Archon-style) so future AI-assisted changes follow explicit repo rules, scoped validation, local-data guardrails, and repeatable workflow templates while reusing existing planning docs as source of truth.
- Keep this change strictly documentation/configuration/validation scoped and preserve all runtime behavior and PowerShell artifacts as required by repo doctrine.

### Description

- Added agent-facing and guidance files: `CLAUDE.md`, `CODEBASE_MAP.md`, `.claudeignore`, `.claude/agents/explorer.md`, and `docs/AI_LAYER.md` to define the harness front door, minimal code-map, and local-data boundaries.
- Added three Claude skills under `.claude/skills/`: `scoped-validation/SKILL.md`, `live-data-guard/SKILL.md`, and `survey-low-noise/SKILL.md` documenting validation selection, live-data guardrails, and low-noise survey doctrine.
- Added lightweight Archon-style workflow templates under `.archon/workflows/`: `sas-survey-change.yaml`, `sas-docs-only.yaml`, and `sas-validate-pr.yaml` to encode canonical phases (load, classify, plan, implement, validate, summarize).
- Added an offline static validator `tools/validate-ai-layer.ps1` that checks for required harness files, required safety phrases, absence of unsafe wording, `.claudeignore` entries, and minimal workflow YAML structure.

### Testing

- Performed a static scan of the new harness docs for forbidden/unsafe terms (e.g., "stealth", "evasion", "hiding", "bypassing logs", "defeating monitoring"); no matches were found (pass).
- Attempted to run the offline validator with `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1`, but `pwsh` is not installed in this environment so the validator could not be executed here and its checks were not run (environment limitation).
- The validator script exists and, when run in an environment with PowerShell Core available, will perform the required automated checks (required-file presence, safety-phrase coverage, unsafe-word absence, and `.claudeignore` entries).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c258782fc832fb50229c5a815c6dd)