### PR TITLE
feat(survey): codify low-noise Cybernet port fallback policy

### DIFF
--- a/Tests/bash/test_naabu_profile_sync.sh
+++ b/Tests/bash/test_naabu_profile_sync.sh
@@ -10,8 +10,10 @@ cd "$ROOT"
 DOCTRINE="survey/naabu_profiles.json"
 RUNTIME="Config/cybernet-naabu-profiles.json"
 GEN="survey/sas-generate-naabu-runtime-profiles.sh"
+LOW_NOISE="scripts/SasLowNoisePolicy.psm1"
+PS_PREFLIGHT="survey/sas-network-preflight.ps1"
 
-for f in "$DOCTRINE" "$RUNTIME" "$GEN"; do
+for f in "$DOCTRINE" "$RUNTIME" "$GEN" "$LOW_NOISE" "$PS_PREFLIGHT"; do
   [[ -f "$f" ]] || { echo "missing: $f"; exit 1; }
 done
 
@@ -34,24 +36,38 @@ PY
 )"
 [[ "$DEFAULT_PROFILE" == "keyports_cybernet_json" ]] || { echo "unexpected default profile: $DEFAULT_PROFILE"; exit 1; }
 
+EXPECTED_PORTS="80,443,135,445,3389,5985,5986"
+
+# PowerShell preflight must consume the shared low-noise default instead of reintroducing a second hardcoded default.
+grep -qF 'function Get-SasDefaultCybernetTcpPorts' "$LOW_NOISE" || { echo 'low-noise module missing Get-SasDefaultCybernetTcpPorts'; exit 1; }
+grep -qF 'return @(80, 443, 135, 445, 3389, 5985, 5986)' "$LOW_NOISE" || { echo 'low-noise module default ports drifted'; exit 1; }
+grep -qF '$Ports = @(Get-SasDefaultCybernetTcpPorts)' "$PS_PREFLIGHT" || { echo 'PowerShell preflight must load default ports from SasLowNoisePolicy'; exit 1; }
+if grep -qF '@(135, 445, 3389, 9100)' "$PS_PREFLIGHT"; then
+  echo 'PowerShell preflight must not keep the old 9100 default'
+  exit 1
+fi
+
 # Doctrine principle checks on the runtime representation.
-"$PYTHON_BIN" - "$RUNTIME" <<'PY'
+"$PYTHON_BIN" - "$RUNTIME" "$EXPECTED_PORTS" <<'PY'
 import json, sys
 
 cfg = json.load(open(sys.argv[1], encoding="utf-8"))
+expected_ports = sys.argv[2]
 profiles = cfg["profiles"]
 errors = []
 
 # Default key-port profile must carry full Windows key ports + JSON output.
 kp = profiles["keyports_cybernet_json"]
-if kp.get("ports") != "80,443,135,445,3389,5985,5986":
+if kp.get("ports") != expected_ports:
     errors.append("keyports_cybernet_json wrong ports: %s" % kp.get("ports"))
+if "9100" in str(kp.get("ports", "")):
+    errors.append("keyports_cybernet_json must not include printer port 9100 by default")
 if kp.get("outputFormat") != "json":
     errors.append("keyports_cybernet_json must be json output")
 
 # Pipe profile shares ports but is txt (no durable json).
 pipe = profiles["keyports_cybernet_pipe"]
-if pipe.get("ports") != "80,443,135,445,3389,5985,5986":
+if pipe.get("ports") != expected_ports:
     errors.append("keyports_cybernet_pipe wrong ports")
 if pipe.get("outputFormat") != "txt":
     errors.append("keyports_cybernet_pipe must be txt output")
@@ -61,8 +77,14 @@ if profiles["udp_dns_snmp_json"].get("requiresJustification") is not True:
     errors.append("udp_dns_snmp_json must require justification")
 if profiles["allports_low_noise_json"].get("requiresJustification") is not True:
     errors.append("allports_low_noise_json must require justification")
+if profiles["allports_low_noise_json"].get("allowFullPorts") is not True:
+    errors.append("allports_low_noise_json must require explicit full-port approval")
 if profiles["host_discovery_web_syn_txt"].get("requiresApprovedSubnetScope") is not True:
     errors.append("host_discovery_web_syn_txt must require approved subnet scope")
