### PR TITLE
feat(harness): add admin software install operator lane

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,6 +8,7 @@ echo "[sas-harness] pre-commit: running static guardrails"
 python3 Tests/survey/test_local_harness_contracts.py
 python3 Tests/survey/test_probe_socket_access_contracts.py
 python3 Tests/survey/test_standard_corporate_tooling_contracts.py
+python3 Tests/survey/test_software_install_harness_contracts.py
 
 blocked=0
 while IFS= read -r path; do

--- a/Tests/Pester/SoftwareInstallHarness.Tests.ps1
+++ b/Tests/Pester/SoftwareInstallHarness.Tests.ps1
@@ -10,6 +10,10 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
         $script:outputRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
     }
 
+    AfterEach {
+        Remove-Variable -Name SasRemoteCall -Scope Global -ErrorAction SilentlyContinue
+    }
+
     It 'exists and parses' {
         $script:installer | Should -Exist
         $tokens = $null
@@ -53,12 +57,12 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
     }
 
     It 'cleans run-specific staging after a copy failure' {
-        $script:remoteCall = 0
+        $global:SasRemoteCall = 0
         Mock Test-Path { return $true }
         Mock New-PSSession { [pscustomobject]@{ ComputerName = 'synthetic-target' } }
         Mock Invoke-Command {
-            $script:remoteCall++
-            if ($script:remoteCall -eq 1) {
+            $global:SasRemoteCall++
+            if ($global:SasRemoteCall -eq 1) {
                 return 'C:\ProgramData\SysAdminSuite\SoftwareInstall\software-install-20260710-120000'
             }
             return [pscustomobject]@{
@@ -90,12 +94,12 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
     }
 
     It 'preserves the original failure and reports cleanup uncertainty' {
-        $script:remoteCall = 0
+        $global:SasRemoteCall = 0
         Mock Test-Path { return $true }
         Mock New-PSSession { [pscustomobject]@{ ComputerName = 'synthetic-target' } }
         Mock Invoke-Command {
-            $script:remoteCall++
-            if ($script:remoteCall -eq 1) {
+            $global:SasRemoteCall++
+            if ($global:SasRemoteCall -eq 1) {
                 return 'C:\ProgramData\SysAdminSuite\SoftwareInstall\software-install-20260710-120000'
             }
             throw 'synthetic cleanup failure'

--- a/Tests/Pester/SoftwareInstallHarness.Tests.ps1
+++ b/Tests/Pester/SoftwareInstallHarness.Tests.ps1
@@ -59,7 +59,11 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
     It 'cleans run-specific staging after a copy failure' {
         $global:SasRemoteCall = 0
         Mock Test-Path { return $true }
-        Mock New-PSSession { [pscustomobject]@{ ComputerName = 'synthetic-target' } }
+        Mock New-PSSession {
+            [System.Runtime.Serialization.FormatterServices]::GetUninitializedObject(
+                [System.Management.Automation.Runspaces.PSSession]
+            )
+        }
         Mock Invoke-Command {
             $global:SasRemoteCall++
             if ($global:SasRemoteCall -eq 1) {
@@ -96,7 +100,11 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
     It 'preserves the original failure and reports cleanup uncertainty' {
         $global:SasRemoteCall = 0
         Mock Test-Path { return $true }
-        Mock New-PSSession { [pscustomobject]@{ ComputerName = 'synthetic-target' } }
+        Mock New-PSSession {
+            [System.Runtime.Serialization.FormatterServices]::GetUninitializedObject(
+                [System.Management.Automation.Runspaces.PSSession]
+            )
+        }
         Mock Invoke-Command {
             $global:SasRemoteCall++
             if ($global:SasRemoteCall -eq 1) {
@@ -124,3 +132,4 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
         Should -Invoke Remove-PSSession -Times 1 -Exactly
     }
 }
+

--- a/Tests/Pester/SoftwareInstallHarness.Tests.ps1
+++ b/Tests/Pester/SoftwareInstallHarness.Tests.ps1
@@ -37,6 +37,17 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
         Should -Invoke New-PSSession -Times 0 -Exactly
     }
 
+    It 'rejects a MaxTargets value above the 25-target ceiling' {
+        {
+            & $script:installer `
+                -ComputerName 'synthetic-target' `
+                -InstallerRelativePath 'Share\Package\setup.exe' `
+                -MaxTargets 26 `
+                -OutputRoot $script:outputRoot `
+                -WhatIf
+        } | Should -Throw '*MaxTargets*'
+    }
+
     It 'keeps WhatIf local and does not probe the share or target' {
         Mock Test-Path { return $true }
         Mock New-PSSession { throw 'New-PSSession must not be called' }

--- a/Tests/Pester/SoftwareInstallHarness.Tests.ps1
+++ b/Tests/Pester/SoftwareInstallHarness.Tests.ps1
@@ -7,11 +7,13 @@ BeforeAll {
 
 Describe 'Invoke-SasSoftwareInstall safety behavior' {
     BeforeEach {
-        $script:outputRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        $script:outputRoot = Join-Path $script:repoRoot ('survey\output\software_install\pester-' + [guid]::NewGuid().ToString('N'))
     }
 
     AfterEach {
-        Remove-Variable -Name SasRemoteCall -Scope Global -ErrorAction SilentlyContinue
+        if ([System.IO.Directory]::Exists($script:outputRoot)) {
+            [System.IO.Directory]::Delete($script:outputRoot, $true)
+        }
     }
 
     It 'exists and parses' {
@@ -33,6 +35,68 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
                 -OutputRoot $script:outputRoot `
                 -WhatIf
         } | Should -Throw '*not an approved software source*'
+
+        Should -Invoke New-PSSession -Times 0 -Exactly
+    }
+
+    It 'accepts the approved root with case and separator normalization' {
+        Mock New-PSSession { throw 'New-PSSession must not be called' }
+
+        $summary = & $script:installer `
+            -ComputerName 'synthetic-target' `
+            -InstallerRelativePath 'Share/Package/setup.exe' `
+            -SoftwareShareRoot '\\NT2KWB972SMS01/' `
+            -OutputRoot $script:outputRoot `
+            -WhatIf
+
+        $summary.planned_count | Should -Be 1
+        Should -Invoke New-PSSession -Times 0 -Exactly
+    }
+
+    It 'rejects a deceptive near-prefix software root' {
+        Mock New-PSSession { throw 'New-PSSession must not be called' }
+
+        {
+            & $script:installer `
+                -ComputerName 'synthetic-target' `
+                -InstallerRelativePath 'Share\Package\setup.exe' `
+                -SoftwareShareRoot '\\nt2kwb972sms01.evil\' `
+                -OutputRoot $script:outputRoot `
+                -WhatIf
+        } | Should -Throw '*not an approved software source*'
+
+        Should -Invoke New-PSSession -Times 0 -Exactly
+    }
+
+    It 'rejects rooted and parent-traversal installer paths before target contact' -ForEach @(
+        @{ RejectedPath = 'C:\Temp\setup.exe'; ExpectedError = '*must be relative*' }
+        @{ RejectedPath = 'Share\..\setup.exe'; ExpectedError = '*parent-directory traversal*' }
+        @{ RejectedPath = 'Share/../setup.exe'; ExpectedError = '*parent-directory traversal*' }
+    ) {
+        Mock New-PSSession { throw 'New-PSSession must not be called' }
+
+        {
+            & $script:installer `
+                -ComputerName 'synthetic-target' `
+                -InstallerRelativePath $RejectedPath `
+                -OutputRoot $script:outputRoot `
+                -WhatIf
+        } | Should -Throw $ExpectedError
+
+        Should -Invoke New-PSSession -Times 0 -Exactly
+    }
+
+    It 'rejects output outside approved generated roots' {
+        Mock New-PSSession { throw 'New-PSSession must not be called' }
+        $outsideRoot = Join-Path $TestDrive 'outside-approved-output'
+
+        {
+            & $script:installer `
+                -ComputerName 'synthetic-target' `
+                -InstallerRelativePath 'Share\Package\setup.exe' `
+                -OutputRoot $outsideRoot `
+                -WhatIf
+        } | Should -Throw '*outside approved generated output roots*'
 
         Should -Invoke New-PSSession -Times 0 -Exactly
     }
@@ -62,13 +126,14 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
 
         $summary.planned_count | Should -Be 1
         Should -Invoke Test-Path -Times 0 -Exactly -ParameterFilter { $LiteralPath -like '\\*' }
+        Should -Invoke Test-Path -Times 0 -Exactly -ParameterFilter { $Path -like '\\*' }
+        Should -Invoke Test-Path -Times 0 -Exactly -ParameterFilter { $args[0] -like '\\*' }
         Should -Invoke New-PSSession -Times 0 -Exactly
         Should -Invoke Invoke-Command -Times 0 -Exactly
         Should -Invoke Copy-Item -Times 0 -Exactly
     }
 
     It 'cleans run-specific staging after a copy failure' {
-        $global:SasRemoteCall = 0
         Mock Test-Path { return $true }
         Mock New-PSSession {
             [System.Runtime.Serialization.FormatterServices]::GetUninitializedObject(
@@ -76,10 +141,11 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
             )
         }
         Mock Invoke-Command {
-            $global:SasRemoteCall++
-            if ($global:SasRemoteCall -eq 1) {
-                return 'C:\ProgramData\SysAdminSuite\SoftwareInstall\software-install-20260710-120000'
-            }
+            return "C:\ProgramData\SysAdminSuite\SoftwareInstall\$($ArgumentList[0])"
+        } -ParameterFilter {
+            $ScriptBlock.ToString() -match 'New-Item -ItemType Directory'
+        } -RemoveParameterType Session
+        Mock Invoke-Command {
             return [pscustomobject]@{
                 cleanup_attempted = $true
                 cleanup_succeeded = $true
@@ -87,6 +153,8 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
                 pruned_empty_parent_dirs = @()
                 error = $null
             }
+        } -ParameterFilter {
+            $ScriptBlock.ToString() -match 'repo_owned_stage_root'
         } -RemoveParameterType Session
         Mock Copy-Item { throw 'synthetic copy failure' } -RemoveParameterType ToSession
         Mock Remove-PSSession {} -RemoveParameterType Session
@@ -105,11 +173,14 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
         $summary.results[0].cleanup_succeeded | Should -BeTrue
         $summary.results[0].repo_artifact_remaining | Should -BeFalse
         Should -Invoke Invoke-Command -Times 2 -Exactly
+        Should -Invoke Invoke-Command -Times 1 -Exactly -ParameterFilter {
+            $ScriptBlock.ToString() -match 'repo_owned_stage_root' -and
+            $ArgumentList[0] -eq $summary.run_id
+        }
         Should -Invoke Remove-PSSession -Times 1 -Exactly
     }
 
     It 'preserves the original failure and reports cleanup uncertainty' {
-        $global:SasRemoteCall = 0
         Mock Test-Path { return $true }
         Mock New-PSSession {
             [System.Runtime.Serialization.FormatterServices]::GetUninitializedObject(
@@ -117,11 +188,14 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
             )
         }
         Mock Invoke-Command {
-            $global:SasRemoteCall++
-            if ($global:SasRemoteCall -eq 1) {
-                return 'C:\ProgramData\SysAdminSuite\SoftwareInstall\software-install-20260710-120000'
-            }
+            return "C:\ProgramData\SysAdminSuite\SoftwareInstall\$($ArgumentList[0])"
+        } -ParameterFilter {
+            $ScriptBlock.ToString() -match 'New-Item -ItemType Directory'
+        } -RemoveParameterType Session
+        Mock Invoke-Command {
             throw 'synthetic cleanup failure'
+        } -ParameterFilter {
+            $ScriptBlock.ToString() -match 'repo_owned_stage_root'
         } -RemoveParameterType Session
         Mock Copy-Item { throw 'synthetic copy failure' } -RemoveParameterType ToSession
         Mock Remove-PSSession {} -RemoveParameterType Session
@@ -138,9 +212,31 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
         $summary.results[0].cleanup_attempted | Should -BeTrue
         $summary.results[0].cleanup_succeeded | Should -BeFalse
         $summary.results[0].repo_artifact_remaining | Should -BeTrue
+        $summary.failed_count | Should -Be 1
         $summary.cleanup_failure_count | Should -Be 1
         $summary.repo_artifact_remaining_count | Should -Be 1
+        Should -Invoke Invoke-Command -Times 1 -Exactly -ParameterFilter {
+            $ScriptBlock.ToString() -match 'repo_owned_stage_root' -and
+            $ArgumentList[0] -eq $summary.run_id
+        }
         Should -Invoke Remove-PSSession -Times 1 -Exactly
+    }
+
+    It 'creates collision-safe run identifiers for back-to-back plans' {
+        $first = & $script:installer `
+            -ComputerName 'synthetic-target' `
+            -InstallerRelativePath 'Share\Package\setup.exe' `
+            -OutputRoot $script:outputRoot `
+            -WhatIf
+        $second = & $script:installer `
+            -ComputerName 'synthetic-target' `
+            -InstallerRelativePath 'Share\Package\setup.exe' `
+            -OutputRoot $script:outputRoot `
+            -WhatIf
+
+        $first.run_id | Should -Not -Be $second.run_id
+        $first.run_id | Should -Match '^software-install-[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$'
+        $second.run_id | Should -Match '^software-install-[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$'
     }
 }
 

--- a/Tests/Pester/SoftwareInstallHarness.Tests.ps1
+++ b/Tests/Pester/SoftwareInstallHarness.Tests.ps1
@@ -34,12 +34,7 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
     }
 
     It 'keeps WhatIf local and does not probe the share or target' {
-        $script:testedPaths = [System.Collections.Generic.List[string]]::new()
-        Mock Test-Path {
-            param($LiteralPath)
-            $script:testedPaths.Add([string]$LiteralPath)
-            return $true
-        }
+        Mock Test-Path { return $true }
         Mock New-PSSession { throw 'New-PSSession must not be called' }
         Mock Invoke-Command { throw 'Invoke-Command must not be called' }
         Mock Copy-Item { throw 'Copy-Item must not be called' }
@@ -51,7 +46,7 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
             -WhatIf
 
         $summary.planned_count | Should -Be 1
-        @($script:testedPaths | Where-Object { $_.StartsWith('\\') }).Count | Should -Be 0
+        Should -Invoke Test-Path -Times 0 -Exactly -ParameterFilter { $LiteralPath -like '\\*' }
         Should -Invoke New-PSSession -Times 0 -Exactly
         Should -Invoke Invoke-Command -Times 0 -Exactly
         Should -Invoke Copy-Item -Times 0 -Exactly
@@ -73,9 +68,9 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
                 pruned_empty_parent_dirs = @()
                 error = $null
             }
-        }
-        Mock Copy-Item { throw 'synthetic copy failure' }
-        Mock Remove-PSSession {}
+        } -RemoveParameterType Session
+        Mock Copy-Item { throw 'synthetic copy failure' } -RemoveParameterType ToSession
+        Mock Remove-PSSession {} -RemoveParameterType Session
 
         $summary = & $script:installer `
             -ComputerName 'synthetic-target' `
@@ -104,9 +99,9 @@ Describe 'Invoke-SasSoftwareInstall safety behavior' {
                 return 'C:\ProgramData\SysAdminSuite\SoftwareInstall\software-install-20260710-120000'
             }
             throw 'synthetic cleanup failure'
-        }
-        Mock Copy-Item { throw 'synthetic copy failure' }
-        Mock Remove-PSSession {}
+        } -RemoveParameterType Session
+        Mock Copy-Item { throw 'synthetic copy failure' } -RemoveParameterType ToSession
+        Mock Remove-PSSession {} -RemoveParameterType Session
 
         $summary = & $script:installer `
             -ComputerName 'synthetic-target' `

--- a/Tests/survey/test_local_harness_contracts.py
+++ b/Tests/survey/test_local_harness_contracts.py
@@ -55,6 +55,7 @@ def test_local_hooks_run_expected_contracts_and_block_generated_evidence():
         "python3 Tests/survey/test_local_harness_contracts.py",
         "python3 Tests/survey/test_probe_socket_access_contracts.py",
         "python3 Tests/survey/test_standard_corporate_tooling_contracts.py",
+        "python3 Tests/survey/test_software_install_harness_contracts.py",
         "git diff --cached --name-only",
         "survey/output/*",
         "logs/*",
@@ -82,6 +83,7 @@ def test_harness_api_manifest_is_local_first_and_has_required_operations():
     assert posture["default_network_activity"] is False
     assert posture["default_target_mutation"] is False
     assert posture["evidence_scope"] == "local_gitignored_artifacts"
+    assert "\\\\nt2kwb972sms01\\" in posture["approved_software_sources"]
 
     allowed_modes = {"plan_only", "local_read", "local_transform", "operator_execute"}
     assert set(api["modes"]) == allowed_modes
@@ -93,16 +95,30 @@ def test_harness_api_manifest_is_local_first_and_has_required_operations():
         "standard_probe.render_powershell",
         "report.generate_from_artifacts",
         "mcp.catalog.list",
+        "software_install.operator_execute",
     }
     assert required_ids <= set(operations), f"missing harness API operations: {required_ids - set(operations)}"
 
     for op_id, op in operations.items():
         assert op["mode"] in allowed_modes, f"invalid mode for {op_id}"
-        assert op["network_activity"] is False, f"first harness API must be non-network: {op_id}"
-        assert op["target_mutation"] is False, f"first harness API must not mutate targets: {op_id}"
         assert op["inputs"], f"operation must name inputs: {op_id}"
         assert op["outputs"], f"operation must name outputs: {op_id}"
         assert op["guardrails"], f"operation must name guardrails: {op_id}"
+
+        if op_id == "software_install.operator_execute":
+            assert op["mode"] == "operator_execute"
+            assert op["network_activity"] is True
+            assert op["target_mutation"] is True
+            for guardrail in [
+                "Approved_read_only_software_share_only",
+                "No_credential_collection",
+                "No_monitoring_bypass_or_log_suppression",
+                "Temporary_staging_must_be_removed_and_cleanup_status_reported",
+            ]:
+                assert guardrail in op["guardrails"]
+        else:
+            assert op["network_activity"] is False, f"planner/local API must be non-network: {op_id}"
+            assert op["target_mutation"] is False, f"planner/local API must not mutate targets: {op_id}"
 
     target_reduction = operations["target_reduction.plan"]
     for output in [
@@ -141,6 +157,7 @@ def test_local_mcp_catalog_only_exposes_allowed_apis():
         assert server["target_mutation"] is False, server["id"]
         assert server["allowed_apis"], server["id"]
         assert set(server["allowed_apis"]) <= allowed_api_ids, server["id"]
+        assert "software_install.operator_execute" not in set(server["allowed_apis"]), server["id"]
         assert server["guardrails"], server["id"]
 
 
@@ -169,6 +186,7 @@ def test_harness_contract_is_wired_into_local_runner_and_ci():
     runner = read(RUNNER)
     workflow = read(WORKFLOW)
     assert "python3 Tests/survey/test_local_harness_contracts.py" in runner
+    assert "python3 Tests/survey/test_software_install_harness_contracts.py" in runner
     assert "Tests/survey/test_local_harness_contracts.py" in workflow
     assert "Local harness contracts" in workflow
 

--- a/Tests/survey/test_local_harness_contracts.py
+++ b/Tests/survey/test_local_harness_contracts.py
@@ -113,7 +113,9 @@ def test_harness_api_manifest_is_local_first_and_has_required_operations():
                 "Approved_read_only_software_share_only",
                 "No_credential_collection",
                 "No_monitoring_bypass_or_log_suppression",
-                "Temporary_staging_must_be_removed_and_cleanup_status_reported",
+                "No_repo_owned_target_logs_reports_manifests_or_transcripts",
+                "Run_specific_staging_cleanup_attempted_on_all_failure_paths",
+                "Prune_empty_SysAdminSuite_target_directories",
             ]:
                 assert guardrail in op["guardrails"]
         else:

--- a/Tests/survey/test_software_install_harness_contracts.py
+++ b/Tests/survey/test_software_install_harness_contracts.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Static contracts for the SysAdminSuite approved software install harness."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+API = ROOT / "harness" / "api" / "sas-harness-api.json"
+DOC = ROOT / "docs" / "SOFTWARE_INSTALL_HARNESS.md"
+SCRIPT = ROOT / "scripts" / "Invoke-SasSoftwareInstall.ps1"
+SCHEMA = ROOT / "schemas" / "harness" / "software-install-request.schema.json"
+RUNNER = ROOT / "tests" / "survey" / "run_offline_survey_tests.sh"
+PRE_COMMIT = ROOT / ".githooks" / "pre-commit"
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"missing expected file: {path.relative_to(ROOT).as_posix()}"
+    return path.read_text(encoding="utf-8")
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(read(path))
+
+
+def test_api_manifest_declares_gated_operator_execute_surface():
+    api = load_json(API)
+    operations = {op["id"]: op for op in api["operations"]}
+    op = operations["software_install.operator_execute"]
+
+    assert op["mode"] == "operator_execute"
+    assert op["network_activity"] is True
+    assert op["target_mutation"] is True
+
+    required_inputs = {
+        "approved_targets_csv_or_computer_name",
+        "package_name",
+        "installer_relative_path",
+        "software_share_root",
+        "installer_arguments",
+        "explicit_allow_target_mutation",
+    }
+    assert required_inputs <= set(op["inputs"])
+
+    required_guardrails = {
+        "Approved_admin_context_only",
+        "Approved_read_only_software_share_only",
+        "No_credential_collection",
+        "No_monitoring_bypass_or_log_suppression",
+        "No_unapproved_background_services",
+        "Prefer_UNC_direct_install_to_avoid_target_staging",
+        "Temporary_staging_must_be_removed_and_cleanup_status_reported",
+        "Local_gitignored_evidence_only",
+    }
+    assert required_guardrails <= set(op["guardrails"])
+
+
+def test_document_names_no_artifact_boundary_without_stealth_claims():
+    text = read(DOC)
+    required = [
+        "not stealth tooling",
+        "must not suppress Windows logs",
+        "no persistent SysAdminSuite staging payloads",
+        "\\\\nt2kwb972sms01\\",
+        "UncDirect",
+        "CopyThenInstall",
+        "Cleanup failure is a reportable failure",
+        "Generated run artifacts stay in gitignored local output paths",
+    ]
+    for fragment in required:
+        assert fragment in text, f"missing software install doc fragment: {fragment}"
+
+
+def test_script_enforces_approved_source_and_explicit_mutation_gate():
+    text = read(SCRIPT)
+    required = [
+        "[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]",
+        "\\\\nt2kwb972sms01\\",
+        "Resolve-SasApprovedInstallerPath",
+        "InstallerRelativePath must be relative",
+        "parent-directory traversal",
+        "-AllowTargetMutation",
+        "Refusing target mutation without -AllowTargetMutation",
+        "No targets were supplied",
+        "exceeds MaxTargets",
+        "New-PSSession -ComputerName $target",
+        "Copy-Item -LiteralPath $installerPath -Destination $remoteInstallerPath -ToSession $session -Force",
+        "Remove-Item -LiteralPath $stageRoot -Recurse -Force",
+        "cleanup_failure_count",
+        "no_monitoring_bypass_or_log_suppression",
+    ]
+    for fragment in required:
+        assert fragment in text, f"missing software install script fragment: {fragment}"
+
+    forbidden = [
+        "Clear-EventLog",
+        "wevtutil cl",
+        "Remove-EventLog",
+        "New-Service",
+        "Register-ScheduledTask",
+        "-Credential",
+    ]
+    for fragment in forbidden:
+        assert fragment not in text, f"forbidden software install script fragment present: {fragment}"
+
+
+def test_schema_keeps_requests_bounded():
+    schema = load_json(SCHEMA)
+    assert schema["title"] == "SysAdminSuite software install request"
+    assert schema["properties"]["software_share_root"]["default"] == "\\\\nt2kwb972sms01\\"
+    assert schema["properties"]["targets"]["maxItems"] == 25
+    assert schema["properties"]["allow_target_mutation"]["const"] is True
+    assert schema["properties"]["install_mode"]["enum"] == ["UncDirect", "CopyThenInstall"]
+
+
+def test_contract_is_wired_into_offline_runner_and_precommit():
+    runner = read(RUNNER)
+    pre_commit = read(PRE_COMMIT)
+    assert "python3 Tests/survey/test_software_install_harness_contracts.py" in runner
+    assert "python3 Tests/survey/test_software_install_harness_contracts.py" in pre_commit
+
+
+if __name__ == "__main__":
+    test_api_manifest_declares_gated_operator_execute_surface()
+    test_document_names_no_artifact_boundary_without_stealth_claims()
+    test_script_enforces_approved_source_and_explicit_mutation_gate()
+    test_schema_keeps_requests_bounded()
+    test_contract_is_wired_into_offline_runner_and_precommit()

--- a/Tests/survey/test_software_install_harness_contracts.py
+++ b/Tests/survey/test_software_install_harness_contracts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 API = ROOT / "harness" / "api" / "sas-harness-api.json"
 DOC = ROOT / "docs" / "SOFTWARE_INSTALL_HARNESS.md"
+LOCAL_DOC = ROOT / "docs" / "LOCAL_DEVELOPMENT_HARNESS.md"
 SCRIPT = ROOT / "scripts" / "Invoke-SasSoftwareInstall.ps1"
 SCHEMA = ROOT / "schemas" / "harness" / "software-install-request.schema.json"
 RUNNER = ROOT / "tests" / "survey" / "run_offline_survey_tests.sh"
@@ -48,8 +49,10 @@ def test_api_manifest_declares_gated_operator_execute_surface():
         "No_credential_collection",
         "No_monitoring_bypass_or_log_suppression",
         "No_unapproved_background_services",
+        "No_repo_owned_target_logs_reports_manifests_or_transcripts",
         "Prefer_UNC_direct_install_to_avoid_target_staging",
-        "Temporary_staging_must_be_removed_and_cleanup_status_reported",
+        "Run_specific_staging_cleanup_attempted_on_all_failure_paths",
+        "Prune_empty_SysAdminSuite_target_directories",
         "Local_gitignored_evidence_only",
     }
     assert required_guardrails <= set(op["guardrails"])
@@ -60,15 +63,25 @@ def test_document_names_no_artifact_boundary_without_stealth_claims():
     required = [
         "not stealth tooling",
         "must not suppress Windows logs",
-        "no persistent SysAdminSuite staging payloads",
+        "no persistent SysAdminSuite-owned staging payloads, reports, manifests, transcripts, scripts, or evidence",
+        "installer-owned files, logs, registry changes, caches, services, or records",
         "\\\\nt2kwb972sms01\\",
         "UncDirect",
         "CopyThenInstall",
+        "%ProgramData%\\SysAdminSuite\\SoftwareInstall\\<run_id>",
+        "Cleanup is attempted from both the normal remote installer `finally` block and the outer failure path",
         "Cleanup failure is a reportable failure",
         "Generated run artifacts stay in gitignored local output paths",
     ]
     for fragment in required:
         assert fragment in text, f"missing software install doc fragment: {fragment}"
+
+    local_text = read(LOCAL_DOC)
+    for fragment in [
+        "no persistent SysAdminSuite-owned staging payload, log, report, manifest, transcript, script, or evidence",
+        "prune empty `ProgramData\\SysAdminSuite\\SoftwareInstall` and `ProgramData\\SysAdminSuite` parent directories",
+    ]:
+        assert fragment in local_text, f"missing local harness software posture fragment: {fragment}"
 
 
 def test_script_enforces_approved_source_and_explicit_mutation_gate():
@@ -85,9 +98,15 @@ def test_script_enforces_approved_source_and_explicit_mutation_gate():
         "exceeds MaxTargets",
         "New-PSSession -ComputerName $target",
         "Copy-Item -LiteralPath $installerPath -Destination $remoteInstallerPath -ToSession $session -Force",
+        "Remove-SasRepoOwnedInstallArtifacts",
+        "$remoteRepoCleanup",
         "Remove-Item -LiteralPath $stageRoot -Recurse -Force",
+        "pruned_empty_parent_dirs",
+        "repo_artifact_remaining_count",
         "operator_handoff.txt",
         "cleanup_failure_count",
+        "no_repo_owned_target_logs_reports_manifests_or_transcripts",
+        "run_specific_staging_cleanup_attempted_on_all_failure_paths",
         "no_monitoring_bypass_or_log_suppression",
     ]
     for fragment in required:
@@ -99,6 +118,8 @@ def test_script_enforces_approved_source_and_explicit_mutation_gate():
         "Remove-EventLog",
         "New-Service",
         "Register-ScheduledTask",
+        "Start-Transcript",
+        "Stop-Transcript",
         "-Credential",
     ]
     for fragment in forbidden:

--- a/Tests/survey/test_software_install_harness_contracts.py
+++ b/Tests/survey/test_software_install_harness_contracts.py
@@ -86,6 +86,7 @@ def test_script_enforces_approved_source_and_explicit_mutation_gate():
         "New-PSSession -ComputerName $target",
         "Copy-Item -LiteralPath $installerPath -Destination $remoteInstallerPath -ToSession $session -Force",
         "Remove-Item -LiteralPath $stageRoot -Recurse -Force",
+        "operator_handoff.txt",
         "cleanup_failure_count",
         "no_monitoring_bypass_or_log_suppression",
     ]
@@ -109,6 +110,7 @@ def test_schema_keeps_requests_bounded():
     assert schema["title"] == "SysAdminSuite software install request"
     assert schema["properties"]["software_share_root"]["default"] == "\\\\nt2kwb972sms01\\"
     assert schema["properties"]["targets"]["maxItems"] == 25
+    assert "allow_target_mutation" in schema["required"]
     assert schema["properties"]["allow_target_mutation"]["const"] is True
     assert schema["properties"]["install_mode"]["enum"] == ["UncDirect", "CopyThenInstall"]
 

--- a/Tests/survey/test_software_install_harness_contracts.py
+++ b/Tests/survey/test_software_install_harness_contracts.py
@@ -104,6 +104,8 @@ def test_script_enforces_approved_source_and_explicit_mutation_gate():
         "No targets were supplied",
         "exceeds MaxTargets",
         "[ValidateRange(1, 25)]",
+        "Assert-SasApprovedOutputPath -Path $OutputRoot",
+        "[guid]::NewGuid()",
         "New-PSSession -ComputerName $target",
         "New-PSSessionOption -OpenTimeout 30000 -OperationTimeout 3600000",
         "WaitForExit($installerTimeoutMilliseconds)",
@@ -161,11 +163,16 @@ def test_behavioral_pester_covers_dry_run_and_cleanup_failures():
     text = read(PESTER)
     for fragment in [
         "rejects an arbitrary UNC root before contacting it",
+        "accepts the approved root with case and separator normalization",
+        "rejects a deceptive near-prefix software root",
+        "rejects rooted and parent-traversal installer paths before target contact",
+        "rejects output outside approved generated roots",
         "keeps WhatIf local and does not probe the share or target",
         "cleans run-specific staging after a copy failure",
         "preserves the original failure and reports cleanup uncertainty",
         "Should -Invoke New-PSSession -Times 0 -Exactly",
         "Should -Invoke Invoke-Command -Times 2 -Exactly",
+        "creates collision-safe run identifiers for back-to-back plans",
     ]:
         assert fragment in text, f"missing behavioral Pester fragment: {fragment}"
 

--- a/Tests/survey/test_software_install_harness_contracts.py
+++ b/Tests/survey/test_software_install_harness_contracts.py
@@ -35,14 +35,15 @@ def test_api_manifest_declares_gated_operator_execute_surface():
     assert op["target_mutation"] is True
 
     required_inputs = {
-        "approved_targets_csv_or_computer_name",
         "package_name",
         "installer_relative_path",
+        "install_mode",
+        "targets",
+        "allow_target_mutation",
         "software_share_root",
         "installer_arguments",
-        "explicit_allow_target_mutation",
     }
-    assert required_inputs <= set(op["inputs"])
+    assert set(op["inputs"]) == required_inputs
 
     required_guardrails = {
         "Approved_admin_context_only",
@@ -81,8 +82,11 @@ def test_document_names_no_artifact_boundary_without_stealth_claims():
     for fragment in [
         "no persistent SysAdminSuite-owned staging payload, log, report, manifest, transcript, script, or evidence",
         "prune empty `ProgramData\\SysAdminSuite\\SoftwareInstall` and `ProgramData\\SysAdminSuite` parent directories",
+        '& "$env:ProgramFiles\\Git\\bin\\bash.exe" scripts/install-local-harness-hooks.sh',
     ]:
         assert fragment in local_text, f"missing local harness software posture fragment: {fragment}"
+
+    assert text.count("pwsh -NoProfile -Command") >= 2
 
 
 def test_script_enforces_approved_source_and_explicit_mutation_gate():
@@ -99,7 +103,11 @@ def test_script_enforces_approved_source_and_explicit_mutation_gate():
         "Refusing target mutation without -AllowTargetMutation",
         "No targets were supplied",
         "exceeds MaxTargets",
+        "[ValidateRange(1, 25)]",
         "New-PSSession -ComputerName $target",
+        "New-PSSessionOption -OpenTimeout 30000 -OperationTimeout 3600000",
+        "WaitForExit($installerTimeoutMilliseconds)",
+        "Installer timed out after",
         "Copy-Item -LiteralPath $installerPath -Destination $remoteInstallerPath -ToSession $session -Force",
         "Remove-SasRepoOwnedInstallArtifacts",
         "$remoteRepoCleanup",
@@ -169,3 +177,4 @@ if __name__ == "__main__":
     test_schema_keeps_requests_bounded()
     test_contract_is_wired_into_offline_runner_and_precommit()
     test_behavioral_pester_covers_dry_run_and_cleanup_failures()
+

--- a/docs/LOCAL_DEVELOPMENT_HARNESS.md
+++ b/docs/LOCAL_DEVELOPMENT_HARNESS.md
@@ -47,6 +47,10 @@ Developers can install the hooks with:
 bash scripts/install-local-harness-hooks.sh
 ```
 
+```powershell
+& "$env:ProgramFiles\Git\bin\bash.exe" scripts/install-local-harness-hooks.sh
+```
+
 ## API posture
 
 Harness APIs are operation contracts, not remote services by default.
@@ -143,3 +147,4 @@ operator_handoff.txt
 ```
 
 That planner should implement the API operation `target_reduction.plan` and stay plan-only/local-transform before any new probe execution is introduced.
+

--- a/docs/LOCAL_DEVELOPMENT_HARNESS.md
+++ b/docs/LOCAL_DEVELOPMENT_HARNESS.md
@@ -89,9 +89,9 @@ The approved software source root is:
 \\nt2kwb972sms01\
 ```
 
-Software install work should prefer direct UNC execution from the read-only source so SysAdminSuite does not stage installer payloads on the target. If staging is required, the wrapper must stage only under a run-specific `ProgramData\SysAdminSuite\SoftwareInstall\<run_id>` folder, remove that folder after execution, and report cleanup status locally.
+Software install work should prefer direct UNC execution from the read-only source so SysAdminSuite does not stage installer payloads on the target. If staging is required, the wrapper must stage only under a run-specific `ProgramData\SysAdminSuite\SoftwareInstall\<run_id>` folder, remove that run folder after execution, and prune empty `ProgramData\SysAdminSuite\SoftwareInstall` and `ProgramData\SysAdminSuite` parent directories when no sibling run artifacts remain.
 
-The no-artifact boundary means no persistent SysAdminSuite staging payload should remain on the target. It does not mean the harness clears Windows event logs, installer logs, registry keys, endpoint-management records, or the installed software's own files.
+The no-artifact boundary means no persistent SysAdminSuite-owned staging payload, log, report, manifest, transcript, script, or evidence should remain on the target. Installer-owned files, installer logs, registry changes, caches, services, and endpoint-management records belong to the software install itself. SysAdminSuite does not erase operating-system audit logs; it avoids and cleans its own target filesystem remnants.
 
 See `docs/SOFTWARE_INSTALL_HARNESS.md` and `scripts/Invoke-SasSoftwareInstall.ps1` for the concrete contract.
 

--- a/docs/LOCAL_DEVELOPMENT_HARNESS.md
+++ b/docs/LOCAL_DEVELOPMENT_HARNESS.md
@@ -9,7 +9,7 @@ It has four jobs:
 3. Catalog local MCP servers that expose repo capabilities without bypassing guardrails.
 4. Make reports emerge from local artifacts instead of ad hoc explanation after the fact.
 
-This harness is for authorized local development and approved operator workflows. It must not introduce hidden network activity, target-side artifacts, credential collection, log suppression, or monitoring bypass behavior.
+This harness is for authorized local development and approved operator workflows. It must not introduce hidden network activity, persistent target-side artifacts, credential collection, log suppression, or monitoring bypass behavior.
 
 ## Harness layers
 
@@ -27,7 +27,7 @@ This harness is for authorized local development and approved operator workflows
 
 The pre-commit hook is a fast local guard. It should:
 
-- run harness, socket-boundary, and standard tooling static contracts;
+- run harness, socket-boundary, standard tooling, and software-install static contracts;
 - block staged generated evidence paths;
 - block accidental commit of live operational files such as generated probe outputs, serial evidence, host/IP/MAC exports, or local MCP runtime logs;
 - stay local-only and avoid network actions.
@@ -71,13 +71,29 @@ Approved modes:
 | `local_transform` | Converts local evidence into reports or reduced target lists. |
 | `operator_execute` | May execute only through an approved wrapper and must be separately gated. |
 
-The first harness APIs are deliberately plan-only or local-transform:
+The default harness APIs are deliberately plan-only or local-transform:
 
 - `target_reduction.plan`
 - `standard_probe.render_cmd`
 - `standard_probe.render_powershell`
 - `report.generate_from_artifacts`
 - `mcp.catalog.list`
+
+The software install lane is intentionally different. `software_install.operator_execute` is an approved operator-execute surface because installing software mutates authorized targets. It must be gated by explicit operator intent, approved source roots, bounded target lists, local evidence, and cleanup reporting. It must not suppress Windows logs, bypass monitoring, collect credentials, or create persistence.
+
+## Software install posture
+
+The approved software source root is:
+
+```text
+\\nt2kwb972sms01\
+```
+
+Software install work should prefer direct UNC execution from the read-only source so SysAdminSuite does not stage installer payloads on the target. If staging is required, the wrapper must stage only under a run-specific `ProgramData\SysAdminSuite\SoftwareInstall\<run_id>` folder, remove that folder after execution, and report cleanup status locally.
+
+The no-artifact boundary means no persistent SysAdminSuite staging payload should remain on the target. It does not mean the harness clears Windows event logs, installer logs, registry keys, endpoint-management records, or the installed software's own files.
+
+See `docs/SOFTWARE_INSTALL_HARNESS.md` and `scripts/Invoke-SasSoftwareInstall.ps1` for the concrete contract.
 
 ## Local MCP posture
 

--- a/docs/SOFTWARE_INSTALL_HARNESS.md
+++ b/docs/SOFTWARE_INSTALL_HARNESS.md
@@ -1,0 +1,100 @@
+# Admin Software Install Harness
+
+## Purpose
+
+SysAdminSuite needs a controlled operator-execute lane for installing approved software from an approved read-only software source onto authorized target computers.
+
+This lane is intentionally not stealth tooling. It must not suppress Windows logs, bypass monitoring, collect credentials, or hide the fact that an authorized install occurred. The no-artifact requirement means no persistent SysAdminSuite staging payloads should remain on the target after the run. The installed software, normal installer traces, endpoint management records, and Windows event logs are expected client records.
+
+## Approved source
+
+Initial approved source root:
+
+```text
+\\nt2kwb972sms01\
+```
+
+The operator supplies an installer path relative to that root, for example:
+
+```text
+SomeShare\Vendor\Package\setup.exe
+```
+
+The harness rejects installer paths that are absolute, use `..`, or do not resolve under the approved source root.
+
+## Modes
+
+| Mode | Target staging | Use when |
+| --- | --- | --- |
+| `UncDirect` | None by SysAdminSuite | The target can execute the installer directly from the approved read-only share. |
+| `CopyThenInstall` | Temporary `ProgramData\SysAdminSuite\SoftwareInstall\<run_id>` | The installer must be copied from the admin box to the target before execution. |
+
+`UncDirect` is preferred because it avoids placing the installer payload on the target. `CopyThenInstall` is allowed only when direct UNC execution is not practical. When staging is used, the wrapper removes the staging directory in a `finally` cleanup block and records cleanup status in local evidence.
+
+## Operator contract
+
+The install wrapper must require all of the following:
+
+1. An explicit target list through `-ComputerName` or `-TargetsCsv`.
+2. An installer path under the approved software source root.
+3. Explicit `-AllowTargetMutation` unless running with `-WhatIf`.
+4. Local output under `survey/output/software_install/<run_id>/` or another operator-supplied local output root.
+5. Per-target status events written locally as JSONL.
+6. A summary JSON that names targets, installer, mode, exit codes, staging cleanup status, and unresolved failures.
+
+## Guardrails
+
+The lane must preserve these boundaries:
+
+- Authorized admin context only.
+- Approved read-only software share only.
+- No credential collection or embedded credentials.
+- No monitoring bypass, log suppression, or event-log cleanup.
+- No hidden listeners, services, agents, persistence, or background daemons.
+- No broad network discovery from this operation.
+- No target-side SysAdminSuite staging artifacts after completion when cleanup succeeds.
+- Cleanup failure is a reportable failure, not something to hide.
+- Generated run artifacts stay in gitignored local output paths.
+
+## Expected artifacts
+
+Each run should produce local evidence similar to:
+
+```text
+survey/output/software_install/<run_id>/
+  software_install_events.jsonl
+  software_install_summary.json
+```
+
+The evidence belongs on the admin box. It should be used to update the client-facing deployment tracker without writing extra audit files to target hosts.
+
+## Example dry run
+
+```powershell
+.\scripts\Invoke-SasSoftwareInstall.ps1 `
+  -ComputerName WNH269OPR009 `
+  -PackageName ExampleVendorTool `
+  -InstallerRelativePath 'SomeShare\Vendor\Package\setup.exe' `
+  -InstallerArguments @('/quiet', '/norestart') `
+  -InstallMode UncDirect `
+  -WhatIf
+```
+
+## Example approved execution
+
+```powershell
+.\scripts\Invoke-SasSoftwareInstall.ps1 `
+  -TargetsCsv .\targets\local\approved-software-targets.csv `
+  -PackageName ExampleVendorTool `
+  -InstallerRelativePath 'SomeShare\Vendor\Package\setup.exe' `
+  -InstallerArguments @('/quiet', '/norestart') `
+  -InstallMode CopyThenInstall `
+  -AllowTargetMutation `
+  -Confirm:$false
+```
+
+## Known operational limits
+
+- Some installers create their own logs, caches, services, scheduled tasks, or registry keys. That is part of the software installation, not SysAdminSuite staging.
+- Direct UNC execution can fail if the target cannot read the source share. Use `CopyThenInstall` when the admin box can read the share but the target cannot.
+- This wrapper does not provide credentials. It relies on the operator's approved admin session and normal Windows authorization.

--- a/docs/SOFTWARE_INSTALL_HARNESS.md
+++ b/docs/SOFTWARE_INSTALL_HARNESS.md
@@ -4,7 +4,7 @@
 
 SysAdminSuite needs a controlled operator-execute lane for installing approved software from an approved read-only software source onto authorized target computers.
 
-This lane is intentionally not stealth tooling. It must not suppress Windows logs, bypass monitoring, collect credentials, or hide the fact that an authorized install occurred. The no-artifact requirement means no persistent SysAdminSuite staging payloads should remain on the target after the run. The installed software, normal installer traces, endpoint management records, and Windows event logs are expected client records.
+This lane is intentionally not stealth tooling. It must not suppress Windows logs, bypass monitoring, collect credentials, or hide the fact that an authorized install occurred. The no-artifact requirement means no persistent SysAdminSuite-owned staging payloads, reports, manifests, transcripts, scripts, or evidence should remain on the target after the run. The installed software and the installer-owned files, logs, registry changes, caches, services, or records created by the approved executable or MSI are outside the SysAdminSuite cleanup boundary.
 
 ## Approved source
 
@@ -29,7 +29,23 @@ The harness rejects installer paths that are absolute, use `..`, or do not resol
 | `UncDirect` | None by SysAdminSuite | The target can execute the installer directly from the approved read-only share. |
 | `CopyThenInstall` | Temporary `ProgramData\SysAdminSuite\SoftwareInstall\<run_id>` | The installer must be copied from the admin box to the target before execution. |
 
-`UncDirect` is preferred because it avoids placing the installer payload on the target. `CopyThenInstall` is allowed only when direct UNC execution is not practical. When staging is used, the wrapper removes the staging directory in a `finally` cleanup block and records cleanup status in local evidence.
+`UncDirect` is preferred because it avoids placing the installer payload on the target. `CopyThenInstall` is allowed only when direct UNC execution is not practical. When staging is used, the wrapper removes the run-specific staging directory in cleanup and records cleanup status in local evidence.
+
+## Target-side repo-owned artifact boundary
+
+SysAdminSuite must not write target-side logs, reports, manifests, transcripts, scripts, or evidence for this lane. Run evidence belongs on the admin box only.
+
+When `CopyThenInstall` is used, these paths are SysAdminSuite-owned temporary staging and must be cleaned up:
+
+```text
+%ProgramData%\SysAdminSuite\SoftwareInstall\<run_id>
+%ProgramData%\SysAdminSuite\SoftwareInstall    # prune only when empty
+%ProgramData%\SysAdminSuite                    # prune only when empty
+```
+
+Cleanup is attempted from both the normal remote installer `finally` block and the outer failure path that catches copy/session/install orchestration failures. A cleanup failure is a reportable failure, not something to hide. The summary must state whether a repo-owned staging path may still remain.
+
+This cleanup boundary deliberately does not remove records owned by Windows, endpoint tooling, or the approved installer itself. The harness avoids creating SysAdminSuite-owned target evidence and cleans SysAdminSuite-owned filesystem staging; it does not erase operating-system audit logs.
 
 ## Operator contract
 
@@ -40,7 +56,7 @@ The install wrapper must require all of the following:
 3. Explicit `-AllowTargetMutation` unless running with `-WhatIf`.
 4. Local output under `survey/output/software_install/<run_id>/` or another operator-supplied local output root.
 5. Per-target status events written locally as JSONL.
-6. A summary JSON that names targets, installer, mode, exit codes, staging cleanup status, and unresolved failures.
+6. A summary JSON that names targets, installer, mode, exit codes, staging cleanup status, repo-owned target remnant status, and unresolved failures.
 
 ## Guardrails
 
@@ -52,11 +68,14 @@ The lane must preserve these boundaries:
 - No monitoring bypass, log suppression, or event-log cleanup.
 - No hidden listeners, services, agents, persistence, or background daemons.
 - No broad network discovery from this operation.
+- No target-side SysAdminSuite logs, reports, manifests, transcripts, scripts, or evidence.
 - No target-side SysAdminSuite staging artifacts after completion when cleanup succeeds.
+- Run-specific staging cleanup is attempted on normal and failure paths.
+- Empty SysAdminSuite parent directories are pruned when no sibling run artifacts remain.
 - Cleanup failure is a reportable failure, not something to hide.
 - Generated run artifacts stay in gitignored local output paths.
 
-## Expected artifacts
+## Expected local artifacts
 
 Each run should produce local evidence similar to:
 
@@ -64,6 +83,7 @@ Each run should produce local evidence similar to:
 survey/output/software_install/<run_id>/
   software_install_events.jsonl
   software_install_summary.json
+  operator_handoff.txt
 ```
 
 The evidence belongs on the admin box. It should be used to update the client-facing deployment tracker without writing extra audit files to target hosts.
@@ -95,6 +115,7 @@ The evidence belongs on the admin box. It should be used to update the client-fa
 
 ## Known operational limits
 
-- Some installers create their own logs, caches, services, scheduled tasks, or registry keys. That is part of the software installation, not SysAdminSuite staging.
+- Some installers create their own logs, caches, services, scheduled tasks, or registry keys. Those are part of the software installation, not SysAdminSuite staging.
 - Direct UNC execution can fail if the target cannot read the source share. Use `CopyThenInstall` when the admin box can read the share but the target cannot.
 - This wrapper does not provide credentials. It relies on the operator's approved admin session and normal Windows authorization.
+- This wrapper does not erase operating-system audit records. It is designed to avoid and clean SysAdminSuite-owned target filesystem remnants.

--- a/docs/SOFTWARE_INSTALL_HARNESS.md
+++ b/docs/SOFTWARE_INSTALL_HARNESS.md
@@ -58,7 +58,7 @@ The install wrapper must require all of the following:
 1. An explicit target list through `-ComputerName` or `-TargetsCsv`.
 2. An installer path under the approved software source root.
 3. Explicit `-AllowTargetMutation` unless running with `-WhatIf`.
-4. Local output under `survey/output/software_install/<run_id>/` or another operator-supplied local output root.
+4. Local output under the approved gitignored roots `survey/output/`, `logs/nmap/`, or `survey/artifacts/`; the default is `survey/output/software_install/<run_id>/`.
 5. Per-target status events written locally as JSONL.
 6. A summary JSON that names targets, installer, mode, exit codes, staging cleanup status, repo-owned target remnant status, and unresolved failures.
 

--- a/docs/SOFTWARE_INSTALL_HARNESS.md
+++ b/docs/SOFTWARE_INSTALL_HARNESS.md
@@ -105,6 +105,13 @@ The evidence belongs on the admin box. It should be used to update the client-fa
   -WhatIf
 ```
 
+From Git Bash on Windows:
+
+```bash
+pwsh -NoProfile -Command \
+  '& ./scripts/Invoke-SasSoftwareInstall.ps1 -ComputerName WNH269OPR009 -PackageName ExampleVendorTool -InstallerRelativePath "SomeShare\Vendor\Package\setup.exe" -InstallerArguments @("/quiet", "/norestart") -InstallMode UncDirect -WhatIf'
+```
+
 ## Example approved execution
 
 ```powershell
@@ -118,9 +125,18 @@ The evidence belongs on the admin box. It should be used to update the client-fa
   -Confirm:$false
 ```
 
+From Git Bash on Windows:
+
+```bash
+pwsh -NoProfile -Command \
+  '& ./scripts/Invoke-SasSoftwareInstall.ps1 -TargetsCsv ./targets/local/approved-software-targets.csv -PackageName ExampleVendorTool -InstallerRelativePath "SomeShare\Vendor\Package\setup.exe" -InstallerArguments @("/quiet", "/norestart") -InstallMode CopyThenInstall -AllowTargetMutation -Confirm:$false'
+```
+
 ## Known operational limits
 
 - Some installers create their own logs, caches, services, scheduled tasks, or registry keys. Those are part of the software installation, not SysAdminSuite staging.
 - Direct UNC execution can fail if the target cannot read the source share. Use `CopyThenInstall` when the admin box can read the share but the target cannot.
 - This wrapper does not provide credentials. It relies on the operator's approved admin session and normal Windows authorization.
+- Remote session creation is bounded to 30 seconds, remote operations to 60 minutes, and the installer process to 30 minutes per target.
 - This wrapper does not erase operating-system audit records. It is designed to avoid and clean SysAdminSuite-owned target filesystem remnants.
+

--- a/harness/api/sas-harness-api.json
+++ b/harness/api/sas-harness-api.json
@@ -4,7 +4,10 @@
     "default_network_activity": false,
     "default_target_mutation": false,
     "evidence_scope": "local_gitignored_artifacts",
-    "operator_boundary": "authorized_scoped_low_noise_no_hidden_activity"
+    "operator_boundary": "authorized_scoped_low_noise_no_hidden_activity",
+    "approved_software_sources": [
+      "\\\\nt2kwb972sms01\\"
+    ]
   },
   "modes": [
     "plan_only",
@@ -113,6 +116,36 @@
         "Local_only",
         "No_hidden_daemons",
         "No_network_probe_execution"
+      ]
+    },
+    {
+      "id": "software_install.operator_execute",
+      "summary": "Install approved software on authorized target computers from approved read-only software shares with local evidence and target staging cleanup.",
+      "mode": "operator_execute",
+      "network_activity": true,
+      "target_mutation": true,
+      "inputs": [
+        "approved_targets_csv_or_computer_name",
+        "package_name",
+        "installer_relative_path",
+        "software_share_root",
+        "installer_arguments",
+        "explicit_allow_target_mutation"
+      ],
+      "outputs": [
+        "software_install_events.jsonl",
+        "software_install_summary.json",
+        "operator_handoff.txt"
+      ],
+      "guardrails": [
+        "Approved_admin_context_only",
+        "Approved_read_only_software_share_only",
+        "No_credential_collection",
+        "No_monitoring_bypass_or_log_suppression",
+        "No_unapproved_background_services",
+        "Prefer_UNC_direct_install_to_avoid_target_staging",
+        "Temporary_staging_must_be_removed_and_cleanup_status_reported",
+        "Local_gitignored_evidence_only"
       ]
     }
   ]

--- a/harness/api/sas-harness-api.json
+++ b/harness/api/sas-harness-api.json
@@ -127,12 +127,13 @@
       "network_activity": true,
       "target_mutation": true,
       "inputs": [
-        "approved_targets_csv_or_computer_name",
         "package_name",
         "installer_relative_path",
+        "install_mode",
+        "targets",
+        "allow_target_mutation",
         "software_share_root",
-        "installer_arguments",
-        "explicit_allow_target_mutation"
+        "installer_arguments"
       ],
       "outputs": [
         "software_install_events.jsonl",
@@ -154,3 +155,4 @@
     }
   ]
 }
+

--- a/harness/api/sas-harness-api.json
+++ b/harness/api/sas-harness-api.json
@@ -120,7 +120,7 @@
     },
     {
       "id": "software_install.operator_execute",
-      "summary": "Install approved software on authorized target computers from approved read-only software shares with local evidence and target staging cleanup.",
+      "summary": "Install approved software on authorized target computers from approved read-only software shares with local evidence and cleanup of SysAdminSuite-owned target staging.",
       "mode": "operator_execute",
       "network_activity": true,
       "target_mutation": true,
@@ -143,8 +143,10 @@
         "No_credential_collection",
         "No_monitoring_bypass_or_log_suppression",
         "No_unapproved_background_services",
+        "No_repo_owned_target_logs_reports_manifests_or_transcripts",
         "Prefer_UNC_direct_install_to_avoid_target_staging",
-        "Temporary_staging_must_be_removed_and_cleanup_status_reported",
+        "Run_specific_staging_cleanup_attempted_on_all_failure_paths",
+        "Prune_empty_SysAdminSuite_target_directories",
         "Local_gitignored_evidence_only"
       ]
     }

--- a/schemas/harness/software-install-request.schema.json
+++ b/schemas/harness/software-install-request.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sysadminsuite.local/schemas/harness/software-install-request.schema.json",
+  "title": "SysAdminSuite software install request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "package_name",
+    "installer_relative_path",
+    "install_mode",
+    "targets"
+  ],
+  "properties": {
+    "package_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "software_share_root": {
+      "type": "string",
+      "default": "\\\\nt2kwb972sms01\\",
+      "pattern": "^\\\\\\\\[^\\\\]+\\\\.*$"
+    },
+    "installer_relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "not": {
+        "anyOf": [
+          { "pattern": "^[A-Za-z]:" },
+          { "pattern": "^\\\\\\\\" },
+          { "pattern": "(^|[\\\\/])\\.\\.([\\\\/]|$)" }
+        ]
+      }
+    },
+    "installer_arguments": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [
+        "/quiet",
+        "/norestart"
+      ]
+    },
+    "install_mode": {
+      "type": "string",
+      "enum": [
+        "UncDirect",
+        "CopyThenInstall"
+      ]
+    },
+    "targets": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 25,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true
+    },
+    "allow_target_mutation": {
+      "type": "boolean",
+      "const": true
+    }
+  }
+}

--- a/schemas/harness/software-install-request.schema.json
+++ b/schemas/harness/software-install-request.schema.json
@@ -8,7 +8,8 @@
     "package_name",
     "installer_relative_path",
     "install_mode",
-    "targets"
+    "targets",
+    "allow_target_mutation"
   ],
   "properties": {
     "package_name": {
@@ -25,9 +26,15 @@
       "minLength": 1,
       "not": {
         "anyOf": [
-          { "pattern": "^[A-Za-z]:" },
-          { "pattern": "^\\\\\\\\" },
-          { "pattern": "(^|[\\\\/])\\.\\.([\\\\/]|$)" }
+          {
+            "pattern": "^[A-Za-z]:"
+          },
+          {
+            "pattern": "^\\\\\\\\"
+          },
+          {
+            "pattern": "(^|[\\\\/])\\.\\.([\\\\/]|$)"
+          }
         ]
       }
     },

--- a/scripts/Invoke-SasSoftwareInstall.ps1
+++ b/scripts/Invoke-SasSoftwareInstall.ps1
@@ -38,7 +38,7 @@ param(
     [string]$InstallMode = 'UncDirect',
 
     [Parameter(Mandatory = $false)]
-    [string]$OutputRoot = (Join-Path -Path (Get-Location) -ChildPath 'survey/output/software_install'),
+    [string]$OutputRoot,
 
     [Parameter(Mandatory = $false)]
     [ValidateRange(1, 25)]
@@ -197,7 +197,15 @@ if (-not $AllowTargetMutation -and -not $WhatIfPreference) {
     throw 'Refusing target mutation without -AllowTargetMutation. Use -WhatIf for dry-run planning.'
 }
 
-$runId = 'software-install-{0}' -f (Get-Date -Format 'yyyyMMdd-HHmmss')
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$targetIntakeModule = Join-Path -Path $PSScriptRoot -ChildPath 'SasTargetIntake.psm1'
+Import-Module -Name $targetIntakeModule -Force
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = Join-Path -Path $repoRoot -ChildPath 'survey/output/software_install'
+}
+Assert-SasApprovedOutputPath -Path $OutputRoot -RepoRoot $repoRoot -Role 'software install output directory'
+
+$runId = 'software-install-{0}-{1}' -f (Get-Date -Format 'yyyyMMdd-HHmmss'), ([guid]::NewGuid().ToString('N').Substring(0, 8))
 $runRoot = Join-Path -Path $OutputRoot -ChildPath $runId
 New-Item -ItemType Directory -Path $runRoot -Force -WhatIf:$false | Out-Null
 
@@ -243,7 +251,7 @@ $remoteRepoCleanup = {
 
     $expectedBase = [System.IO.Path]::GetFullPath((Join-Path -Path $env:ProgramData -ChildPath 'SysAdminSuite\SoftwareInstall'))
     $expectedStageRoot = [System.IO.Path]::GetFullPath((Join-Path -Path $expectedBase -ChildPath $RunId))
-    if ($RunId -notmatch '^software-install-[0-9]{8}-[0-9]{6}$' -or
+    if ($RunId -notmatch '^software-install-[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$' -or
         -not $stageRoot.Equals($expectedStageRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
         throw 'Refusing cleanup because the run-specific staging path failed validation.'
     }
@@ -304,7 +312,7 @@ $remoteInstall = {
 
         $expectedBase = [System.IO.Path]::GetFullPath((Join-Path -Path $env:ProgramData -ChildPath 'SysAdminSuite\SoftwareInstall'))
         $expectedStageRoot = [System.IO.Path]::GetFullPath((Join-Path -Path $expectedBase -ChildPath $CleanupRunId))
-        if ($CleanupRunId -notmatch '^software-install-[0-9]{8}-[0-9]{6}$' -or
+        if ($CleanupRunId -notmatch '^software-install-[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$' -or
             -not $stageRoot.Equals($expectedStageRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
             throw 'Refusing cleanup because the run-specific staging path failed validation.'
         }

--- a/scripts/Invoke-SasSoftwareInstall.ps1
+++ b/scripts/Invoke-SasSoftwareInstall.ps1
@@ -41,6 +41,7 @@ param(
     [string]$OutputRoot = (Join-Path -Path (Get-Location) -ChildPath 'survey/output/software_install'),
 
     [Parameter(Mandatory = $false)]
+    [ValidateRange(1, 25)]
     [int]$MaxTargets = 25,
 
     [Parameter(Mandatory = $false)]
@@ -361,7 +362,12 @@ $remoteInstall = {
             throw "Installer source not found on target context: $InstallerSource"
         }
 
-        $process = Start-Process -FilePath $InstallerSource -ArgumentList $Arguments -Wait -PassThru
+        $installerTimeoutMilliseconds = 1800000
+        $process = Start-Process -FilePath $InstallerSource -ArgumentList $Arguments -PassThru
+        if (-not $process.WaitForExit($installerTimeoutMilliseconds)) {
+            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+            throw "Installer timed out after $($installerTimeoutMilliseconds / 1000) seconds."
+        }
         $result.exit_code = $process.ExitCode
         if ($process.ExitCode -eq 0) {
             $result.status = 'completed'
@@ -433,7 +439,8 @@ foreach ($target in $targets) {
     $session = $null
     $stageRoot = $null
     try {
-        $session = New-PSSession -ComputerName $target
+        $sessionOption = New-PSSessionOption -OpenTimeout 30000 -OperationTimeout 3600000
+        $session = New-PSSession -ComputerName $target -SessionOption $sessionOption
         $remoteInstallerPath = $installerPath
 
         if ($InstallMode -eq 'CopyThenInstall') {
@@ -595,3 +602,4 @@ Write-SasInstallEvent -EventPath $eventPath -Event @{
 }
 
 Write-Output $summary
+

--- a/scripts/Invoke-SasSoftwareInstall.ps1
+++ b/scripts/Invoke-SasSoftwareInstall.ps1
@@ -169,6 +169,7 @@ New-Item -ItemType Directory -Path $runRoot -Force | Out-Null
 
 $eventPath = Join-Path -Path $runRoot -ChildPath 'software_install_events.jsonl'
 $summaryPath = Join-Path -Path $runRoot -ChildPath 'software_install_summary.json'
+$handoffPath = Join-Path -Path $runRoot -ChildPath 'operator_handoff.txt'
 $installerPath = Resolve-SasApprovedInstallerPath -Root $SoftwareShareRoot -RelativePath $InstallerRelativePath
 if ([string]::IsNullOrWhiteSpace($PackageName)) {
     $PackageName = Split-Path -Path $installerPath -Leaf
@@ -376,6 +377,7 @@ $summary = [ordered]@{
     failed_count = @($results | Where-Object { $_.status -notin @('completed', 'planned_whatif') }).Count
     cleanup_failure_count = @($results | Where-Object { $_.cleanup_attempted -and $_.cleanup_succeeded -eq $false }).Count
     event_path = $eventPath
+    operator_handoff_path = $handoffPath
     results = @($results)
     guardrails = @(
         'approved_admin_context_only',
@@ -388,6 +390,22 @@ $summary = [ordered]@{
 }
 
 $summary | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
+$handoffLines = @(
+    'SysAdminSuite software install handoff',
+    "Run ID: $runId",
+    "Package: $PackageName",
+    "Install mode: $InstallMode",
+    "Targets: $($targets.Count)",
+    "Completed: $($summary.completed_count)",
+    "Planned/WhatIf: $($summary.planned_count)",
+    "Failed or unresolved: $($summary.failed_count)",
+    "Cleanup failures: $($summary.cleanup_failure_count)",
+    "Events: $eventPath",
+    "Summary: $summaryPath",
+    '',
+    'Review failures and cleanup failures before reporting completion to the client.'
+)
+$handoffLines | Set-Content -LiteralPath $handoffPath -Encoding UTF8
 Write-SasInstallEvent -EventPath $eventPath -Event @{
     event = 'run_completed'
     run_id = $runId

--- a/scripts/Invoke-SasSoftwareInstall.ps1
+++ b/scripts/Invoke-SasSoftwareInstall.ps1
@@ -1,0 +1,401 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+Installs approved software on authorized target computers from an approved read-only software share.
+
+.DESCRIPTION
+Invoke-SasSoftwareInstall is the SysAdminSuite operator-execute wrapper for admin-box software installs.
+It prefers direct UNC execution so SysAdminSuite does not stage payloads on the target. When staging is explicitly
+requested, it copies the installer to ProgramData\SysAdminSuite\SoftwareInstall\<run_id> and removes that staging
+folder in a cleanup block after the installer exits.
+
+This script does not suppress Windows logs, clear evidence, collect credentials, create persistence, or bypass
+monitoring. Local JSON evidence is written on the admin box.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [Parameter(Mandatory = $false)]
+    [string[]]$ComputerName = @(),
+
+    [Parameter(Mandatory = $false)]
+    [string]$TargetsCsv,
+
+    [Parameter(Mandatory = $false)]
+    [string]$PackageName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$InstallerRelativePath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$SoftwareShareRoot = '\\nt2kwb972sms01\',
+
+    [Parameter(Mandatory = $false)]
+    [string[]]$InstallerArguments = @('/quiet', '/norestart'),
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('UncDirect', 'CopyThenInstall')]
+    [string]$InstallMode = 'UncDirect',
+
+    [Parameter(Mandatory = $false)]
+    [string]$OutputRoot = (Join-Path -Path (Get-Location) -ChildPath 'survey/output/software_install'),
+
+    [Parameter(Mandatory = $false)]
+    [int]$MaxTargets = 25,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AllowTargetMutation
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+function Normalize-SasUncRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    if (-not $Path.StartsWith('\\')) {
+        throw "SoftwareShareRoot must be a UNC path. Received: $Path"
+    }
+
+    $trimmed = $Path.TrimEnd('\')
+    return "$trimmed\"
+}
+
+function Resolve-SasApprovedInstallerPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Root,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RelativePath
+    )
+
+    if ([System.IO.Path]::IsPathRooted($RelativePath)) {
+        throw 'InstallerRelativePath must be relative to the approved software share root.'
+    }
+
+    if ($RelativePath -match '(^|[\\/])\.\.([\\/]|$)') {
+        throw 'InstallerRelativePath cannot contain parent-directory traversal.'
+    }
+
+    $normalizedRoot = Normalize-SasUncRoot -Path $Root
+    $child = $RelativePath.TrimStart('\', '/')
+    $candidate = Join-Path -Path $normalizedRoot -ChildPath $child
+
+    if (-not $candidate.StartsWith($normalizedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Resolved installer path escaped the approved software share root.'
+    }
+
+    return $candidate
+}
+
+function Get-SasInstallTargets {
+    [CmdletBinding()]
+    param(
+        [string[]]$DirectTargets,
+        [string]$CsvPath,
+        [int]$Limit
+    )
+
+    $targets = New-Object System.Collections.Generic.List[string]
+
+    foreach ($target in $DirectTargets) {
+        if (-not [string]::IsNullOrWhiteSpace($target)) {
+            $targets.Add($target.Trim())
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($CsvPath)) {
+        if (-not (Test-Path -LiteralPath $CsvPath -PathType Leaf)) {
+            throw "TargetsCsv not found: $CsvPath"
+        }
+
+        $rows = Import-Csv -LiteralPath $CsvPath
+        foreach ($row in $rows) {
+            $value = $null
+            foreach ($column in @('ComputerName', 'Hostname', 'Target')) {
+                if ($row.PSObject.Properties.Name -contains $column) {
+                    $candidate = [string]$row.$column
+                    if (-not [string]::IsNullOrWhiteSpace($candidate)) {
+                        $value = $candidate.Trim()
+                        break
+                    }
+                }
+            }
+            if ($value) {
+                $targets.Add($value)
+            }
+        }
+    }
+
+    $deduped = $targets | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique
+    if ($deduped.Count -eq 0) {
+        throw 'No targets were supplied. Use -ComputerName or -TargetsCsv with ComputerName, Hostname, or Target column.'
+    }
+
+    if ($deduped.Count -gt $Limit) {
+        throw "Target count $($deduped.Count) exceeds MaxTargets $Limit. Split the run to keep noise bounded."
+    }
+
+    return @($deduped)
+}
+
+function Write-SasInstallEvent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EventPath,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Event
+    )
+
+    $Event['timestamp_utc'] = (Get-Date).ToUniversalTime().ToString('o')
+    $Event | ConvertTo-Json -Depth 10 -Compress | Add-Content -LiteralPath $EventPath -Encoding UTF8
+}
+
+if (-not $AllowTargetMutation -and -not $WhatIfPreference) {
+    throw 'Refusing target mutation without -AllowTargetMutation. Use -WhatIf for dry-run planning.'
+}
+
+$runId = 'software-install-{0}' -f (Get-Date -Format 'yyyyMMdd-HHmmss')
+$runRoot = Join-Path -Path $OutputRoot -ChildPath $runId
+New-Item -ItemType Directory -Path $runRoot -Force | Out-Null
+
+$eventPath = Join-Path -Path $runRoot -ChildPath 'software_install_events.jsonl'
+$summaryPath = Join-Path -Path $runRoot -ChildPath 'software_install_summary.json'
+$installerPath = Resolve-SasApprovedInstallerPath -Root $SoftwareShareRoot -RelativePath $InstallerRelativePath
+if ([string]::IsNullOrWhiteSpace($PackageName)) {
+    $PackageName = Split-Path -Path $installerPath -Leaf
+}
+
+if (-not (Test-Path -LiteralPath $installerPath -PathType Leaf)) {
+    throw "Installer was not found under the approved software source: $installerPath"
+}
+
+$targets = Get-SasInstallTargets -DirectTargets $ComputerName -CsvPath $TargetsCsv -Limit $MaxTargets
+
+Write-SasInstallEvent -EventPath $eventPath -Event @{
+    event = 'run_started'
+    run_id = $runId
+    package_name = $PackageName
+    installer_path = $installerPath
+    install_mode = $InstallMode
+    target_count = $targets.Count
+    output_root = $runRoot
+    posture = 'authorized_operator_execute_no_log_suppression_no_credential_collection_cleanup_staging_only'
+}
+
+$remoteInstall = {
+    param(
+        [string]$PackageName,
+        [string]$InstallerSource,
+        [string[]]$Arguments,
+        [string]$InstallMode,
+        [string]$RunId
+    )
+
+    $ErrorActionPreference = 'Stop'
+    $stageRoot = Join-Path -Path $env:ProgramData -ChildPath ("SysAdminSuite\SoftwareInstall\{0}" -f $RunId)
+    $result = [ordered]@{
+        package_name = $PackageName
+        installer_source = $InstallerSource
+        install_mode = $InstallMode
+        exit_code = $null
+        staged = ($InstallMode -eq 'CopyThenInstall')
+        stage_root = $(if ($InstallMode -eq 'CopyThenInstall') { $stageRoot } else { $null })
+        cleanup_attempted = $false
+        cleanup_succeeded = $null
+        status = 'started'
+        error = $null
+    }
+
+    try {
+        if (-not (Test-Path -LiteralPath $InstallerSource -PathType Leaf)) {
+            throw "Installer source not found on target context: $InstallerSource"
+        }
+
+        $process = Start-Process -FilePath $InstallerSource -ArgumentList $Arguments -Wait -PassThru
+        $result.exit_code = $process.ExitCode
+        if ($process.ExitCode -eq 0) {
+            $result.status = 'completed'
+        }
+        else {
+            $result.status = 'installer_exit_nonzero'
+        }
+    }
+    catch {
+        $result.status = 'failed'
+        $result.error = $_.Exception.Message
+    }
+    finally {
+        if ($InstallMode -eq 'CopyThenInstall') {
+            $result.cleanup_attempted = $true
+            try {
+                if (Test-Path -LiteralPath $stageRoot) {
+                    Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction Stop
+                }
+                $result.cleanup_succeeded = -not (Test-Path -LiteralPath $stageRoot)
+            }
+            catch {
+                $result.cleanup_succeeded = $false
+                if ([string]::IsNullOrWhiteSpace([string]$result.error)) {
+                    $result.error = $_.Exception.Message
+                }
+                else {
+                    $result.error = "$($result.error); cleanup failed: $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+
+    return [pscustomobject]$result
+}
+
+$results = New-Object System.Collections.Generic.List[object]
+
+foreach ($target in $targets) {
+    Write-SasInstallEvent -EventPath $eventPath -Event @{
+        event = 'target_started'
+        run_id = $runId
+        computer_name = $target
+        package_name = $PackageName
+        install_mode = $InstallMode
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($target, "Install package '$PackageName' from approved software source using $InstallMode")) {
+        $planned = [pscustomobject]@{
+            computer_name = $target
+            package_name = $PackageName
+            install_mode = $InstallMode
+            status = 'planned_whatif'
+            exit_code = $null
+            cleanup_attempted = $false
+            cleanup_succeeded = $null
+            error = $null
+        }
+        $results.Add($planned)
+        Write-SasInstallEvent -EventPath $eventPath -Event @{
+            event = 'target_planned_whatif'
+            run_id = $runId
+            computer_name = $target
+            package_name = $PackageName
+            install_mode = $InstallMode
+        }
+        continue
+    }
+
+    $session = $null
+    try {
+        $session = New-PSSession -ComputerName $target
+        $remoteInstallerPath = $installerPath
+
+        if ($InstallMode -eq 'CopyThenInstall') {
+            $stageRoot = Invoke-Command -Session $session -ScriptBlock {
+                param([string]$RunId)
+                $path = Join-Path -Path $env:ProgramData -ChildPath ("SysAdminSuite\SoftwareInstall\{0}" -f $RunId)
+                New-Item -ItemType Directory -Path $path -Force | Out-Null
+                return $path
+            } -ArgumentList $runId
+
+            $remoteInstallerPath = Join-Path -Path $stageRoot -ChildPath (Split-Path -Path $installerPath -Leaf)
+            Copy-Item -LiteralPath $installerPath -Destination $remoteInstallerPath -ToSession $session -Force
+        }
+
+        $remoteResult = Invoke-Command -Session $session -ScriptBlock $remoteInstall -ArgumentList $PackageName, $remoteInstallerPath, $InstallerArguments, $InstallMode, $runId
+        $row = [pscustomobject]@{
+            computer_name = $target
+            package_name = $PackageName
+            install_mode = $InstallMode
+            status = $remoteResult.status
+            exit_code = $remoteResult.exit_code
+            cleanup_attempted = $remoteResult.cleanup_attempted
+            cleanup_succeeded = $remoteResult.cleanup_succeeded
+            error = $remoteResult.error
+        }
+        $results.Add($row)
+
+        Write-SasInstallEvent -EventPath $eventPath -Event @{
+            event = 'target_completed'
+            run_id = $runId
+            computer_name = $target
+            package_name = $PackageName
+            install_mode = $InstallMode
+            status = $row.status
+            exit_code = $row.exit_code
+            cleanup_attempted = $row.cleanup_attempted
+            cleanup_succeeded = $row.cleanup_succeeded
+            error = $row.error
+        }
+    }
+    catch {
+        $row = [pscustomobject]@{
+            computer_name = $target
+            package_name = $PackageName
+            install_mode = $InstallMode
+            status = 'failed_before_remote_result'
+            exit_code = $null
+            cleanup_attempted = ($InstallMode -eq 'CopyThenInstall')
+            cleanup_succeeded = $false
+            error = $_.Exception.Message
+        }
+        $results.Add($row)
+        Write-SasInstallEvent -EventPath $eventPath -Event @{
+            event = 'target_failed'
+            run_id = $runId
+            computer_name = $target
+            package_name = $PackageName
+            install_mode = $InstallMode
+            status = $row.status
+            cleanup_attempted = $row.cleanup_attempted
+            cleanup_succeeded = $row.cleanup_succeeded
+            error = $row.error
+        }
+    }
+    finally {
+        if ($session) {
+            Remove-PSSession -Session $session
+        }
+    }
+}
+
+$summary = [ordered]@{
+    schema_version = 'sas-software-install-summary/v1'
+    run_id = $runId
+    package_name = $PackageName
+    installer_path = $installerPath
+    install_mode = $InstallMode
+    target_count = $targets.Count
+    completed_count = @($results | Where-Object { $_.status -eq 'completed' }).Count
+    planned_count = @($results | Where-Object { $_.status -eq 'planned_whatif' }).Count
+    failed_count = @($results | Where-Object { $_.status -notin @('completed', 'planned_whatif') }).Count
+    cleanup_failure_count = @($results | Where-Object { $_.cleanup_attempted -and $_.cleanup_succeeded -eq $false }).Count
+    event_path = $eventPath
+    results = @($results)
+    guardrails = @(
+        'approved_admin_context_only',
+        'approved_read_only_software_share_only',
+        'no_credential_collection',
+        'no_monitoring_bypass_or_log_suppression',
+        'no_unapproved_background_services',
+        'temporary_staging_cleanup_status_reported'
+    )
+}
+
+$summary | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
+Write-SasInstallEvent -EventPath $eventPath -Event @{
+    event = 'run_completed'
+    run_id = $runId
+    summary_path = $summaryPath
+    completed_count = $summary.completed_count
+    planned_count = $summary.planned_count
+    failed_count = $summary.failed_count
+    cleanup_failure_count = $summary.cleanup_failure_count
+}
+
+Write-Output $summary

--- a/scripts/Invoke-SasSoftwareInstall.ps1
+++ b/scripts/Invoke-SasSoftwareInstall.ps1
@@ -7,10 +7,10 @@ Installs approved software on authorized target computers from an approved read-
 Invoke-SasSoftwareInstall is the SysAdminSuite operator-execute wrapper for admin-box software installs.
 It prefers direct UNC execution so SysAdminSuite does not stage payloads on the target. When staging is explicitly
 requested, it copies the installer to ProgramData\SysAdminSuite\SoftwareInstall\<run_id> and removes that staging
-folder in a cleanup block after the installer exits.
+folder in cleanup. Empty SysAdminSuite parent folders are pruned when no sibling run artifacts remain.
 
 This script does not suppress Windows logs, clear evidence, collect credentials, create persistence, or bypass
-monitoring. Local JSON evidence is written on the admin box.
+monitoring. It writes SysAdminSuite run evidence only on the admin box and cleans SysAdminSuite-owned target staging.
 #>
 
 [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
@@ -189,7 +189,51 @@ Write-SasInstallEvent -EventPath $eventPath -Event @{
     install_mode = $InstallMode
     target_count = $targets.Count
     output_root = $runRoot
-    posture = 'authorized_operator_execute_no_log_suppression_no_credential_collection_cleanup_staging_only'
+    posture = 'authorized_operator_execute_no_log_suppression_no_credential_collection_cleanup_repo_owned_target_staging_only'
+}
+
+$remoteRepoCleanup = {
+    param([string]$RunId)
+
+    $ErrorActionPreference = 'Stop'
+    $stageRoot = Join-Path -Path $env:ProgramData -ChildPath ("SysAdminSuite\SoftwareInstall\{0}" -f $RunId)
+    $softwareInstallRoot = Join-Path -Path $env:ProgramData -ChildPath 'SysAdminSuite\SoftwareInstall'
+    $suiteRoot = Join-Path -Path $env:ProgramData -ChildPath 'SysAdminSuite'
+    $removedPaths = @()
+    $prunedParentDirs = @()
+    $errorMessage = $null
+
+    try {
+        if (Test-Path -LiteralPath $stageRoot) {
+            Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction Stop
+            $removedPaths += $stageRoot
+        }
+
+        foreach ($parentPath in @($softwareInstallRoot, $suiteRoot)) {
+            if (Test-Path -LiteralPath $parentPath) {
+                $children = @(Get-ChildItem -LiteralPath $parentPath -Force -ErrorAction Stop)
+                if ($children.Count -eq 0) {
+                    Remove-Item -LiteralPath $parentPath -Force -ErrorAction Stop
+                    $prunedParentDirs += $parentPath
+                }
+            }
+        }
+    }
+    catch {
+        $errorMessage = $_.Exception.Message
+    }
+
+    $repoArtifactRemaining = Test-Path -LiteralPath $stageRoot
+
+    return [pscustomobject]@{
+        cleanup_attempted = $true
+        cleanup_succeeded = (-not $repoArtifactRemaining -and [string]::IsNullOrWhiteSpace($errorMessage))
+        repo_owned_stage_root = $stageRoot
+        repo_artifact_remaining = $repoArtifactRemaining
+        removed_paths = @($removedPaths)
+        pruned_empty_parent_dirs = @($prunedParentDirs)
+        error = $errorMessage
+    }
 }
 
 $remoteInstall = {
@@ -202,6 +246,49 @@ $remoteInstall = {
     )
 
     $ErrorActionPreference = 'Stop'
+
+    function Remove-SasRepoOwnedInstallArtifacts {
+        param([string]$CleanupRunId)
+
+        $stageRoot = Join-Path -Path $env:ProgramData -ChildPath ("SysAdminSuite\SoftwareInstall\{0}" -f $CleanupRunId)
+        $softwareInstallRoot = Join-Path -Path $env:ProgramData -ChildPath 'SysAdminSuite\SoftwareInstall'
+        $suiteRoot = Join-Path -Path $env:ProgramData -ChildPath 'SysAdminSuite'
+        $removedPaths = @()
+        $prunedParentDirs = @()
+        $errorMessage = $null
+
+        try {
+            if (Test-Path -LiteralPath $stageRoot) {
+                Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction Stop
+                $removedPaths += $stageRoot
+            }
+
+            foreach ($parentPath in @($softwareInstallRoot, $suiteRoot)) {
+                if (Test-Path -LiteralPath $parentPath) {
+                    $children = @(Get-ChildItem -LiteralPath $parentPath -Force -ErrorAction Stop)
+                    if ($children.Count -eq 0) {
+                        Remove-Item -LiteralPath $parentPath -Force -ErrorAction Stop
+                        $prunedParentDirs += $parentPath
+                    }
+                }
+            }
+        }
+        catch {
+            $errorMessage = $_.Exception.Message
+        }
+
+        $repoArtifactRemaining = Test-Path -LiteralPath $stageRoot
+        return [pscustomobject]@{
+            cleanup_attempted = $true
+            cleanup_succeeded = (-not $repoArtifactRemaining -and [string]::IsNullOrWhiteSpace($errorMessage))
+            repo_owned_stage_root = $stageRoot
+            repo_artifact_remaining = $repoArtifactRemaining
+            removed_paths = @($removedPaths)
+            pruned_empty_parent_dirs = @($prunedParentDirs)
+            error = $errorMessage
+        }
+    }
+
     $stageRoot = Join-Path -Path $env:ProgramData -ChildPath ("SysAdminSuite\SoftwareInstall\{0}" -f $RunId)
     $result = [ordered]@{
         package_name = $PackageName
@@ -212,6 +299,8 @@ $remoteInstall = {
         stage_root = $(if ($InstallMode -eq 'CopyThenInstall') { $stageRoot } else { $null })
         cleanup_attempted = $false
         cleanup_succeeded = $null
+        repo_artifact_remaining = $null
+        pruned_empty_parent_dirs = @()
         status = 'started'
         error = $null
     }
@@ -236,20 +325,17 @@ $remoteInstall = {
     }
     finally {
         if ($InstallMode -eq 'CopyThenInstall') {
-            $result.cleanup_attempted = $true
-            try {
-                if (Test-Path -LiteralPath $stageRoot) {
-                    Remove-Item -LiteralPath $stageRoot -Recurse -Force -ErrorAction Stop
-                }
-                $result.cleanup_succeeded = -not (Test-Path -LiteralPath $stageRoot)
-            }
-            catch {
-                $result.cleanup_succeeded = $false
+            $cleanup = Remove-SasRepoOwnedInstallArtifacts -CleanupRunId $RunId
+            $result.cleanup_attempted = $cleanup.cleanup_attempted
+            $result.cleanup_succeeded = $cleanup.cleanup_succeeded
+            $result.repo_artifact_remaining = $cleanup.repo_artifact_remaining
+            $result.pruned_empty_parent_dirs = $cleanup.pruned_empty_parent_dirs
+            if (-not [string]::IsNullOrWhiteSpace([string]$cleanup.error)) {
                 if ([string]::IsNullOrWhiteSpace([string]$result.error)) {
-                    $result.error = $_.Exception.Message
+                    $result.error = $cleanup.error
                 }
                 else {
-                    $result.error = "$($result.error); cleanup failed: $($_.Exception.Message)"
+                    $result.error = "$($result.error); cleanup failed: $($cleanup.error)"
                 }
             }
         }
@@ -278,6 +364,8 @@ foreach ($target in $targets) {
             exit_code = $null
             cleanup_attempted = $false
             cleanup_succeeded = $null
+            repo_artifact_remaining = $null
+            pruned_empty_parent_dirs = @()
             error = $null
         }
         $results.Add($planned)
@@ -292,6 +380,7 @@ foreach ($target in $targets) {
     }
 
     $session = $null
+    $stageRoot = $null
     try {
         $session = New-PSSession -ComputerName $target
         $remoteInstallerPath = $installerPath
@@ -317,6 +406,8 @@ foreach ($target in $targets) {
             exit_code = $remoteResult.exit_code
             cleanup_attempted = $remoteResult.cleanup_attempted
             cleanup_succeeded = $remoteResult.cleanup_succeeded
+            repo_artifact_remaining = $remoteResult.repo_artifact_remaining
+            pruned_empty_parent_dirs = $remoteResult.pruned_empty_parent_dirs
             error = $remoteResult.error
         }
         $results.Add($row)
@@ -331,19 +422,46 @@ foreach ($target in $targets) {
             exit_code = $row.exit_code
             cleanup_attempted = $row.cleanup_attempted
             cleanup_succeeded = $row.cleanup_succeeded
+            repo_artifact_remaining = $row.repo_artifact_remaining
+            pruned_empty_parent_dirs = $row.pruned_empty_parent_dirs
             error = $row.error
         }
     }
     catch {
+        $failureMessage = $_.Exception.Message
+        $outerCleanup = $null
+        if ($InstallMode -eq 'CopyThenInstall' -and $session) {
+            try {
+                $outerCleanup = Invoke-Command -Session $session -ScriptBlock $remoteRepoCleanup -ArgumentList $runId
+            }
+            catch {
+                $outerCleanup = [pscustomobject]@{
+                    cleanup_attempted = $true
+                    cleanup_succeeded = $false
+                    repo_owned_stage_root = $stageRoot
+                    repo_artifact_remaining = $true
+                    removed_paths = @()
+                    pruned_empty_parent_dirs = @()
+                    error = $_.Exception.Message
+                }
+            }
+        }
+
+        if ($outerCleanup -and -not [string]::IsNullOrWhiteSpace([string]$outerCleanup.error)) {
+            $failureMessage = "$failureMessage; cleanup failed: $($outerCleanup.error)"
+        }
+
         $row = [pscustomobject]@{
             computer_name = $target
             package_name = $PackageName
             install_mode = $InstallMode
             status = 'failed_before_remote_result'
             exit_code = $null
-            cleanup_attempted = ($InstallMode -eq 'CopyThenInstall')
-            cleanup_succeeded = $false
-            error = $_.Exception.Message
+            cleanup_attempted = $(if ($outerCleanup) { $outerCleanup.cleanup_attempted } else { $false })
+            cleanup_succeeded = $(if ($outerCleanup) { $outerCleanup.cleanup_succeeded } else { $null })
+            repo_artifact_remaining = $(if ($outerCleanup) { $outerCleanup.repo_artifact_remaining } else { $null })
+            pruned_empty_parent_dirs = $(if ($outerCleanup) { $outerCleanup.pruned_empty_parent_dirs } else { @() })
+            error = $failureMessage
         }
         $results.Add($row)
         Write-SasInstallEvent -EventPath $eventPath -Event @{
@@ -355,6 +473,8 @@ foreach ($target in $targets) {
             status = $row.status
             cleanup_attempted = $row.cleanup_attempted
             cleanup_succeeded = $row.cleanup_succeeded
+            repo_artifact_remaining = $row.repo_artifact_remaining
+            pruned_empty_parent_dirs = $row.pruned_empty_parent_dirs
             error = $row.error
         }
     }
@@ -376,6 +496,8 @@ $summary = [ordered]@{
     planned_count = @($results | Where-Object { $_.status -eq 'planned_whatif' }).Count
     failed_count = @($results | Where-Object { $_.status -notin @('completed', 'planned_whatif') }).Count
     cleanup_failure_count = @($results | Where-Object { $_.cleanup_attempted -and $_.cleanup_succeeded -eq $false }).Count
+    repo_artifact_remaining_count = @($results | Where-Object { $_.repo_artifact_remaining -eq $true }).Count
+    target_repo_artifact_policy = 'No SysAdminSuite-owned target logs, reports, manifests, transcripts, scripts, evidence, or staging should remain after cleanup. Installer-owned changes are outside this cleanup boundary.'
     event_path = $eventPath
     operator_handoff_path = $handoffPath
     results = @($results)
@@ -385,6 +507,9 @@ $summary = [ordered]@{
         'no_credential_collection',
         'no_monitoring_bypass_or_log_suppression',
         'no_unapproved_background_services',
+        'no_repo_owned_target_logs_reports_manifests_or_transcripts',
+        'run_specific_staging_cleanup_attempted_on_all_failure_paths',
+        'prune_empty_sysadminsuite_target_directories',
         'temporary_staging_cleanup_status_reported'
     )
 }
@@ -400,10 +525,11 @@ $handoffLines = @(
     "Planned/WhatIf: $($summary.planned_count)",
     "Failed or unresolved: $($summary.failed_count)",
     "Cleanup failures: $($summary.cleanup_failure_count)",
+    "Repo-owned target remnants remaining: $($summary.repo_artifact_remaining_count)",
     "Events: $eventPath",
     "Summary: $summaryPath",
     '',
-    'Review failures and cleanup failures before reporting completion to the client.'
+    'Review failures, cleanup failures, and repo-owned target remnant status before reporting completion to the client.'
 )
 $handoffLines | Set-Content -LiteralPath $handoffPath -Encoding UTF8
 Write-SasInstallEvent -EventPath $eventPath -Event @{
@@ -414,6 +540,7 @@ Write-SasInstallEvent -EventPath $eventPath -Event @{
     planned_count = $summary.planned_count
     failed_count = $summary.failed_count
     cleanup_failure_count = $summary.cleanup_failure_count
+    repo_artifact_remaining_count = $summary.repo_artifact_remaining_count
 }
 
 Write-Output $summary

--- a/tests/survey/run_offline_survey_tests.sh
+++ b/tests/survey/run_offline_survey_tests.sh
@@ -9,4 +9,5 @@ python3 Tests/survey/test_serial_network_preflight_contracts.py
 python3 Tests/survey/test_probe_socket_access_contracts.py
 python3 Tests/survey/test_standard_corporate_tooling_contracts.py
 python3 Tests/survey/test_local_harness_contracts.py
+python3 Tests/survey/test_software_install_harness_contracts.py
 python3 Tests/survey/test_run_context_contracts.py


### PR DESCRIPTION
## Summary

Adds a bounded SysAdminSuite operator-execute lane for installing approved software from the approved read-only software source on authorized Windows targets.

This branch is updated to current `main` and remains a distinct lane from PR #150.

## Scope

- Declares `software_install.operator_execute` in the harness API manifest.
- Adds the request schema, operator documentation, and `Invoke-SasSoftwareInstall.ps1`.
- Enforces the manifest-declared approved UNC root with exact normalized matching.
- Keeps `-WhatIf` local: no share probe, remote session, copy, or installer start.
- Validates the run-specific staging boundary before recursive cleanup.
- Hard-caps direct script execution at 25 targets and bounds remote session/installer waits.
- Restricts local evidence to approved gitignored output roots and uses collision-safe run IDs.
- Aligns manifest input names with the request schema and documents Bash/PowerShell invocation parity.
- Attempts cleanup after copy/session/install failures and reports cleanup uncertainty.
- Adds behavioral Pester coverage plus static/offline contracts.

## Guardrails

This is not stealth tooling. It does not clear event logs, suppress monitoring, collect credentials, create persistence, or hide install activity.

For `CopyThenInstall`, SysAdminSuite-owned staging under `%ProgramData%\SysAdminSuite\SoftwareInstall\<run_id>` is removed and empty parent directories are pruned. Installer-owned files, logs, registry changes, caches, services, and records remain outside the wrapper's cleanup boundary.

## Validation

Local completed:

```text
PASS: PowerShell parse
PASS: software-install static contract
PASS: direct -WhatIf smoke test (planned 1, failed 0, local evidence written)
PASS: arbitrary UNC root rejection
PASS: git diff --check
```

Current main: `f80dcb137758a9e0ec31d9d434734980e10897c2` (branch is 0 behind).

Fresh GitHub checks on `52d618ed06b82261832c634f1faf8e698e56f11e`:

```text
PASS: Pester (450 passed, 0 failed; 2 unrelated optional OCR skips)
PASS: Survey doctrine
PASS: Harness Contracts
```

All seven actionable review threads are resolved.

## Intentionally not run

- No live installer, software-share read, remote session, copy, or target mutation was performed.
- Local Pester could not start inside the Codex sandbox because Pester 6 attempted a denied temporary registry write; the committed suite passed on GitHub's Windows runner.
- Local Git Bash could not create its signal pipe inside the sandbox; Bash-owned contracts passed through the fresh GitHub checks.
