### PR TITLE
docs(harness): add sprint working rules

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,5 +7,6 @@ cd "$repo_root"
 echo "[sas-harness] pre-push: running offline survey guardrails"
 bash tests/survey/run_offline_survey_tests.sh
 python3 Tests/survey/test_local_harness_contracts.py
+python3 Tests/survey/test_sprint_working_rules_contracts.py
 
 echo "[sas-harness] pre-push: ok"

--- a/Tests/survey/test_sprint_working_rules_contracts.py
+++ b/Tests/survey/test_sprint_working_rules_contracts.py
@@ -9,53 +9,66 @@ DOC = ROOT / "docs" / "SPRINTS.md"
 
 
 def read(path: Path) -> str:
-    assert path.exists(), f"missing expected file: {path.relative_to(ROOT).as_posix()}"
+    if not path.exists():
+        raise AssertionError(f"missing expected file: {path.relative_to(ROOT).as_posix()}")
     return path.read_text(encoding="utf-8")
+
+
+def require_fragments(text: str, fragments: list[str], label: str) -> None:
+    missing = [fragment for fragment in fragments if fragment not in text]
+    if missing:
+        raise AssertionError(f"missing {label}: {', '.join(missing)}")
 
 
 def test_sprint_rules_require_repo_progress():
     text = read(DOC)
-    required = [
-        "Implementation sprints should produce repository progress",
-        "tracked file changes",
-        "validation",
-        "Planning and next-agent prompts are closeout artifacts",
-        "not substitutes for implementation work",
-    ]
-    for fragment in required:
-        assert fragment in text, f"missing sprint progress rule: {fragment}"
+    require_fragments(
+        text,
+        [
+            "Implementation sprints should produce repository progress",
+            "tracked file changes",
+            "validation",
+            "Planning and next-agent prompts are closeout artifacts",
+            "not substitutes for implementation work",
+        ],
+        "sprint progress rule",
+    )
 
 
 def test_sprint_rules_require_repo_evidence_before_new_patterns():
     text = read(DOC)
-    required = [
-        "inspect existing docs",
-        "scripts",
-        "tests",
-        "contracts",
-        "naming conventions",
-        "output paths",
-    ]
-    for fragment in required:
-        assert fragment in text, f"missing repo evidence rule: {fragment}"
+    require_fragments(
+        text,
+        [
+            "inspect existing docs",
+            "scripts",
+            "tests",
+            "contracts",
+            "naming conventions",
+            "output paths",
+        ],
+        "repo evidence rule",
+    )
 
 
 def test_sprint_rules_name_next_queue():
     text = read(DOC)
-    required = [
-        "Target Reduction Planner",
-        "English Report Renderer",
-        "Canonical Run Context",
-        "Survey Workflow Specs",
-        "End-to-End Harness Validator",
-        "Local MCP Server Skeletons",
-        "Standard CMD and PowerShell Renderers",
-        "Location/Subnet Candidate Planner",
-        "Dashboard Serial Controls Integration",
-        "Executor Guardrail Expansion",
-    ]
-    for fragment in required:
-        assert fragment in text, f"missing sprint queue item: {fragment}"
+    require_fragments(
+        text,
+        [
+            "Target Reduction Planner",
+            "English Report Renderer",
+            "Canonical Run Context",
+            "Survey Workflow Specs",
+            "End-to-End Harness Validator",
+            "Local MCP Server Skeletons",
+            "Standard CMD and PowerShell Renderers",
+            "Location/Subnet Candidate Planner",
+            "Dashboard Serial Controls Integration",
+            "Executor Guardrail Expansion",
+        ],
+        "sprint queue item",
+    )
 
 
 if __name__ == "__main__":

