### PR TITLE
feat(harness): add canonical run context module

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,5 @@ cd "$repo_root"
 echo "[sas-harness] pre-push: running offline survey guardrails"
 bash tests/survey/run_offline_survey_tests.sh
 python3 Tests/survey/test_local_harness_contracts.py
-python3 Tests/survey/test_sprint_working_rules_contracts.py
 
 echo "[sas-harness] pre-push: ok"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,5 +7,6 @@ cd "$repo_root"
 echo "[sas-harness] pre-push: running offline survey guardrails"
 bash tests/survey/run_offline_survey_tests.sh
 python3 Tests/survey/test_local_harness_contracts.py
+python3 Tests/survey/test_sprint_working_rules_contracts.py
 
 echo "[sas-harness] pre-push: ok"

--- a/.github/workflows/run-context-contracts.yml
+++ b/.github/workflows/run-context-contracts.yml
@@ -1,0 +1,26 @@
+name: Run context contracts
+
+on:
+  push:
+    branches: [main, 'feat/**', 'feature/**']
+    paths:
+      - 'scripts/SasRunContext.psm1'
+      - 'Tests/survey/test_run_context_contracts.py'
+      - '.github/workflows/run-context-contracts.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/SasRunContext.psm1'
+      - 'Tests/survey/test_run_context_contracts.py'
+      - '.github/workflows/run-context-contracts.yml'
+
+jobs:
+  contracts:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run static run context contracts
+        shell: bash
+        run: |
+          python3 Tests/survey/test_run_context_contracts.py

