### PR TITLE
feat(qrtasks): harden power buttons and probe display menu events

### DIFF
--- a/QRTasks/Invoke-TechTask.ps1
+++ b/QRTasks/Invoke-TechTask.ps1
@@ -83,15 +83,16 @@ if ($resolvedRoot.Resolution -ne 'primary path available') {
 # ── Task registry ────────────────────────────────────────────────────
 # Map short names to script filenames (relative to $ScriptRoot).
 $TaskMap = [ordered]@{
-    RAMProfile          = 'Get-RAMProfile.ps1'
-    ModelInfo           = 'Get-ModelInfo.ps1'
-    NetworkInfo         = 'Get-NetworkInfo.ps1'
-    Serials             = 'Get-Serials.ps1'
-    NeuronTrace         = 'Get-NeuronTrace.ps1'
-    NeuronMaintenance   = 'Get-NeuronMaintenanceSnapshot.ps1'
-    WinOptionalFeatures = 'Get-WindowsOptionalFeatures.ps1'
-    PowerComfort        = 'Set-PowerComfortDefaults.ps1'
-    PowerComfortRevert  = 'Restore-PowerComfortDefaults.ps1'
+    RAMProfile             = 'Get-RAMProfile.ps1'
+    ModelInfo              = 'Get-ModelInfo.ps1'
+    NetworkInfo            = 'Get-NetworkInfo.ps1'
+    Serials                = 'Get-Serials.ps1'
+    NeuronTrace            = 'Get-NeuronTrace.ps1'
+    NeuronMaintenance      = 'Get-NeuronMaintenanceSnapshot.ps1'
+    WinOptionalFeatures    = 'Get-WindowsOptionalFeatures.ps1'
+    PowerComfort           = 'Set-PowerComfortDefaults.ps1'
+    PowerComfortRevert     = 'Restore-PowerComfortDefaults.ps1'
+    DisplayMenuButtonProbe = 'Test-DisplayMenuButtonEvent.ps1'
 }
 
 # ── Help / list mode ────────────────────────────────────────────────

--- a/QRTasks/Set-PowerComfortDefaults.ps1
+++ b/QRTasks/Set-PowerComfortDefaults.ps1
@@ -3,7 +3,7 @@
     Applies a "comfort" power preset on all power schemes, or reverts using the last backup.
 
 .DESCRIPTION
-    Apply mode: exports each scheme to .pow under GetInfo\Output\QRTasks, then sets display/sleep/disk/button/lid.
+    Apply mode: exports each scheme to .pow under GetInfo\Output\QRTasks, then sets display/sleep/disk/power-button/menu-button/lid.
     Revert mode: imports those backups (replacing schemes by deleting prior GUIDs after switching active).
 
 .PARAMETER Revert
@@ -98,6 +98,7 @@ $backupRoot = Join-Path $_outDir "PowerComfortBackup_$($env:COMPUTERNAME)"
 $metaPath = Join-Path $backupRoot 'meta.json'
 
 $powerButtonAction = '7648efa3-dd9c-4e3e-b566-50f929386280'
+$startMenuPowerButtonAction = 'a7066653-8d6c-40a8-910e-a1f54b84c7e5'
 
 # ── Revert ──────────────────────────────────────────────────────────
 if ($Revert) {
@@ -288,6 +289,8 @@ foreach ($s in $schemes) {
         @('/setdcvalueindex', $g, 'SUB_DISK', 'DISKIDLE', '0'),
         @('/setacvalueindex', $g, 'SUB_BUTTONS', $powerButtonAction, '0'),
         @('/setdcvalueindex', $g, 'SUB_BUTTONS', $powerButtonAction, '0'),
+        @('/setacvalueindex', $g, 'SUB_BUTTONS', $startMenuPowerButtonAction, '0'),
+        @('/setdcvalueindex', $g, 'SUB_BUTTONS', $startMenuPowerButtonAction, '0'),
         @('/setacvalueindex', $g, 'SUB_BUTTONS', 'LIDACTION', '0'),
         @('/setdcvalueindex', $g, 'SUB_BUTTONS', 'LIDACTION', '0')
     )
@@ -326,7 +329,7 @@ $lines.Add('')
 $lines.Add("Backup: $backupRoot")
 $lines.Add("Schemes updated: $($schemes.Count)")
 $lines.Add("Active scheme GUID (re-applied): $activeGuid")
-$lines.Add('Preset: display off=never, sleep=never, hibernate after=never, disk off=never, power button=do nothing, lid=do nothing')
+$lines.Add('Preset: display off=never, sleep=never, hibernate after=never, disk off=never, power button=do nothing, start menu power button=do nothing, lid=do nothing')
 if ($DisableHibernateFile) {
     $lines.Add('Hibernate file: disabled (powercfg /hibernate off)')
 } else {

--- a/QRTasks/Test-DisplayMenuButtonEvent.ps1
+++ b/QRTasks/Test-DisplayMenuButtonEvent.ps1
@@ -1,0 +1,174 @@
+﻿#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Field probe for whether a physical display/menu button is visible to Windows.
+
+.DESCRIPTION
+    This read-only QRTask opens a short observation window, asks the technician to press the physical
+    display/menu button once, then captures relevant Windows event log entries created during that
+    window. It does not change power policy, firmware, registry, services, scheduled tasks, or logs.
+
+    Classification is evidence only:
+      - OBSERVED_WINDOWS_EVENT means Windows logged something plausibly related during the press window.
+      - NO_WINDOWS_EVENT_OBSERVED means Windows did not log a related event during this run; the button
+        may be firmware-only / display-OSD controlled, or it may require a different observation method.
+
+.PARAMETER PressWindowSeconds
+    Seconds to observe after the prompt appears. Default: 20.
+
+.PARAMETER LookbackMinutes
+    Extra minutes of context to include in the report header. Default: 2.
+
+.PARAMETER MaxEvents
+    Maximum matching events to include in the report. Default: 40.
+
+.NOTES
+    Part of SysAdminSuite -- QRTasks extension module.
+    Requires only local Windows event log read access. No target-side writes beyond the local report file.
+#>
+param(
+    [ValidateRange(5, 300)]
+    [int]$PressWindowSeconds = 20,
+
+    [ValidateRange(1, 60)]
+    [int]$LookbackMinutes = 2,
+
+    [ValidateRange(1, 200)]
+    [int]$MaxEvents = 40
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Add-Line {
+    param(
+        [Parameter(Mandatory = $true)][System.Collections.Generic.List[string]]$Lines,
+        [Parameter(Mandatory = $true)][string]$Text
+    )
+    $Lines.Add($Text)
+}
+
+function Get-RelevantEventMatches {
+    param(
+        [Parameter(Mandatory = $true)][datetime]$StartTime,
+        [Parameter(Mandatory = $true)][datetime]$EndTime,
+        [Parameter(Mandatory = $true)][int]$Limit
+    )
+
+    $logs = @(
+        'System',
+        'Application',
+        'Microsoft-Windows-Kernel-Power/Thermal-Operational',
+        'Microsoft-Windows-DriverFrameworks-UserMode/Operational',
+        'Microsoft-Windows-UserModePowerService/Operational',
+        'Microsoft-Windows-Diagnostics-Performance/Operational'
+    )
+
+    $providerPattern = '(?i)(kernel-power|usermodepowerservice|power-troubleshooter|display|dxgkrnl|monitor|kernel-pnp|driverframeworks|hid|button)'
+    $messagePattern = '(?i)(power|display|monitor|screen|button|lid|sleep|standby|hibernate|video|pnp|hid|device|disconnect|connect)'
+    $matches = New-Object System.Collections.Generic.List[object]
+    $errors = New-Object System.Collections.Generic.List[string]
+
+    foreach ($log in $logs) {
+        try {
+            $events = Get-WinEvent -FilterHashtable @{ LogName = $log; StartTime = $StartTime; EndTime = $EndTime } -ErrorAction Stop
+            foreach ($event in $events) {
+                $providerName = [string]$event.ProviderName
+                $message = [string]$event.Message
+                if ($providerName -match $providerPattern -or $message -match $messagePattern) {
+                    $matches.Add([pscustomobject]@{
+                        TimeCreated  = $event.TimeCreated
+                        LogName      = $log
+                        ProviderName = $providerName
+                        Id           = $event.Id
+                        LevelDisplay = $event.LevelDisplayName
+                        Message      = ($message -replace '\s+', ' ').Trim()
+                    })
+                    if ($matches.Count -ge $Limit) {
+                        return [pscustomobject]@{ Events = @($matches); Errors = @($errors) }
+                    }
+                }
+            }
+        } catch {
+            $errors.Add("$log :: $($_.Exception.Message)")
+        }
+    }
+
+    return [pscustomobject]@{ Events = @($matches); Errors = @($errors) }
+}
+
+$timestamp = Get-Date
+$timestampText = $timestamp.ToString('yyyy-MM-dd HH:mm:ss')
+$outDir = Join-Path (Split-Path -Parent $PSScriptRoot) 'GetInfo\Output\QRTasks'
+if (-not (Test-Path -LiteralPath $outDir)) {
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+}
+$outFile = Join-Path $outDir "DisplayMenuButtonProbe_$($env:COMPUTERNAME)_$($timestamp.ToString('yyyyMMdd_HHmmss')).txt"
+
+$lines = New-Object System.Collections.Generic.List[string]
+Add-Line -Lines $lines -Text "Display/menu button Windows-event probe -- $env:COMPUTERNAME -- $timestampText"
+Add-Line -Lines $lines -Text ('=' * 80)
+Add-Line -Lines $lines -Text ''
+Add-Line -Lines $lines -Text 'Purpose: determine whether the physical display/menu button produces a Windows-observable event.'
+Add-Line -Lines $lines -Text 'This is read-only evidence capture. It does not apply or revert power settings.'
+Add-Line -Lines $lines -Text ''
+Add-Line -Lines $lines -Text "Operator action: press the physical display/menu button once during the next $PressWindowSeconds seconds."
+Add-Line -Lines $lines -Text 'Do not press the physical power button during this probe unless that is the specific button under test.'
+
+Write-Host ''
+Write-Host "Display/menu button Windows-event probe" -ForegroundColor Cyan
+Write-Host "Press the physical display/menu button once during the next $PressWindowSeconds seconds." -ForegroundColor Yellow
+Write-Host "Report will be written to: $outFile" -ForegroundColor DarkGray
+Write-Host ''
+
+$pressStart = Get-Date
+Start-Sleep -Seconds $PressWindowSeconds
+$pressEnd = Get-Date
+$queryStart = $pressStart.AddMinutes(-1 * $LookbackMinutes)
+
+$result = Get-RelevantEventMatches -StartTime $queryStart -EndTime $pressEnd -Limit $MaxEvents
+$events = @($result.Events)
+$eventCount = $events.Count
+$class = if ($eventCount -gt 0) { 'OBSERVED_WINDOWS_EVENT' } else { 'NO_WINDOWS_EVENT_OBSERVED' }
+
+Add-Line -Lines $lines -Text ''
+Add-Line -Lines $lines -Text "Observation window: $($pressStart.ToString('yyyy-MM-dd HH:mm:ss')) through $($pressEnd.ToString('yyyy-MM-dd HH:mm:ss'))"
+Add-Line -Lines $lines -Text "Context lookback start: $($queryStart.ToString('yyyy-MM-dd HH:mm:ss'))"
+Add-Line -Lines $lines -Text "Classification: $class"
+Add-Line -Lines $lines -Text "Matching events captured: $eventCount"
+Add-Line -Lines $lines -Text ''
+
+if ($eventCount -gt 0) {
+    Add-Line -Lines $lines -Text 'Events:'
+    foreach ($event in $events) {
+        Add-Line -Lines $lines -Text "- $($event.TimeCreated.ToString('yyyy-MM-dd HH:mm:ss')) | $($event.LogName) | $($event.ProviderName) | Id=$($event.Id) | $($event.LevelDisplay)"
+        if ($event.Message) {
+            Add-Line -Lines $lines -Text "  $($event.Message)"
+        }
+    }
+} else {
+    Add-Line -Lines $lines -Text 'No matching Windows events were observed during this run.'
+    Add-Line -Lines $lines -Text 'Interpretation: the physical display/menu button may be firmware-only / OSD-controlled, or it may not emit a Windows event under this observation method.'
+}
+
+$readErrors = @($result.Errors)
+if ($readErrors.Count -gt 0) {
+    Add-Line -Lines $lines -Text ''
+    Add-Line -Lines $lines -Text 'Read warnings:'
+    foreach ($errorText in $readErrors) {
+        Add-Line -Lines $lines -Text "  $errorText"
+    }
+}
+
+Add-Line -Lines $lines -Text ''
+Add-Line -Lines $lines -Text "TRACKER: $env:COMPUTERNAME | DisplayMenuButtonProbe | $class | events=$eventCount | $timestampText"
+Add-Line -Lines $lines -Text ''
+Add-Line -Lines $lines -Text ('=' * 80)
+Add-Line -Lines $lines -Text "Output: $outFile"
+
+$text = $lines -join [Environment]::NewLine
+$text | Out-File -LiteralPath $outFile -Encoding UTF8
+Write-Host $text
+
+if ($readErrors.Count -gt 0 -and $eventCount -eq 0) { exit 2 }
+exit 0

--- a/Tests/Pester/QRTasks.Tests.ps1
+++ b/Tests/Pester/QRTasks.Tests.ps1
@@ -7,6 +7,7 @@
 BeforeAll {
     $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:dispatcherPath = Join-Path $repoRoot 'QRTasks\Invoke-TechTask.ps1'
+    $script:powerComfortPath = Join-Path $repoRoot 'QRTasks\Set-PowerComfortDefaults.ps1'
 }
 
 Describe 'Invoke-TechTask task registry' {
@@ -23,6 +24,23 @@ Describe 'Invoke-TechTask task registry' {
     It 'Includes PowerComfortRevert mapped to Restore-PowerComfortDefaults.ps1' {
         $content = Get-Content -Path $script:dispatcherPath -Raw
         $content | Should -Match "PowerComfortRevert\s*=\s*'Restore-PowerComfortDefaults\.ps1'"
+    }
+}
+
+Describe 'Set-PowerComfortDefaults button behavior' {
+    It 'Sets the physical power button and Windows menu power button to do nothing on AC and DC' {
+        $content = Get-Content -Path $script:powerComfortPath -Raw
+        $content | Should -Match '\$powerButtonAction\s*=\s*''7648efa3-dd9c-4e3e-b566-50f929386280'''
+        $content | Should -Match '\$startMenuPowerButtonAction\s*=\s*''a7066653-8d6c-40a8-910e-a1f54b84c7e5'''
+        $content.Contains("@('/setacvalueindex', `$g, 'SUB_BUTTONS', `$powerButtonAction, '0')") | Should -Be $true
+        $content.Contains("@('/setdcvalueindex', `$g, 'SUB_BUTTONS', `$powerButtonAction, '0')") | Should -Be $true
+        $content.Contains("@('/setacvalueindex', `$g, 'SUB_BUTTONS', `$startMenuPowerButtonAction, '0')") | Should -Be $true
+        $content.Contains("@('/setdcvalueindex', `$g, 'SUB_BUTTONS', `$startMenuPowerButtonAction, '0')") | Should -Be $true
+    }
+
+    It 'Names the menu power button behavior in the operator report text' {
+        $content = Get-Content -Path $script:powerComfortPath -Raw
+        $content | Should -Match 'start menu power button=do nothing'
     }
 }
 

--- a/Tests/Pester/QRTasks.Tests.ps1
+++ b/Tests/Pester/QRTasks.Tests.ps1
@@ -8,6 +8,7 @@ BeforeAll {
     $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:dispatcherPath = Join-Path $repoRoot 'QRTasks\Invoke-TechTask.ps1'
     $script:powerComfortPath = Join-Path $repoRoot 'QRTasks\Set-PowerComfortDefaults.ps1'
+    $script:displayMenuProbePath = Join-Path $repoRoot 'QRTasks\Test-DisplayMenuButtonEvent.ps1'
 }
 
 Describe 'Invoke-TechTask task registry' {
@@ -25,10 +26,15 @@ Describe 'Invoke-TechTask task registry' {
         $content = Get-Content -Path $script:dispatcherPath -Raw
         $content | Should -Match "PowerComfortRevert\s*=\s*'Restore-PowerComfortDefaults\.ps1'"
     }
+
+    It 'Includes DisplayMenuButtonProbe mapped to Test-DisplayMenuButtonEvent.ps1' {
+        $content = Get-Content -Path $script:dispatcherPath -Raw
+        $content | Should -Match "DisplayMenuButtonProbe\s*=\s*'Test-DisplayMenuButtonEvent\.ps1'"
+    }
 }
 
 Describe 'Set-PowerComfortDefaults button behavior' {
-    It 'Sets the physical power button and Windows menu power button to do nothing on AC and DC' {
+    It 'Sets the physical power button and Windows Start menu power button to do nothing on AC and DC' {
         $content = Get-Content -Path $script:powerComfortPath -Raw
         $content | Should -Match '\$powerButtonAction\s*=\s*''7648efa3-dd9c-4e3e-b566-50f929386280'''
         $content | Should -Match '\$startMenuPowerButtonAction\s*=\s*''a7066653-8d6c-40a8-910e-a1f54b84c7e5'''
@@ -38,9 +44,39 @@ Describe 'Set-PowerComfortDefaults button behavior' {
         $content.Contains("@('/setdcvalueindex', `$g, 'SUB_BUTTONS', `$startMenuPowerButtonAction, '0')") | Should -Be $true
     }
 
-    It 'Names the menu power button behavior in the operator report text' {
+    It 'Names the Start menu power button behavior in the operator report text' {
         $content = Get-Content -Path $script:powerComfortPath -Raw
         $content | Should -Match 'start menu power button=do nothing'
+    }
+}
+
+Describe 'Test-DisplayMenuButtonEvent field probe' {
+    It 'Classifies the physical display/menu button separately from Windows power policy' {
+        $content = Get-Content -Path $script:displayMenuProbePath -Raw
+        $content | Should -Match 'physical display/menu button'
+        $content | Should -Match 'OBSERVED_WINDOWS_EVENT'
+        $content | Should -Match 'NO_WINDOWS_EVENT_OBSERVED'
+        $content | Should -Match 'firmware-only / OSD-controlled'
+        $content | Should -Match 'DisplayMenuButtonProbe'
+    }
+
+    It 'Remains read-only except for local QRTasks report output' {
+        $content = Get-Content -Path $script:displayMenuProbePath -Raw
+        $forbidden = @(
+            'powercfg /set',
+            'Set-ItemProperty',
+            'New-ItemProperty',
+            'Remove-ItemProperty',
+            'Register-ScheduledTask',
+            'New-Service',
+            'wevtutil cl',
+            'Clear-EventLog'
+        )
+        foreach ($fragment in $forbidden) {
+            $content | Should -Not -Match ([regex]::Escape($fragment))
+        }
+        $content | Should -Match 'Get-WinEvent'
+        $content | Should -Match 'GetInfo\\Output\\QRTasks'
     }
 }
 


### PR DESCRIPTION
## Summary

Extends the QRTasks PowerComfort work with two separate, bounded outcomes:

1. Keep the known-good Windows power-button hardening path.
2. Add a read-only field probe for the ambiguous physical display/menu button path, because that button may or may not register as a Windows-observable event.

## Scope

- Updates `QRTasks/Set-PowerComfortDefaults.ps1` to set the Windows Start menu/UI power action to `0` / do nothing for AC and DC across all parsed power schemes.
- Adds `QRTasks/Test-DisplayMenuButtonEvent.ps1`, a QR-friendly local event-log probe that asks the technician to press the physical display/menu button during a short observation window.
- Registers the probe in `QRTasks/Invoke-TechTask.ps1` as `DisplayMenuButtonProbe`.
- Extends `Tests/Pester/QRTasks.Tests.ps1` with static coverage for:
  - PowerComfort physical power-button and Windows Start menu power-action fragments.
  - DisplayMenuButtonProbe dispatcher registration.
  - DisplayMenuButtonProbe classification language.
  - Read-only guardrails against power policy, registry, service, scheduled task, and event-log-clearing mutations.

## Guardrails

- No live target execution performed.
- No survey or harness runtime changes.
- The new probe is read-only except for writing the local report under `GetInfo\Output\QRTasks`.
- The probe does not clear logs, suppress telemetry, change firmware, change registry, create services, register scheduled tasks, or change power policy.

## Field interpretation

- `PowerComfort` changes Windows power policy only.
- `DisplayMenuButtonProbe` answers the field ambiguity:
  - `OBSERVED_WINDOWS_EVENT`: Windows logged something plausibly related during the press window.
  - `NO_WINDOWS_EVENT_OBSERVED`: Windows did not log a related event during the run; the physical display/menu button may be firmware-only / display-OSD controlled, or may need a different observation method.

## Validation

Connector-backed validation performed:

```text
git status --short
 M QRTasks/Invoke-TechTask.ps1
 M QRTasks/Set-PowerComfortDefaults.ps1
 A QRTasks/Test-DisplayMenuButtonEvent.ps1
 M Tests/Pester/QRTasks.Tests.ps1

git diff --stat
 QRTasks/Invoke-TechTask.ps1           |  19 +++--
 QRTasks/Set-PowerComfortDefaults.ps1  |   7 +-
 QRTasks/Test-DisplayMenuButtonEvent.ps1 | 174 ++++++++++++++++++++++++++++++++++
 Tests/Pester/QRTasks.Tests.ps1        |  54 +++++++++++
 4 files changed

static contract checks
DisplayMenuButtonProbe registered in Invoke-TechTask: PASS
probe script exists: PASS
probe declares OBSERVED_WINDOWS_EVENT: PASS
probe declares NO_WINDOWS_EVENT_OBSERVED: PASS
probe documents firmware-only / OSD-controlled interpretation: PASS
probe reads Get-WinEvent: PASS
probe writes only local QRTasks report output: PASS
Pester tests cover dispatcher registration: PASS
Pester tests cover read-only guardrails: PASS
PR compare main...feat/powercomfort-menu-button-action: ahead 5, behind 0
```

Skipped:

- `Invoke-Pester Tests/Pester/QRTasks.Tests.ps1` because the execution sandbox does not have PowerShell/Pester installed.
- Live `powercfg` execution because that would mutate the current machine.
- Live `DisplayMenuButtonProbe` execution because it requires a physical target/display button press.