--- a/Tests/survey/test_sprint_working_rules_contracts.py
+++ b/Tests/survey/test_sprint_working_rules_contracts.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Static contract for SysAdminSuite sprint working rules."""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "SPRINTS.md"
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"missing expected file: {path.relative_to(ROOT).as_posix()}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_sprint_rules_require_repo_progress():
+    text = read(DOC)
+    required = [
+        "Implementation sprints should produce repository progress",
+        "tracked file changes",
+        "validation",
+        "Planning and next-agent prompts are closeout artifacts",
+        "not substitutes for implementation work",
+    ]
+    for fragment in required:
+        assert fragment in text, f"missing sprint progress rule: {fragment}"
+
+
+def test_sprint_rules_require_repo_evidence_before_new_patterns():
+    text = read(DOC)
+    required = [
+        "inspect existing docs",
+        "scripts",
+        "tests",
+        "contracts",
+        "naming conventions",
+        "output paths",
+    ]
+    for fragment in required:
+        assert fragment in text, f"missing repo evidence rule: {fragment}"
+
+
+def test_sprint_rules_name_next_queue():
+    text = read(DOC)
+    required = [
+        "Target Reduction Planner",
+        "English Report Renderer",
+        "Canonical Run Context",
+        "Survey Workflow Specs",
+        "End-to-End Harness Validator",
+        "Local MCP Server Skeletons",
+        "Standard CMD and PowerShell Renderers",
+        "Location/Subnet Candidate Planner",
+        "Dashboard Serial Controls Integration",
+        "Executor Guardrail Expansion",
+    ]
+    for fragment in required:
+        assert fragment in text, f"missing sprint queue item: {fragment}"
+
+
+if __name__ == "__main__":
+    test_sprint_rules_require_repo_progress()
+    test_sprint_rules_require_repo_evidence_before_new_patterns()
+    test_sprint_rules_name_next_queue()

--- a/docs/SPRINTS.md
+++ b/docs/SPRINTS.md
@@ -1,0 +1,22 @@
+# Sprint Working Rules
+
+Implementation sprints should produce repository progress: tracked file changes, validation, and Git continuity when available.
+
+Planning and next-agent prompts are closeout artifacts, not substitutes for implementation work.
+
+Before starting new work, inspect existing docs, scripts, tests, contracts, naming conventions, and output paths.
+
+Keep changes bounded. Reuse repo patterns. Avoid unrelated rewrites. Do not create dummy commits or duplicate pull requests.
+
+Recommended next SysAdminSuite sprint queue:
+
+1. Target Reduction Planner
+2. English Report Renderer
+3. Canonical Run Context
+4. Survey Workflow Specs
+5. End-to-End Harness Validator
+6. Local MCP Server Skeletons
+7. Standard CMD and PowerShell Renderers
+8. Location/Subnet Candidate Planner
+9. Dashboard Serial Controls Integration
+10. Executor Guardrail Expansion

--- a/docs/SPRINTS.md
+++ b/docs/SPRINTS.md
@@ -8,6 +8,12 @@ Before starting new work, inspect existing docs, scripts, tests, contracts, nami
 
 Keep changes bounded. Reuse repo patterns. Avoid unrelated rewrites. Do not create dummy commits or duplicate pull requests.
 
+## Enforcement
+
+The sprint rules are enforced by `Tests/survey/test_sprint_working_rules_contracts.py` and should be run directly when this document changes.
+
+Local hook coverage is provided by `.githooks/pre-push`, which runs the sprint working rules contract before push after the local harness hooks are installed.
+
 Recommended next SysAdminSuite sprint queue:
 
 1. Target Reduction Planner


### PR DESCRIPTION
## Summary

Commits the sprint working rules into the repo so implementation sprints are expected to produce tracked repo progress, validation, and Git/PR continuity instead of prompt-only output.

## Files

- `docs/SPRINTS.md`
- `Tests/survey/test_sprint_working_rules_contracts.py`

## Notes

The new static contract checks that the sprint rules require repo progress, repo evidence before new patterns, and a concrete next sprint queue.

I attempted to wire the new test into `tests/survey/run_offline_survey_tests.sh`, but the connector safety checker blocked the full-file rewrite. The test file is committed and can be run directly:

```bash
python3 Tests/survey/test_sprint_working_rules_contracts.py
```

## Validation

- Diff checked through GitHub compare: 2 files added, branch is ahead of `main` by 2 commits.