--- a/Tests/Pester/SasRunContext.Tests.ps1
+++ b/Tests/Pester/SasRunContext.Tests.ps1
@@ -1,0 +1,91 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0' }
+
+Set-StrictMode -Version Latest
+
+Describe 'SasRunContext module' {
+    BeforeAll {
+        $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        $script:modulePath = Join-Path $repoRoot 'scripts/SasRunContext.psm1'
+        Import-Module $script:modulePath -Force
+    }
+
+    It 'creates run ids with prefix and timestamp' {
+        $id = New-SasRunId -Prefix 'target-reduction' -Timestamp ([datetime]'2026-07-07T21:00:00Z')
+        $id | Should -Match '^target-reduction-20260707-210000-[a-f0-9]{8}$'
+    }
+
+    It 'validates workflow ids and rejects traversal' {
+        Test-SasWorkflowId -WorkflowId 'serial-to-preflight' | Should -BeTrue
+        Test-SasWorkflowId -WorkflowId '../serial-to-preflight' | Should -BeFalse
+        Test-SasWorkflowId -WorkflowId 'serial/to/preflight' | Should -BeFalse
+    }
+
+    It 'creates the canonical local run context and registry' {
+        $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-run-context-' + [guid]::NewGuid().Guid)
+        $repoRoot = Join-Path $tmpRoot 'repo'
+        New-Item -Path (Join-Path $repoRoot 'survey/output/runs') -ItemType Directory -Force | Out-Null
+        New-Item -Path (Join-Path $repoRoot 'targets') -ItemType Directory -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $repoRoot 'targets/README.md') -Encoding UTF8 -Value '# targets'
+
+        $context = New-SasRunContext `
+            -WorkflowId 'serial-to-preflight' `
+            -RunId 'run-20260707-210000-abc123ef' `
+            -RepoRoot $repoRoot `
+            -Survey `
+            -RequestSummary 'fixture request' `
+            -SourceArtifact 'Tests/fixtures/harness/request.json'
+
+        foreach ($relative in @(
+            'request.json',
+            'context.json',
+            'plan.json',
+            'plan.md',
+            'actions',
+            'artifacts',
+            'evidence',
+            'reports',
+            'review',
+            'summary.json',
+            'operator_handoff.txt',
+            'artifact_registry.json'
+        )) {
+            Test-Path -LiteralPath (Join-Path $context.run_root $relative) | Should -BeTrue
+        }
+
+        $registry = Get-Content -LiteralPath $context.artifact_registry_path -Raw | ConvertFrom-Json
+        $registry.schema_version | Should -Be 'sas-artifact-registry/v1'
+        $registry.workflow_id | Should -Be 'serial-to-preflight'
+        $registry.run_id | Should -Be 'run-20260707-210000-abc123ef'
+
+        $entry = Register-SasArtifact `
+            -RegistryPath $context.artifact_registry_path `
+            -Role 'source-request' `
+            -Path 'Tests/fixtures/harness/request.json' `
+            -Tracked $true `
+            -LiveData $false `
+            -Description 'fixture request artifact' `
+            -SourceArtifact 'operator request' `
+            -NetworkActivity 'No network activity performed.'
+
+        $entry.role | Should -Be 'source-request'
+        $entry.tracked | Should -BeTrue
+        $entry.live_data | Should -BeFalse
+
+        $updated = Get-Content -LiteralPath $context.artifact_registry_path -Raw | ConvertFrom-Json
+        @($updated.artifacts).Count | Should -Be 1
+        $updated.artifacts[0].network_activity | Should -Be 'No network activity performed.'
+
+        Remove-Item -LiteralPath $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'rejects non-local output roots unless explicitly overridden' {
+        $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-run-context-deny-' + [guid]::NewGuid().Guid)
+        $repoRoot = Join-Path $tmpRoot 'repo'
+        New-Item -Path (Join-Path $repoRoot 'survey') -ItemType Directory -Force | Out-Null
+        New-Item -Path (Join-Path $repoRoot 'targets') -ItemType Directory -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $repoRoot 'targets/README.md') -Encoding UTF8 -Value '# targets'
+
+        { Assert-SasLocalOutputRoot -RepoRoot $repoRoot -OutputRoot (Join-Path $tmpRoot 'outside') } | Should -Throw
+        Remove-Item -LiteralPath $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/Tests/Pester/SasRunContext.Tests.ps1
+++ b/Tests/Pester/SasRunContext.Tests.ps1
@@ -20,7 +20,7 @@ Describe 'SasRunContext module' {
         Test-SasWorkflowId -WorkflowId 'serial/to/preflight' | Should -BeFalse
     }
 
-    It 'creates the canonical local run context and registry' {
+    It 'creates the canonical local run context and registry under workflow/run id' {
         $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-run-context-' + [guid]::NewGuid().Guid)
         $repoRoot = Join-Path $tmpRoot 'repo'
         New-Item -Path (Join-Path $repoRoot 'survey/output/runs') -ItemType Directory -Force | Out-Null
@@ -34,6 +34,10 @@ Describe 'SasRunContext module' {
             -Survey `
             -RequestSummary 'fixture request' `
             -SourceArtifact 'Tests/fixtures/harness/request.json'
+
+        (Split-Path -Leaf $context.run_root) | Should -Be 'run-20260707-210000-abc123ef'
+        (Split-Path -Leaf (Split-Path -Parent $context.run_root)) | Should -Be 'serial-to-preflight'
+        Test-Path -LiteralPath $context.workflow_root | Should -BeTrue
 
         foreach ($relative in @(
             'request.json',
@@ -51,6 +55,15 @@ Describe 'SasRunContext module' {
         )) {
             Test-Path -LiteralPath (Join-Path $context.run_root $relative) | Should -BeTrue
         }
+
+        { New-SasRunContext -WorkflowId 'serial-to-preflight' -RunId 'run-20260707-210000-abc123ef' -RepoRoot $repoRoot -Survey } | Should -Throw
+
+        $second = New-SasRunContext `
+            -WorkflowId 'serial-to-preflight' `
+            -RunId 'run-20260707-210001-def456ab' `
+            -RepoRoot $repoRoot `
+            -Survey
+        $second.run_root | Should -Not -Be $context.run_root
 
         $registry = Get-Content -LiteralPath $context.artifact_registry_path -Raw | ConvertFrom-Json
         $registry.schema_version | Should -Be 'sas-artifact-registry/v1'
@@ -74,6 +87,22 @@ Describe 'SasRunContext module' {
         $updated = Get-Content -LiteralPath $context.artifact_registry_path -Raw | ConvertFrom-Json
         @($updated.artifacts).Count | Should -Be 1
         $updated.artifacts[0].network_activity | Should -Be 'No network activity performed.'
+
+        Remove-Item -LiteralPath $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'derives safe run ids from numeric and long workflow ids' {
+        $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-run-context-prefix-' + [guid]::NewGuid().Guid)
+        $repoRoot = Join-Path $tmpRoot 'repo'
+        New-Item -Path (Join-Path $repoRoot 'survey/output/runs') -ItemType Directory -Force | Out-Null
+        New-Item -Path (Join-Path $repoRoot 'targets') -ItemType Directory -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $repoRoot 'targets/README.md') -Encoding UTF8 -Value '# targets'
+
+        $numeric = New-SasRunContext -WorkflowId '2026-rollout' -RepoRoot $repoRoot -Survey
+        $numeric.run_id | Should -Match '^run-2026-rollout-\d{8}-\d{6}-[a-f0-9]{8}$'
+
+        $long = New-SasRunContext -WorkflowId 'serial-to-preflight-with-a-very-long-workflow-name-for-contracts' -RepoRoot $repoRoot -Survey
+        ($long.run_id -split '-\d{8}-\d{6}-')[0].Length | Should -BeLessOrEqual 32
 
         Remove-Item -LiteralPath $tmpRoot -Recurse -Force -ErrorAction SilentlyContinue
     }

--- a/Tests/survey/test_run_context_contracts.py
+++ b/Tests/survey/test_run_context_contracts.py
@@ -54,6 +54,23 @@ def test_run_context_module_preserves_canonical_directory_shape():
         assert fragment in text, f"missing canonical run fragment: {fragment}"
 
 
+def test_run_context_root_includes_workflow_id_and_run_id():
+    text = read(MODULE)
+    assert "$workflowRoot = Join-Path $resolvedOutputRoot $WorkflowId" in text
+    assert "$runRoot = Join-Path $workflowRoot $RunId" in text
+    assert "$runRoot = Join-Path $resolvedOutputRoot $WorkflowId" not in text
+    assert "Run context already exists" in text
+
+
+def test_workflow_id_is_sanitized_before_generating_run_id_prefix():
+    text = read(MODULE)
+    assert "function ConvertTo-SasRunIdPrefix" in text
+    assert "ConvertTo-SasRunIdPrefix -WorkflowId $WorkflowId" in text
+    assert "New-SasRunId -Prefix $WorkflowId.Replace" not in text
+    assert "if ($sanitized -notmatch '^[a-zA-Z]')" in text
+    assert "if ($sanitized.Length -gt 32)" in text
+
+
 def test_artifact_registry_entries_preserve_required_metadata():
     text = read(MODULE)
     required_fields = [
@@ -114,6 +131,8 @@ def test_harness_plan_names_the_same_run_context_shape():
 if __name__ == "__main__":
     test_run_context_module_exists_and_exports_expected_api()
     test_run_context_module_preserves_canonical_directory_shape()
+    test_run_context_root_includes_workflow_id_and_run_id()
+    test_workflow_id_is_sanitized_before_generating_run_id_prefix()
     test_artifact_registry_entries_preserve_required_metadata()
     test_run_context_defaults_to_no_activity_for_planner_initialization()
     test_run_context_module_does_not_introduce_probe_execution_surfaces()

--- a/Tests/survey/test_run_context_contracts.py
+++ b/Tests/survey/test_run_context_contracts.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Static contracts for the SysAdminSuite run context module."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = ROOT / "scripts" / "SasRunContext.psm1"
+HARNESS_PLAN = ROOT / "docs" / "HARNESS_COMPLETION_PLAN.md"
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"missing expected file: {path.relative_to(ROOT).as_posix()}"
+    return path.read_text(encoding="utf-8-sig")
+
+
+def test_run_context_module_exists_and_exports_expected_api():
+    text = read(MODULE)
+    required_functions = [
+        "New-SasRunId",
+        "Test-SasWorkflowId",
+        "Resolve-SasOutputRoot",
+        "Assert-SasLocalOutputRoot",
+        "New-SasArtifactRegistry",
+        "Register-SasArtifact",
+        "Get-SasRunSummaryPath",
+        "New-SasRunContext",
+    ]
+
+    for function_name in required_functions:
+        assert re.search(rf"function\s+{re.escape(function_name)}\b", text), f"missing function: {function_name}"
+        assert function_name in text.split("Export-ModuleMember", 1)[-1], f"function is not exported: {function_name}"
+
+
+def test_run_context_module_preserves_canonical_directory_shape():
+    text = read(MODULE)
+    required_fragments = [
+        "request.json",
+        "context.json",
+        "plan.json",
+        "plan.md",
+        "actions",
+        "artifacts",
+        "evidence",
+        "reports",
+        "review",
+        "summary.json",
+        "operator_handoff.txt",
+        "artifact_registry.json",
+        "survey/output/runs",
+    ]
+    for fragment in required_fragments:
+        assert fragment in text, f"missing canonical run fragment: {fragment}"
+
+
+def test_artifact_registry_entries_preserve_required_metadata():
+    text = read(MODULE)
+    required_fields = [
+        "role",
+        "path",
+        "tracked",
+        "live_data",
+        "description",
+        "source_artifact",
+        "network_activity",
+        "created_at",
+        "created_by",
+    ]
+    for field in required_fields:
+        assert field in text, f"missing artifact metadata field: {field}"
+
+
+def test_run_context_defaults_to_no_activity_for_planner_initialization():
+    text = read(MODULE)
+    assert "No network activity performed." in text
+    assert "initialize-run-context" in text
+    assert "Register source and output artifacts before rendering reports." in text
+
+
+def test_run_context_module_does_not_introduce_probe_execution_surfaces():
+    text = read(MODULE)
+    forbidden = [
+        "Test-Connection",
+        "Test-NetConnection",
+        "Resolve-DnsName",
+        "Invoke-WebRequest",
+        "Invoke-RestMethod",
+        "Start-Process",
+        "nmap",
+        "naabu",
+        "nc.exe",
+        "ncat",
+        "ping.exe",
+        "tracert",
+    ]
+    for fragment in forbidden:
+        assert fragment not in text, f"run context module must not execute probes or external network tooling: {fragment}"
+
+
+def test_harness_plan_names_the_same_run_context_shape():
+    plan = read(HARNESS_PLAN)
+    for fragment in [
+        "runs/<workflow_id>/",
+        "request.json",
+        "context.json",
+        "plan.json",
+        "operator_handoff.txt",
+        "survey/output/runs/<workflow_id>/",
+    ]:
+        assert fragment in plan, f"harness plan no longer names run context fragment: {fragment}"
+
+
+if __name__ == "__main__":
+    test_run_context_module_exists_and_exports_expected_api()
+    test_run_context_module_preserves_canonical_directory_shape()
+    test_artifact_registry_entries_preserve_required_metadata()
+    test_run_context_defaults_to_no_activity_for_planner_initialization()
+    test_run_context_module_does_not_introduce_probe_execution_surfaces()
+    test_harness_plan_names_the_same_run_context_shape()

--- a/docs/SPRINTS.md
+++ b/docs/SPRINTS.md
@@ -1,0 +1,28 @@
+# Sprint Working Rules
+
+Implementation sprints should produce repository progress: tracked file changes, validation, and Git continuity when available.
+
+Planning and next-agent prompts are closeout artifacts, not substitutes for implementation work.
+
+Before starting new work, inspect existing docs, scripts, tests, contracts, naming conventions, and output paths.
+
+Keep changes bounded. Reuse repo patterns. Avoid unrelated rewrites. Do not create dummy commits or duplicate pull requests.
+
+## Enforcement
+
+The sprint rules are enforced by `Tests/survey/test_sprint_working_rules_contracts.py` and should be run directly when this document changes.
+
+Local hook coverage is provided by `.githooks/pre-push`, which runs the sprint working rules contract before push after the local harness hooks are installed.
+
+Recommended next SysAdminSuite sprint queue:
+
+1. Target Reduction Planner
+2. English Report Renderer
+3. Canonical Run Context
+4. Survey Workflow Specs
+5. End-to-End Harness Validator
+6. Local MCP Server Skeletons
+7. Standard CMD and PowerShell Renderers
+8. Location/Subnet Candidate Planner
+9. Dashboard Serial Controls Integration
+10. Executor Guardrail Expansion

--- a/scripts/SasRunContext.psm1
+++ b/scripts/SasRunContext.psm1
@@ -1,0 +1,320 @@
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+function Get-SasRepoRoot {
+    [CmdletBinding()]
+    param([string]$StartPath)
+
+    $cursor = if ($StartPath) { [System.IO.Path]::GetFullPath($StartPath) } else { (Get-Location).Path }
+    if (Test-Path -LiteralPath $cursor -PathType Leaf) {
+        $cursor = Split-Path -Parent $cursor
+    }
+
+    while ($cursor) {
+        if ((Test-Path -LiteralPath (Join-Path $cursor 'targets/README.md')) -and
+            (Test-Path -LiteralPath (Join-Path $cursor 'survey'))) {
+            return $cursor
+        }
+        $parent = Split-Path -Parent $cursor
+        if (-not $parent -or $parent -eq $cursor) { break }
+        $cursor = $parent
+    }
+
+    throw 'Unable to resolve SysAdminSuite repo root.'
+}
+
+function ConvertTo-SasRunContextFullPath {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Test-SasRunContextPathUnderRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Root
+    )
+
+    $fullPath = ConvertTo-SasRunContextFullPath -Path $Path
+    $fullRoot = ConvertTo-SasRunContextFullPath -Path $Root
+    if (-not $fullRoot.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+        $fullRoot = $fullRoot + [System.IO.Path]::DirectorySeparatorChar
+    }
+
+    return $fullPath.StartsWith($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function New-SasRunId {
+    [CmdletBinding()]
+    param(
+        [datetime]$Timestamp = (Get-Date),
+        [string]$Prefix = 'run'
+    )
+
+    if ($Prefix -notmatch '^[a-zA-Z][a-zA-Z0-9_-]{0,31}$') {
+        throw "Run ID prefix is invalid: $Prefix"
+    }
+
+    return ('{0}-{1}-{2}' -f $Prefix.ToLowerInvariant(), $Timestamp.ToUniversalTime().ToString('yyyyMMdd-HHmmss'), ([guid]::NewGuid().ToString('N').Substring(0, 8)))
+}
+
+function Test-SasWorkflowId {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$WorkflowId)
+
+    return ($WorkflowId -match '^[a-zA-Z0-9][a-zA-Z0-9_.-]{1,127}$' -and
+        $WorkflowId -notmatch '\.\.' -and
+        $WorkflowId -notmatch '[\\/:*?"<>|]')
+}
+
+function Assert-SasWorkflowId {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$WorkflowId)
+
+    if (-not (Test-SasWorkflowId -WorkflowId $WorkflowId)) {
+        throw "Invalid SysAdminSuite workflow id: $WorkflowId"
+    }
+}
+
+function Resolve-SasOutputRoot {
+    [CmdletBinding()]
+    param(
+        [string]$RepoRoot,
+        [switch]$Survey,
+        [string]$OutputRoot
+    )
+
+    if ($OutputRoot) { return ConvertTo-SasRunContextFullPath -Path $OutputRoot }
+    if (-not $RepoRoot) { $RepoRoot = Get-SasRepoRoot }
+
+    if ($Survey) {
+        return Join-Path $RepoRoot 'survey/output/runs'
+    }
+
+    return Join-Path $RepoRoot 'runs'
+}
+
+function Assert-SasLocalOutputRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$OutputRoot,
+        [string]$RepoRoot,
+        [switch]$AllowNonstandard
+    )
+
+    if (-not $RepoRoot) { $RepoRoot = Get-SasRepoRoot }
+
+    $approvedRoots = @(
+        (Join-Path $RepoRoot 'runs'),
+        (Join-Path $RepoRoot 'survey/output/runs'),
+        (Join-Path $RepoRoot 'survey/output'),
+        (Join-Path $RepoRoot 'survey/artifacts'),
+        (Join-Path $RepoRoot 'logs')
+    )
+
+    foreach ($root in $approvedRoots) {
+        if (Test-SasRunContextPathUnderRoot -Path $OutputRoot -Root $root) { return }
+    }
+
+    if ($AllowNonstandard) {
+        Write-Warning "NONSTANDARD RUN OUTPUT OVERRIDE: output root is outside codified local roots: $OutputRoot"
+        return
+    }
+
+    throw "Run output root is outside approved local output roots. Use runs/, survey/output/runs/, survey/output/, survey/artifacts/, or logs/. Refusing: $OutputRoot"
+}
+
+function New-SasArtifactRegistry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkflowId,
+        [Parameter(Mandatory = $true)][string]$RunId,
+        [string]$CreatedBy = 'SasRunContext'
+    )
+
+    Assert-SasWorkflowId -WorkflowId $WorkflowId
+
+    return [pscustomobject]@{
+        schema_version = 'sas-artifact-registry/v1'
+        workflow_id = $WorkflowId
+        run_id = $RunId
+        created_at = (Get-Date).ToUniversalTime().ToString('o')
+        created_by = $CreatedBy
+        artifacts = @()
+    }
+}
+
+function Save-SasJsonFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][object]$InputObject,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [int]$Depth = 12
+    )
+
+    $parent = Split-Path -Parent $Path
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -Path $parent -ItemType Directory -Force | Out-Null
+    }
+
+    $InputObject | ConvertTo-Json -Depth $Depth | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Get-SasRunSummaryPath {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$RunRoot)
+
+    return Join-Path $RunRoot 'summary.json'
+}
+
+function New-SasRunContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkflowId,
+        [string]$RunId,
+        [string]$RepoRoot,
+        [string]$OutputRoot,
+        [switch]$Survey,
+        [string]$RequestSummary = 'No request summary provided.',
+        [string]$SourceArtifact = '',
+        [string]$CreatedBy = 'SasRunContext',
+        [switch]$AllowNonstandardOutputRoot
+    )
+
+    Assert-SasWorkflowId -WorkflowId $WorkflowId
+    if (-not $RepoRoot) { $RepoRoot = Get-SasRepoRoot }
+    if (-not $RunId) { $RunId = New-SasRunId -Prefix $WorkflowId.Replace('.', '-').Replace('_', '-') }
+
+    $resolvedOutputRoot = Resolve-SasOutputRoot -RepoRoot $RepoRoot -Survey:$Survey -OutputRoot $OutputRoot
+    Assert-SasLocalOutputRoot -OutputRoot $resolvedOutputRoot -RepoRoot $RepoRoot -AllowNonstandard:$AllowNonstandardOutputRoot
+
+    $runRoot = Join-Path $resolvedOutputRoot $WorkflowId
+    $directories = @(
+        $runRoot,
+        (Join-Path $runRoot 'actions'),
+        (Join-Path $runRoot 'artifacts'),
+        (Join-Path $runRoot 'evidence'),
+        (Join-Path $runRoot 'reports'),
+        (Join-Path $runRoot 'review')
+    )
+
+    foreach ($directory in $directories) {
+        New-Item -Path $directory -ItemType Directory -Force | Out-Null
+    }
+
+    $context = [pscustomobject]@{
+        schema_version = 'sas-run-context/v1'
+        workflow_id = $WorkflowId
+        run_id = $RunId
+        run_root = $runRoot
+        output_root = $resolvedOutputRoot
+        request_summary = $RequestSummary
+        source_artifact = $SourceArtifact
+        network_activity = 'No network activity performed.'
+        created_at = (Get-Date).ToUniversalTime().ToString('o')
+        created_by = $CreatedBy
+        directories = [pscustomobject]@{
+            actions = Join-Path $runRoot 'actions'
+            artifacts = Join-Path $runRoot 'artifacts'
+            evidence = Join-Path $runRoot 'evidence'
+            reports = Join-Path $runRoot 'reports'
+            review = Join-Path $runRoot 'review'
+        }
+        artifact_registry_path = Join-Path $runRoot 'artifact_registry.json'
+        summary_path = Get-SasRunSummaryPath -RunRoot $runRoot
+        operator_handoff_path = Join-Path $runRoot 'operator_handoff.txt'
+    }
+
+    $request = [pscustomobject]@{
+        schema_version = 'sas-run-request/v1'
+        workflow_id = $WorkflowId
+        run_id = $RunId
+        request_summary = $RequestSummary
+        source_artifact = $SourceArtifact
+        network_activity = 'No network activity performed.'
+        created_at = $context.created_at
+    }
+
+    $plan = [pscustomobject]@{
+        schema_version = 'sas-run-plan/v1'
+        workflow_id = $WorkflowId
+        run_id = $RunId
+        action = 'initialize-run-context'
+        network_activity = 'No network activity performed.'
+        next_action = 'Register source and output artifacts before rendering reports.'
+    }
+
+    $summary = [pscustomobject]@{
+        schema_version = 'sas-run-summary/v1'
+        workflow_id = $WorkflowId
+        run_id = $RunId
+        network_activity = 'No network activity performed.'
+        artifact_count = 0
+        review_required = $false
+    }
+
+    $registry = New-SasArtifactRegistry -WorkflowId $WorkflowId -RunId $RunId -CreatedBy $CreatedBy
+
+    Save-SasJsonFile -InputObject $request -Path (Join-Path $runRoot 'request.json')
+    Save-SasJsonFile -InputObject $context -Path (Join-Path $runRoot 'context.json')
+    Save-SasJsonFile -InputObject $plan -Path (Join-Path $runRoot 'plan.json')
+    Save-SasJsonFile -InputObject $summary -Path $context.summary_path
+    Save-SasJsonFile -InputObject $registry -Path $context.artifact_registry_path
+    Set-Content -LiteralPath (Join-Path $runRoot 'plan.md') -Encoding UTF8 -Value @(
+        "# $WorkflowId plan",
+        '',
+        'Network activity: No network activity performed.',
+        '',
+        'Next action: Register source and output artifacts before rendering reports.'
+    )
+    Set-Content -LiteralPath $context.operator_handoff_path -Encoding UTF8 -Value 'No network activity performed. Register source and output artifacts before rendering reports.'
+
+    return $context
+}
+
+function Register-SasArtifact {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$RegistryPath,
+        [Parameter(Mandatory = $true)][string]$Role,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [bool]$Tracked = $false,
+        [bool]$LiveData = $false,
+        [Parameter(Mandatory = $true)][string]$Description,
+        [string]$SourceArtifact = '',
+        [string]$NetworkActivity = 'No network activity performed.',
+        [string]$CreatedBy = 'SasRunContext'
+    )
+
+    if (-not (Test-Path -LiteralPath $RegistryPath -PathType Leaf)) {
+        throw "Artifact registry not found: $RegistryPath"
+    }
+
+    $registry = Get-Content -LiteralPath $RegistryPath -Raw | ConvertFrom-Json
+    if ($registry.schema_version -ne 'sas-artifact-registry/v1') {
+        throw "Unsupported artifact registry schema: $($registry.schema_version)"
+    }
+
+    $entry = [pscustomobject]@{
+        role = $Role
+        path = $Path
+        tracked = $Tracked
+        live_data = $LiveData
+        description = $Description
+        source_artifact = $SourceArtifact
+        network_activity = $NetworkActivity
+        created_at = (Get-Date).ToUniversalTime().ToString('o')
+        created_by = $CreatedBy
+    }
+
+    $artifacts = @($registry.artifacts)
+    $artifacts += $entry
+    $registry.artifacts = $artifacts
+    Save-SasJsonFile -InputObject $registry -Path $RegistryPath
+
+    return $entry
+}
+
+Export-ModuleMember -Function New-SasRunId, Test-SasWorkflowId, Resolve-SasOutputRoot, Assert-SasLocalOutputRoot, New-SasArtifactRegistry, Register-SasArtifact, Get-SasRunSummaryPath, New-SasRunContext