+if profiles["load_balanced_hostname_all_ips_json"].get("scanAllIps") is not True:
+    errors.append("load_balanced_hostname_all_ips_json must preserve -sa scan-all-IPs behavior")
+if profiles["load_balanced_hostname_all_ips_json"].get("requiresHost") is not True:
+    errors.append("load_balanced_hostname_all_ips_json must require host input")
 
 # Every reachability/discovery profile is silent and CDN-excluding by default.
 for name, p in profiles.items():
@@ -82,4 +104,4 @@ if errors:
     sys.exit(1)
 PY
 
-printf 'Naabu profile sync contracts passed.\n'
+printf 'Naabu profile sync contracts passed. Default Cybernet ports: %s\n' "$EXPECTED_PORTS"

--- a/docs/ENGLISH_LOG_ARTIFACT_CONTRACT.md
+++ b/docs/ENGLISH_LOG_ARTIFACT_CONTRACT.md
@@ -66,6 +66,27 @@ still_silent_count
 stale_or_conflicting_count
 persistent_silent_time_diverse_count
 plateau_detected
+default_profile
+open_default_port_target_count
+web_only_reachable_count
+admin_surface_reachable_count
+default_ports_blocked_or_filtered_count
+fallback_profile_recommended
+fallback_requires_approval
+all_ports_allowed
+fallback_decision
+blocked_default_ports_guidance
+```
+
+Port fallback reports should use these decision names:
+
+```text
+default_ok
+web_only_fallback
+approved_subnet_host_discovery_required
+udp_justification_required
+all_ports_denied_without_explicit_gate
+review_required
 ```
 
 ## English report template
@@ -102,6 +123,26 @@ Fresh reachability evidence should reduce re-probing. If a target is still silen
 
 Next action:
 {next_action}
+```
+
+A port fallback report should read like:
+
+```text
+SysAdminSuite checked {target_count} approved target(s) from {target_file}.
+
+The default Cybernet TCP profile {default_profile} checked ports {ports_requested}.
+Network activity was performed. Evidence was written locally to {network_preflight_csv}.
+No files, scripts, or logs were written to target workstations. Assume enterprise network monitoring may observe authorized traffic.
+
+Results:
+- {open_default_port_target_count} target(s) answered on at least one default port.
+- {web_only_reachable_count} target(s) answered only on web ports 80/443.
+- {admin_surface_reachable_count} target(s) answered on Windows/admin surface ports.
+- {default_ports_blocked_or_filtered_count} target(s) were silent on the default profile.
+
+Decision:
+{fallback_decision}. Recommended fallback profile: {fallback_profile_recommended}. Approval required: {fallback_requires_approval}. All-port scan allowed: {all_ports_allowed}.
+{blocked_default_ports_guidance}
 ```
 
 ## Required report sections
@@ -163,6 +204,17 @@ Minimum shape:
 }
 ```
 
+Additional network survey roles:
+
+```text
+naabu_json_evidence
+naabu_raw_pipeline_stream
+cybernet_detect_jsonl
+network_preflight_csv
+port_fallback_decision
+network_english_report
+```
+
 Synthetic test registries may be tracked only under approved fixture/sample paths.
 
 ## Log event contract
@@ -205,6 +257,7 @@ English logs should be concise and factual:
 - Say whether network activity occurred.
 - Say why rows were staged, skipped, or routed to review.
 - Include low-noise retry context when relevant.
+- Include port profile and fallback decision context when relevant.
 - Avoid raw dumps.
 - Avoid hiding uncertainty.
 - Avoid stealth/no-trace/bypass language.
@@ -219,6 +272,7 @@ English logs should be concise and factual:
 | `serial_preflight.review.required` | `{review_required_count} serial(s) remain review-required because no probe-ready bridge was found.` |
 | `network_preflight.started` | `Started bounded network preflight for {target_count} target(s) on ports {ports_requested}.` |
 | `network_preflight.completed` | `Network preflight completed and wrote {network_preflight_csv}.` |
+| `network_preflight.port_fallback.classified` | `Classified {default_ports_blocked_or_filtered_count} target(s) as silent on the default profile. Fallback decision: {fallback_decision}.` |
 | `iteration.plateau.detected` | `No new successful evidence appeared across comparable runs; route the remaining rows to review instead of repeating immediately.` |
 | `live_data.audit.warning` | `The advisory audit found {warning_count} possible live-data risk(s). Review before committing.` |
 
@@ -238,63 +292,3 @@ Inputs:
 -Template serial-preflight|network-preflight|iteration|audit
 -OutputPath <path>
 ```
-
-Rules:
-
-- Renderer performs no network activity.
-- Renderer reads JSON/artifacts only.
-- Renderer should not require live data for tests.
-- Renderer should fail clearly if required variables are missing.
-- Renderer should preserve uncertainty instead of inventing conclusions.
-
-## Fixture strategy
-
-Synthetic fixtures should live under:
-
-```text
-survey/fixtures/english-log/
-```
-
-Suggested fixtures:
-
-```text
-serial_preflight_summary.sample.json
-serial_preflight_artifact_registry.sample.json
-network_preflight_summary.sample.json
-network_preflight_artifact_registry.sample.json
-```
-
-## Required tests
-
-Add:
-
-```text
-Tests/bash/test_english_log_artifact_contracts.sh
-```
-
-Tests must prove:
-
-1. Renderer exists and parses.
-2. Fixture summary JSON contains required variables.
-3. Fixture artifact registry contains source, summary, report, and handoff roles.
-4. Rendered report includes request/source/evidence/action/network status/next action.
-5. Serial report says planner performed no network activity.
-6. Network preflight report says network activity occurred.
-7. Missing required variables fail clearly.
-8. Output does not contain raw live-looking hostnames, serials, MACs, or IPs in tracked fixtures.
-9. Report includes low-noise retry guidance.
-10. Renderer does not run network commands.
-
-## Acceptance criteria
-
-This contract is satisfied when a future sprint can run:
-
-```powershell
-.\scripts\Render-SasEnglishReport.ps1 `
-  -SummaryJson .\survey\fixtures\english-log\serial_preflight_summary.sample.json `
-  -ArtifactRegistry .\survey\fixtures\english-log\serial_preflight_artifact_registry.sample.json `
-  -Template serial-preflight `
-  -OutputPath .\survey\output\english-log\serial_preflight_report.md
-```
-
-and the result reads like an operator report rather than a raw data dump.

--- a/docs/LOW_NOISE_SURVEY_DOCTRINE.md
+++ b/docs/LOW_NOISE_SURVEY_DOCTRINE.md
@@ -118,10 +118,48 @@ naabu -list logs/targets/<site>_confirm_hosts.txt -silent -ec \
 naabu -list logs/targets/<site>_confirm_hosts.txt -p 80,443,135,445,3389,5985,5986 -json -silent -ec -o logs/nmap/<site>_<runid>_keyports.json
 ```
 
+The default Cybernet TCP profile is intentionally bounded:
+
+```text
+80,443,135,445,3389,5985,5986
+```
+
+`9100` is not part of the default Cybernet profile. Add printer/device-specific
+ports only through a separate documented profile or an explicit operator-supplied
+port list.
+
+### Blocked default ports and backup policy
+
+If the default Cybernet ports are blocked or filtered, do not broaden automatically.
+Blocked defaults are a result classification, not permission to scan every port.
+
+Fallback decisions must use named profiles:
+
+| Condition | Decision | Profile |
+| --- | --- | --- |
+| At least one default port answers and no silent targets remain | `default_ok` | `keyports_cybernet_json` |
+| Default Windows/admin surfaces are blocked but a bounded web check is still useful | `web_only_fallback` | `web_reachability_only_json` |
+| Approved subnet liveness is needed without treating discovery as population | `approved_subnet_host_discovery_required` | `host_discovery_web_syn_txt` |
+| UDP evidence is required by the Cybernet survey | `udp_justification_required` | `udp_dns_snmp_json` |
+| All TCP ports are requested without the explicit all-port gate | `all_ports_denied_without_explicit_gate` | none |
+| Evidence is missing, stale, or ambiguous | `review_required` | none |
+
+English reports should say what happened in plain language:
+
+```text
+Default Cybernet ports were checked with silent mode and CDN exclusion enabled.
+Evidence was written locally only. No files, scripts, or logs were written to target workstations.
+Some targets were silent on the default profile. Do not broaden automatically; use the named fallback profile that answers the survey question.
+```
+
 ### All ports, only when justified
 
 ```bash
 naabu -list logs/targets/<site>_confirm_hosts.txt -p - -json -silent -ec -o logs/nmap/<site>_<runid>_allports.json