--- a/scripts/SasRunContext.psm1
+++ b/scripts/SasRunContext.psm1
@@ -50,6 +50,35 @@ function Test-SasRunContextPathUnderRoot {
     return $fullPath.StartsWith($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)
 }
 
+function ConvertTo-SasRunIdPrefix {
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$WorkflowId)
+
+    Assert-SasWorkflowId -WorkflowId $WorkflowId
+
+    $sanitized = $WorkflowId.ToLowerInvariant() -replace '[^a-z0-9_-]', '-'
+    $sanitized = $sanitized -replace '-+', '-'
+
+    while ($sanitized.Length -gt 0 -and ($sanitized.StartsWith('-') -or $sanitized.StartsWith('_'))) {
+        $sanitized = $sanitized.Substring(1)
+    }
+    while ($sanitized.Length -gt 0 -and ($sanitized.EndsWith('-') -or $sanitized.EndsWith('_'))) {
+        $sanitized = $sanitized.Substring(0, $sanitized.Length - 1)
+    }
+
+    if ([string]::IsNullOrWhiteSpace($sanitized)) {
+        $sanitized = 'run'
+    }
+    if ($sanitized -notmatch '^[a-zA-Z]') {
+        $sanitized = "run-$sanitized"
+    }
+    if ($sanitized.Length -gt 32) {
+        $sanitized = $sanitized.Substring(0, 32)
+    }
+
+    return $sanitized
+}
+
 function New-SasRunId {
     [CmdletBinding()]
     param(
@@ -189,12 +218,17 @@ function New-SasRunContext {
 
     Assert-SasWorkflowId -WorkflowId $WorkflowId
     if (-not $RepoRoot) { $RepoRoot = Get-SasRepoRoot }
-    if (-not $RunId) { $RunId = New-SasRunId -Prefix $WorkflowId.Replace('.', '-').Replace('_', '-') }
+    if (-not $RunId) { $RunId = New-SasRunId -Prefix (ConvertTo-SasRunIdPrefix -WorkflowId $WorkflowId) }
 
     $resolvedOutputRoot = Resolve-SasOutputRoot -RepoRoot $RepoRoot -Survey:$Survey -OutputRoot $OutputRoot
     Assert-SasLocalOutputRoot -OutputRoot $resolvedOutputRoot -RepoRoot $RepoRoot -AllowNonstandard:$AllowNonstandardOutputRoot
 
-    $runRoot = Join-Path $resolvedOutputRoot $WorkflowId
+    $workflowRoot = Join-Path $resolvedOutputRoot $WorkflowId
+    $runRoot = Join-Path $workflowRoot $RunId
+    if (Test-Path -LiteralPath (Join-Path $runRoot 'context.json') -PathType Leaf) {
+        throw "Run context already exists: $runRoot"
+    }
+
     $directories = @(
         $runRoot,
         (Join-Path $runRoot 'actions'),
@@ -212,6 +246,7 @@ function New-SasRunContext {
         schema_version = 'sas-run-context/v1'
         workflow_id = $WorkflowId
         run_id = $RunId
+        workflow_root = $workflowRoot
         run_root = $runRoot
         output_root = $resolvedOutputRoot
         request_summary = $RequestSummary

--- a/scripts/SasRunContext.psm1
+++ b/scripts/SasRunContext.psm1
@@ -39,6 +39,10 @@ function Test-SasRunContextPathUnderRoot {
 
     $fullPath = ConvertTo-SasRunContextFullPath -Path $Path
     $fullRoot = ConvertTo-SasRunContextFullPath -Path $Root
+    if ($fullPath.Equals($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $true
+    }
+
     if (-not $fullRoot.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
         $fullRoot = $fullRoot + [System.IO.Path]::DirectorySeparatorChar
     }

--- a/tests/survey/run_offline_survey_tests.sh
+++ b/tests/survey/run_offline_survey_tests.sh
@@ -9,3 +9,4 @@ python3 Tests/survey/test_serial_network_preflight_contracts.py
 python3 Tests/survey/test_probe_socket_access_contracts.py
 python3 Tests/survey/test_standard_corporate_tooling_contracts.py
 python3 Tests/survey/test_local_harness_contracts.py
+python3 Tests/survey/test_run_context_contracts.py


### PR DESCRIPTION
## Summary

Adds the first executable A0 harness-spine code for canonical SysAdminSuite run contexts.

## Scope

- Adds `scripts/SasRunContext.psm1`
- Adds static run-context contract coverage
- Adds Pester behavior coverage for temp run creation and artifact registration
- Wires the static contract into the offline survey runner
- Adds a focused run-context workflow for the new module/test pair

## Implemented API

- `New-SasRunId`
- `Test-SasWorkflowId`
- `Resolve-SasOutputRoot`
- `Assert-SasLocalOutputRoot`
- `New-SasArtifactRegistry`
- `Register-SasArtifact`
- `Get-SasRunSummaryPath`
- `New-SasRunContext`

## Network activity

No network activity performed. This lane initializes local run folders, JSON context files, artifact registries, and reports default no-activity metadata.

## Verification performed through connector

- Fetched `scripts/SasRunContext.psm1` from the branch after commit and verified the module contains the run context helpers and exact-root path fix.
- Fetched `Tests/survey/test_run_context_contracts.py` from the branch after commit and verified it covers exports, directory shape, registry metadata, no-activity defaults, and no probe execution surfaces.
- Compared `main...feat/harness-run-context`: branch is 6 commits ahead, 0 behind, with 5 changed files.

## Validation still needed from CI/local worktree

- `python3 Tests/survey/test_run_context_contracts.py`
- `bash tests/survey/run_offline_survey_tests.sh`
- `Invoke-Pester -Path Tests/Pester/SasRunContext.Tests.ps1 -CI`

## Notes

A direct edit to the existing Survey doctrine workflow was not made because the file includes existing probe-tool terminology that was blocked by connector safety checks. A focused run-context contract workflow was added instead.