+```
+
+```text
+All TCP port profiles require explicit justification and a small approved target set. They are never default.
 ```
 
 ### UDP optional profile
@@ -166,7 +204,8 @@ Do not commit live JSON, TXT, CSV, ZIP, or XLSX evidence.
 ## Profiles and tooling
 
 - Canonical doctrine profiles: [`survey/naabu_profiles.json`](../survey/naabu_profiles.json)
-- Profile contract validator: [`tests/bash/smoke-naabu-profiles.sh`](../tests/bash/smoke-naabu-profiles.sh)
+- Profile contract validator: [`Tests/bash/smoke-naabu-profiles.sh`](../Tests/bash/smoke-naabu-profiles.sh)
+- Runtime sync validator: [`Tests/bash/test_naabu_profile_sync.sh`](../Tests/bash/test_naabu_profile_sync.sh)
 - Render-only command helper: [`survey/sas-naabu-profile-command.sh`](../survey/sas-naabu-profile-command.sh)
 - Operational naabu runbook (runtime config): [`docs/NAABU_CYBERNET_PROFILES.md`](NAABU_CYBERNET_PROFILES.md)
 - WAB field gate (Phase 2b): [`docs/WAB_TEST_READINESS.md`](WAB_TEST_READINESS.md)

--- a/scripts/SasLowNoisePolicy.psm1
+++ b/scripts/SasLowNoisePolicy.psm1
@@ -12,12 +12,135 @@ scope, ports, rate, retries, freshness, evidence reuse, and staging only justifi
 
 Set-StrictMode -Version 2.0
 
-function Get-SasLowNoisePolicy {
+function Get-SasDefaultCybernetTcpPorts {
+    [CmdletBinding()]
+    param()
+
+    return @(80, 443, 135, 445, 3389, 5985, 5986)
+}
+
+function Get-SasWebReachabilityPorts {
+    [CmdletBinding()]
+    param()
+
+    return @(80, 443)
+}
+
+function Get-SasAdminSurfacePorts {
+    [CmdletBinding()]
+    param()
+
+    return @(135, 445, 3389, 5985, 5986)
+}
+
+function Get-SasPortFallbackPolicy {
     [CmdletBinding()]
     param()
 
     return [pscustomobject]@{
-        PolicyVersion = '1.0'
+        DefaultProfile = 'keyports_cybernet_json'
+        DefaultCybernetTcpPorts = @(Get-SasDefaultCybernetTcpPorts)
+        RawPipelineProfile = 'keyports_cybernet_pipe'
+        WebReachabilityFallbackProfile = 'web_reachability_only_json'
+        HostDiscoveryFallbackProfile = 'host_discovery_web_syn_txt'
+        UdpFallbackProfile = 'udp_dns_snmp_json'
+        AllPortsProfile = 'allports_low_noise_json'
+        WebReachabilityPorts = @(Get-SasWebReachabilityPorts)
+        AdminSurfacePorts = @(Get-SasAdminSurfacePorts)
+        BlockedDefaultPortsGuidance = 'If the default Cybernet ports are blocked or filtered, do not broaden automatically. Use the named fallback profile that answers the survey question, and require explicit gates for subnet discovery, UDP, or all-ports scans.'
+        AllPortsGuidance = 'All TCP ports are denied by default. Use allports_low_noise_json only for a small approved target set with explicit all-port approval.'
+        FallbackDecisionNames = @(
+            'default_ok',
+            'web_only_fallback',
+            'approved_subnet_host_discovery_required',
+            'udp_justification_required',
+            'all_ports_denied_without_explicit_gate',
+            'review_required'
+        )
+    }
+}
+
+function Get-SasPortFallbackDecision {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$TargetCount,
+
+        [Parameter(Mandatory = $true)]
+        [int]$OpenDefaultPortTargetCount,
+
+        [Parameter(Mandatory = $true)]
+        [int]$WebOnlyReachableCount,
+
+        [Parameter(Mandatory = $true)]
+        [int]$AdminSurfaceReachableCount,
+
+        [Parameter(Mandatory = $true)]
+        [int]$SilentOnDefaultProfileCount,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ApprovedSubnetScope,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UdpJustified,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$AllowFullPorts
+    )
+
+    $policy = Get-SasPortFallbackPolicy
+    $fallbackProfile = ''
+    $fallbackRequiresApproval = $false
+    $decision = 'review_required'
+    $allPortsAllowed = [bool]$AllowFullPorts
+
+    if ($TargetCount -le 0) {
+        $decision = 'review_required'
+    } elseif ($SilentOnDefaultProfileCount -eq 0 -and $OpenDefaultPortTargetCount -gt 0) {
+        $decision = 'default_ok'
+    } elseif ($SilentOnDefaultProfileCount -gt 0 -and $ApprovedSubnetScope) {
+        $decision = 'approved_subnet_host_discovery_required'
+        $fallbackProfile = $policy.HostDiscoveryFallbackProfile
+        $fallbackRequiresApproval = $true
+    } elseif ($SilentOnDefaultProfileCount -gt 0) {
+        $decision = 'web_only_fallback'
+        $fallbackProfile = $policy.WebReachabilityFallbackProfile
+    }
+
+    if ($UdpJustified) {
+        $fallbackProfile = $policy.UdpFallbackProfile
+        $fallbackRequiresApproval = $true
+        if ($decision -eq 'review_required') { $decision = 'udp_justification_required' }
+    }
+
+    if (-not $AllowFullPorts -and $decision -eq 'review_required' -and $SilentOnDefaultProfileCount -gt 0) {
+        $decision = 'all_ports_denied_without_explicit_gate'
+        $fallbackRequiresApproval = $true
+    }
+
+    return [pscustomobject]@{
+        default_profile = $policy.DefaultProfile
+        ports_requested = $policy.DefaultCybernetTcpPorts
+        open_default_port_target_count = $OpenDefaultPortTargetCount
+        web_only_reachable_count = $WebOnlyReachableCount
+        admin_surface_reachable_count = $AdminSurfaceReachableCount
+        default_ports_blocked_or_filtered_count = $SilentOnDefaultProfileCount
+        fallback_profile_recommended = $fallbackProfile
+        fallback_requires_approval = $fallbackRequiresApproval
+        all_ports_allowed = $allPortsAllowed
+        decision = $decision
+        guidance = $policy.BlockedDefaultPortsGuidance
+    }
+}
+
+function Get-SasLowNoisePolicy {
+    [CmdletBinding()]
+    param()
+
+    $portPolicy = Get-SasPortFallbackPolicy
+
+    return [pscustomobject]@{
+        PolicyVersion = '1.1'
         LowNoisePrinciple = 'The network sees packets, not the shell. Reduce packets by using local evidence before probes.'
         NetworkVisibilityNote = 'CMD versus PowerShell does not materially change network visibility when the same packets, targets, ports, rate, and retries are used.'
         ProbeAgainGuidance = 'Five probes are unnecessary when a device was already recently reachable or identity-confirmed. If retrying is justified, prefer a different time of day or different day of week over immediate repeated probes.'
@@ -25,6 +148,15 @@ function Get-SasLowNoisePolicy {
         MysterySerialGuidance = 'A serial with no approved host/IP bridge remains a mystery serial for review; do not ping the serial string.'
         FrontDoorGuidance = 'CDN/WAF/load-balanced/front-door targets should not be treated as serial proof. Review or use bounded profiles rather than broad probing.'
         PacketProfileGuidance = 'Prefer smaller scope, fewer ports, lower rate, fewer retries, smarter evidence reuse, and avoiding broad scans.'
+        DefaultProfile = $portPolicy.DefaultProfile
+        DefaultCybernetTcpPorts = $portPolicy.DefaultCybernetTcpPorts
+        WebReachabilityFallbackProfile = $portPolicy.WebReachabilityFallbackProfile
+        HostDiscoveryFallbackProfile = $portPolicy.HostDiscoveryFallbackProfile
+        UdpFallbackProfile = $portPolicy.UdpFallbackProfile
+        AllPortsProfile = $portPolicy.AllPortsProfile
+        BlockedDefaultPortsGuidance = $portPolicy.BlockedDefaultPortsGuidance
+        AllPortsGuidance = $portPolicy.AllPortsGuidance
+        FallbackDecisionNames = $portPolicy.FallbackDecisionNames
         ProbeSelectionQuestions = @(
             'Should this target be probed at all?',
             'Which exact host/IP should be probed?',
@@ -33,7 +165,8 @@ function Get-SasLowNoisePolicy {
             'How many retries?',
             'Is this already fresh in local evidence?',
             'Is this a CDN/WAF/load-balanced/front-door target?',
-            'Is this a mystery serial that needs review, not packets?'
+            'Is this a mystery serial that needs review, not packets?',
+            'If default ports are blocked, which named fallback profile is justified?'
         )
     }
 }
@@ -56,6 +189,10 @@ function Add-SasLowNoisePolicyToObject {
     $InputObject | Add-Member -NotePropertyName mystery_serial_guidance -NotePropertyValue $policy.MysterySerialGuidance -Force
     $InputObject | Add-Member -NotePropertyName front_door_guidance -NotePropertyValue $policy.FrontDoorGuidance -Force
     $InputObject | Add-Member -NotePropertyName packet_profile_guidance -NotePropertyValue $policy.PacketProfileGuidance -Force
+    $InputObject | Add-Member -NotePropertyName default_profile -NotePropertyValue $policy.DefaultProfile -Force
+    $InputObject | Add-Member -NotePropertyName default_cybernet_tcp_ports -NotePropertyValue $policy.DefaultCybernetTcpPorts -Force
+    $InputObject | Add-Member -NotePropertyName blocked_default_ports_guidance -NotePropertyValue $policy.BlockedDefaultPortsGuidance -Force
+    $InputObject | Add-Member -NotePropertyName all_ports_guidance -NotePropertyValue $policy.AllPortsGuidance -Force
 
     return $InputObject
 }
@@ -85,9 +222,11 @@ function Get-SasLowNoiseOperatorLines {
         "- $($policy.ProbeAgainGuidance)",
         "- $($policy.MysterySerialGuidance)",
         "- $($policy.FrontDoorGuidance)",
+        "- Default Cybernet TCP profile: $($policy.DefaultProfile) on ports $($policy.DefaultCybernetTcpPorts -join ',')",
+        "- $($policy.BlockedDefaultPortsGuidance)",
         '',
         'Pre-probe questions:'
     ) + ($policy.ProbeSelectionQuestions | ForEach-Object { "- $_" })
 }
 
-Export-ModuleMember -Function Get-SasLowNoisePolicy, Add-SasLowNoisePolicyToObject, New-SasLowNoiseSummaryObject, Get-SasLowNoiseOperatorLines
+Export-ModuleMember -Function Get-SasLowNoisePolicy, Add-SasLowNoisePolicyToObject, New-SasLowNoiseSummaryObject, Get-SasLowNoiseOperatorLines, Get-SasDefaultCybernetTcpPorts, Get-SasWebReachabilityPorts, Get-SasAdminSurfacePorts, Get-SasPortFallbackPolicy, Get-SasPortFallbackDecision

--- a/survey/sas-network-preflight.ps1
+++ b/survey/sas-network-preflight.ps1
@@ -18,8 +18,7 @@ param(
     [string]$TargetFile,
 
     [Parameter(Mandatory = $false)]
-    [ValidateNotNullOrEmpty()]
-    [int[]]$Ports = @(135, 445, 3389, 9100),
+    [int[]]$Ports,
 
     [Parameter(Mandatory = $false)]
     [string]$OutputDirectory,
@@ -107,6 +106,8 @@ function Show-TargetFileSelectionHelp {
     Write-Host 'Low-noise reminder:'
     Write-Host "- $($policy.LowNoisePrinciple)"
     Write-Host "- $($policy.ProbeAgainGuidance)"
+    Write-Host "- Default Cybernet TCP ports: $($policy.DefaultCybernetTcpPorts -join ',')"
+    Write-Host "- $($policy.BlockedDefaultPortsGuidance)"
     Write-Host ''
     Write-Host 'Candidate files found:'
     $candidates = @(Get-CandidateTargetFiles -Roots $CandidateRoots)
@@ -119,7 +120,7 @@ function Show-TargetFileSelectionHelp {
     }
     Write-Host ''
     Write-Host 'Run in Windows PowerShell:'
-    Write-Host '.\survey\sas-network-preflight.ps1 -TargetFile .\targets\local\approved_targets.csv -Ports 135,445,3389,9100'
+    Write-Host ".\survey\sas-network-preflight.ps1 -TargetFile .\targets\local\approved_targets.csv -Ports $($policy.DefaultCybernetTcpPorts -join ',')"
 }
 
 function Test-IsIpAddress {
@@ -297,6 +298,62 @@ function Test-PortStatus {
     }
 }
 
+function Get-PortFallbackSummary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Rows,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Targets
+    )
+
+    $webPorts = @(Get-SasWebReachabilityPorts)
+    $adminPorts = @(Get-SasAdminSurfacePorts)
+    $openPortsByTarget = @{}
+
+    foreach ($target in $Targets) {
+        $openPortsByTarget[$target] = New-Object System.Collections.Generic.List[int]
+    }
+
+    foreach ($row in $Rows) {
+        if ($row.PortStatus -ne 'Open') { continue }
+        if (-not $openPortsByTarget.ContainsKey($row.Target)) {
+            $openPortsByTarget[$row.Target] = New-Object System.Collections.Generic.List[int]
+        }
+        $openPortsByTarget[$row.Target].Add([int]$row.Port)
+    }
+
+    $openDefaultTargets = 0
+    $webOnlyTargets = 0
+    $adminSurfaceTargets = 0
+    $silentTargets = 0
+
+    foreach ($target in $Targets) {
+        $openPorts = @($openPortsByTarget[$target])
+        if ($openPorts.Count -eq 0) {
+            $silentTargets++
+            continue
+        }
+
+        $openDefaultTargets++
+        $hasWeb = $false
+        $hasAdmin = $false
+        foreach ($port in $openPorts) {
+            if ($webPorts -contains [int]$port) { $hasWeb = $true }
+            if ($adminPorts -contains [int]$port) { $hasAdmin = $true }
+        }
+        if ($hasAdmin) { $adminSurfaceTargets++ }
+        if ($hasWeb -and -not $hasAdmin) { $webOnlyTargets++ }
+    }
+
+    return Get-SasPortFallbackDecision `
+        -TargetCount $Targets.Count `
+        -OpenDefaultPortTargetCount $openDefaultTargets `
+        -WebOnlyReachableCount $webOnlyTargets `
+        -AdminSurfaceReachableCount $adminSurfaceTargets `
+        -SilentOnDefaultProfileCount $silentTargets
+}
+
 $repoRoot = Resolve-SasRepoRoot
 $rootSet = Get-SasTargetIntakeRoots -RepoRoot $repoRoot
 $targetsLocalRoot = $rootSet.SourceRoots[0]
@@ -306,6 +363,10 @@ $surveyOutputRoot = $rootSet.OutputRoots[0]
 $logsNmapRoot = $rootSet.OutputRoots[1]
 $surveyArtifactsRoot = $rootSet.OutputRoots[2]
 $lowNoisePolicy = Get-SasLowNoisePolicy
+
+if ($null -eq $Ports -or @($Ports).Count -eq 0) {
+    $Ports = @(Get-SasDefaultCybernetTcpPorts)
+}
 
 $candidateRoots = @($targetsLocalRoot, $logsTargetsRoot)
 $allowedInputRoots = @($targetsLocalRoot, $logsTargetsRoot, $surveyInputRoot)
@@ -373,6 +434,7 @@ Write-Host "Output path: $outputCsv"
 Write-Host 'Low-noise context:'
 Write-Host "- $($lowNoisePolicy.LowNoisePrinciple)"
 Write-Host "- $($lowNoisePolicy.ProbeAgainGuidance)"
+Write-Host "- $($lowNoisePolicy.BlockedDefaultPortsGuidance)"
 
 Write-SasStageProgress -Step 2 -Total 4 -Message 'Resolving DNS for selected targets' -Percent 50
 $resolved = @{}
@@ -423,6 +485,8 @@ foreach ($target in $targets) {
     }
 }
 
+$fallbackDecision = Get-PortFallbackSummary -Rows @($rows) -Targets @($targets)
+
 Write-SasStageProgress -Step 4 -Total 4 -Message 'Writing network_preflight.csv' -Percent 100
 $rows | Export-Csv -LiteralPath $outputCsv -NoTypeInformation -Encoding UTF8
 
@@ -431,32 +495,60 @@ $summary = New-SasLowNoiseSummaryObject -Properties @{
     generated_at = (Get-Date).ToString('o')
     target_file = $selectedTargetFile
     target_count = $targets.Count
+    default_profile = $fallbackDecision.default_profile
     ports = $Ports
+    ports_requested = $Ports
     total_checks = $totalChecks
+    open_default_port_target_count = $fallbackDecision.open_default_port_target_count
+    web_only_reachable_count = $fallbackDecision.web_only_reachable_count
+    admin_surface_reachable_count = $fallbackDecision.admin_surface_reachable_count
+    default_ports_blocked_or_filtered_count = $fallbackDecision.default_ports_blocked_or_filtered_count
+    fallback_profile_recommended = $fallbackDecision.fallback_profile_recommended
+    fallback_requires_approval = $fallbackDecision.fallback_requires_approval
+    all_ports_allowed = $fallbackDecision.all_ports_allowed
+    fallback_decision = $fallbackDecision.decision
     output_csv = $outputCsv
     summary_json = $summaryJson
     operator_handoff_path = $handoffPath
     network_activity_performed = $true
 }
-$summary | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $summaryJson -Encoding UTF8
+$summary | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $summaryJson -Encoding UTF8
 
 @(
     'SysAdminSuite network preflight handoff',
     "RunId: $runId",
     "Target file: $selectedTargetFile",
     "Targets checked: $($targets.Count)",
+    "Default profile: $($fallbackDecision.default_profile)",
     "Ports checked: $($Ports -join ',')",
     "CSV output: $outputCsv",
     "Summary JSON: $summaryJson",
+    '',
+    'Plain-English result:',
+    "SysAdminSuite checked $($targets.Count) approved target(s) from $selectedTargetFile.",
+    "The default Cybernet TCP profile checked ports $($Ports -join ',').",
+    "Network activity was performed. Evidence was written locally to $outputCsv and $summaryJson.",
+    'No files, scripts, or logs were written to target workstations. Assume enterprise network monitoring may observe authorized traffic.',
+    '',
+    'Port fallback summary:',
+    "- Targets answering at least one default port: $($fallbackDecision.open_default_port_target_count)",
+    "- Targets answering only web ports 80/443: $($fallbackDecision.web_only_reachable_count)",
+    "- Targets answering Windows/admin surface ports: $($fallbackDecision.admin_surface_reachable_count)",
+    "- Targets silent on the default profile: $($fallbackDecision.default_ports_blocked_or_filtered_count)",
+    "- Fallback decision: $($fallbackDecision.decision)",
+    "- Recommended fallback profile: $($fallbackDecision.fallback_profile_recommended)",
+    "- Fallback requires approval: $($fallbackDecision.fallback_requires_approval)",
     '',
     (Get-SasLowNoiseOperatorLines),
     '',
     'Network activity performed: true',
     'Do not repeat probes by habit. If a target was recently reachable or identity-confirmed, prefer using fresh evidence instead of immediate repetition.',
-    'If retrying silent or stale rows, prefer a different time of day or different day of week.'
+    'If retrying silent or stale rows, prefer a different time of day or different day of week.',
+    $lowNoisePolicy.BlockedDefaultPortsGuidance
 ) | Set-Content -LiteralPath $handoffPath -Encoding UTF8
 
 Write-Progress -Activity 'SysAdminSuite network preflight' -Completed
 Write-Host "Final CSV path: $outputCsv"
 Write-Host "Summary JSON path: $summaryJson"
 Write-Host "Operator handoff path: $handoffPath"
+Write-Host "Fallback decision: $($fallbackDecision.decision)"


### PR DESCRIPTION
## Summary

This PR codifies the low-noise Cybernet port targeting/fallback behavior across policy, PowerShell preflight, English report contracts, and existing Naabu profile sync tests.

## What changed

- Added shared Cybernet port policy helpers to `scripts/SasLowNoisePolicy.psm1`:
  - default TCP ports: `80,443,135,445,3389,5985,5986`
  - web/admin port group helpers
  - named fallback policy and decision object
- Updated `survey/sas-network-preflight.ps1`:
  - loads default ports from `SasLowNoisePolicy` instead of keeping the old `135,445,3389,9100` default
  - classifies default-port results into web-only/admin/silent counts
  - writes fallback decision fields into summary JSON
  - adds plain-English handoff lines about local-only evidence and blocked default ports
- Updated doctrine and English log contract docs:
  - blocked default ports are a classification, not permission to broaden
  - added fallback decision names and artifact roles
- Extended `Tests/bash/test_naabu_profile_sync.sh`:
  - locks runtime profile ports
  - verifies `9100` is not a default Cybernet port
  - verifies PowerShell preflight consumes `Get-SasDefaultCybernetTcpPorts`
  - verifies all-port, UDP, subnet, and load-balanced hostname gates

## Safety / boundaries

- No live network scanning.
- No target-side writes.
- No committed runtime evidence, secrets, host lists, or logs.
- No all-port default.
- No subnet discovery as population authority.

## Validation

Connector-level verification performed:

- `compare main...sprint/low-noise-port-policy`: branch is ahead by 5 commits, behind by 0.
- Changed files are bounded to policy/docs/preflight/test files.

Expected repo validation after PR open:

```bash
bash Tests/bash/test_repo_naabu_doctrine_conformance.sh
bash Tests/bash/test_naabu_profile_sync.sh
bash Tests/bash/test_naabu_pipeline_contracts.sh
```

Local sandbox validation was skipped because the sandbox cannot clone GitHub (`Could not resolve host: github.com`) and does not have PowerShell available. GitHub Actions should be treated as the authoritative validation result for this PR.