### PR TITLE
feat(cybernet): add local network posture gate

### DIFF
--- a/Tests/Pester/CybernetNetworkPosture.Tests.ps1
+++ b/Tests/Pester/CybernetNetworkPosture.Tests.ps1
@@ -1,0 +1,66 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0' }
+
+Set-StrictMode -Version Latest
+
+Describe 'Cybernet network posture gate' {
+    BeforeAll {
+        $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        $script:postureScript = Join-Path $repoRoot 'scripts/Test-CybernetNetworkPosture.ps1'
+        $script:tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('sas-network-posture-' + [guid]::NewGuid().Guid)
+        New-Item -ItemType Directory -Path $script:tempRoot -Force | Out-Null
+        $script:configPath = Join-Path $script:tempRoot 'guard.json'
+        $script:emptyConfigPath = Join-Path $script:tempRoot 'empty-guard.json'
+        $script:networkTextPath = Join-Path $script:tempRoot 'ipconfig.txt'
+        @{
+            allowedDnsSuffixes = @('wired.example.invalid')
+            allowedWindowsDomains = @()
+            allowedLocalIpCidrs = @('192.0.2.0/24')
+            allowedGatewayCidrs = @('192.0.2.1/32')
+            allowedDnsServerCidrs = @('198.51.100.0/24')
+        } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $script:configPath -Encoding UTF8
+        @{
+            allowedDnsSuffixes = @()
+            allowedWindowsDomains = @()
+            allowedLocalIpCidrs = @()
+            allowedGatewayCidrs = @()
+            allowedDnsServerCidrs = @()
+        } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $script:emptyConfigPath -Encoding UTF8
+        @(
+            'Windows IP Configuration'
+            'Ethernet adapter Ethernet:'
+            '   Connection-specific DNS Suffix  . : wired.example.invalid'
+            '   IPv4 Address. . . . . . . . . . . : 192.0.2.25(Preferred)'
+            '   Default Gateway . . . . . . . . . : 192.0.2.1'
+            '   DNS Servers . . . . . . . . . . . : 198.51.100.10'
+        ) | Set-Content -LiteralPath $script:networkTextPath -Encoding UTF8
+    }
+
+    AfterAll {
+        Remove-Item -LiteralPath $script:tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'accepts approved Wi-Fi without target activity' {
+        $output = Join-Path $script:tempRoot 'wifi.json'
+        $result = & $script:postureScript -Ssid 'NSLIJHS-WAB-Test' -NetworkTextPath $script:networkTextPath -GuardConfigPath $script:configPath -OutputPath $output -NoExitCode
+        $result.classification | Should -Be 'OK_NETWORK_POSTURE'
+        $result.allowed_for_target_preflight | Should -BeTrue
+        $result.network_activity_performed | Should -BeFalse
+        $result.target_mutation_performed | Should -BeFalse
+        (Get-Content -LiteralPath $output -Raw | ConvertFrom-Json).classification | Should -Be 'OK_NETWORK_POSTURE'
+    }
+
+    It 'accepts approved wired evidence without target activity' {
+        $output = Join-Path $script:tempRoot 'wired.json'
+        $result = & $script:postureScript -Ssid 'unknown' -NetworkTextPath $script:networkTextPath -GuardConfigPath $script:configPath -OutputPath $output -NoExitCode
+        $result.classification | Should -Be 'OK_NETWORK_POSTURE'
+        $result.wired_approved | Should -BeTrue
+    }
+
+    It 'classifies an unapproved Wi-Fi segment without probing targets' {
+        $output = Join-Path $script:tempRoot 'guest.json'
+        $result = & $script:postureScript -Ssid 'Guest-WiFi' -NetworkTextPath $script:networkTextPath -GuardConfigPath $script:emptyConfigPath -OutputPath $output -NoExitCode
+        $result.classification | Should -Be 'ENVIRONMENT_BLOCKED_GUEST_NETWORK'
+        $result.allowed_for_target_preflight | Should -BeFalse
+        $result.network_activity_performed | Should -BeFalse
+    }
+}

--- a/Tests/survey/test_cybernet_network_posture_contracts.py
+++ b/Tests/survey/test_cybernet_network_posture_contracts.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Static contracts for the local-only Cybernet network posture gate."""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "Test-CybernetNetworkPosture.ps1"
+TEST = ROOT / "Tests" / "Pester" / "CybernetNetworkPosture.Tests.ps1"
+RUNBOOK = ROOT / "docs" / "WAB_TEST_READINESS.md"
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"missing file: {path.relative_to(ROOT).as_posix()}"
+    return path.read_text(encoding="utf-8-sig")
+
+
+def test_posture_gate_is_local_only_and_classifies_environment() -> None:
+    text = read(SCRIPT)
+    for fragment in [
+        "SasNetworkGuard.psm1",
+        "OK_NETWORK_POSTURE",
+        "ENVIRONMENT_BLOCKED_GUEST_NETWORK",
+        "ENVIRONMENT_BLOCKED_POLICY",
+        "INCONCLUSIVE",
+        "network_activity_performed = $false",
+        "target_mutation_performed = $false",
+        "allowed_for_target_preflight",
+        "wired_guard_configured",
+        "survey/output/network_posture",
+        "[switch]$NoExitCode",
+    ]:
+        assert fragment in text, f"missing posture gate contract: {fragment}"
+
+    for forbidden in ["Test-NetConnection", "Resolve-DnsName", "Invoke-WebRequest", "Invoke-Command", "Set-ItemProperty", "Start-Process", "nmap", "naabu"]:
+        assert forbidden not in text, f"posture gate must not execute {forbidden}"
+
+
+def test_posture_gate_has_fixture_backed_pester_coverage() -> None:
+    text = read(TEST)
+    for fragment in [
+        "accepts approved Wi-Fi",
+        "accepts approved wired evidence",
+        "classifies an unapproved Wi-Fi segment",
+        "network_activity_performed",
+        "target_mutation_performed",
+    ]:
+        assert fragment in text
+
+
+def test_wab_runbook_names_posture_before_target_preflight() -> None:
+    text = read(RUNBOOK)
+    assert "Test-CybernetNetworkPosture.ps1" in text
+    assert "before target preflight" in text
+
+
+if __name__ == "__main__":
+    test_posture_gate_is_local_only_and_classifies_environment()
+    test_posture_gate_has_fixture_backed_pester_coverage()
+    test_wab_runbook_names_posture_before_target_preflight()

--- a/docs/WAB_TEST_READINESS.md
+++ b/docs/WAB_TEST_READINESS.md
@@ -87,6 +87,14 @@ Evidence to save:
 
 Before printer mapping, remote probes, or host reachability tests, record the network posture.
 
+Run this local-only gate first. It records an ignored JSON result and does not contact a Cybernet or any other target:
+
+```powershell
+.\scripts\Test-CybernetNetworkPosture.ps1
+```
+
+Only continue when it reports `OK_NETWORK_POSTURE`. If it reports `ENVIRONMENT_BLOCKED_GUEST_NETWORK`, move to an approved enterprise segment. If it reports `ENVIRONMENT_BLOCKED_POLICY`, correct the ignored local network-guard allowlist. This classification happens before target preflight.
+
 ```powershell
 ipconfig /all
 hostname

--- a/scripts/Test-CybernetNetworkPosture.ps1
+++ b/scripts/Test-CybernetNetworkPosture.ps1
@@ -1,0 +1,128 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+Classifies local workstation network posture before Cybernet target preflight.
+
+.DESCRIPTION
+Reads only local Wi-Fi and network-configuration evidence through SasNetworkGuard.
+It never probes a target, scans a subnet, launches an app, or changes local or remote state.
+The JSON result is local evidence and belongs in an ignored output directory.
+#>
+[CmdletBinding()]
+param(
+    [string]$Ssid,
+    [string]$NetworkTextPath,
+    [string]$GuardConfigPath,
+    [string]$OutputPath,
+    [switch]$NoExitCode
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$guardModule = Join-Path $repoRoot 'scripts/SasNetworkGuard.psm1'
+if (-not (Test-Path -LiteralPath $guardModule -PathType Leaf)) {
+    throw "Missing shared network guard module: $guardModule"
+}
+
+if (-not $OutputPath) {
+    $stamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $OutputPath = Join-Path $repoRoot "survey/output/network_posture/network_posture_$stamp.json"
+}
+elseif (-not [System.IO.Path]::IsPathRooted($OutputPath)) {
+    $OutputPath = Join-Path $repoRoot $OutputPath
+}
+
+$originalGuardConfig = $env:SAS_NETWORK_GUARD_CONFIG
+$originalRepoRoot = $env:SAS_REPO_ROOT
+try {
+    $env:SAS_REPO_ROOT = $repoRoot
+    if ($GuardConfigPath) {
+        $env:SAS_NETWORK_GUARD_CONFIG = (Resolve-Path -LiteralPath $GuardConfigPath -ErrorAction Stop).Path
+    }
+
+    Import-Module $guardModule -Force
+    $effectiveSsid = if ($PSBoundParameters.ContainsKey('Ssid')) { $Ssid } else { Get-SasCurrentWifiSsid }
+    $networkText = if ($NetworkTextPath) {
+        Get-Content -LiteralPath $NetworkTextPath -Raw -ErrorAction Stop
+    }
+    else {
+        Get-SasLocalNetworkText
+    }
+    $config = Get-SasNetworkGuardConfig
+    $wiredGuardConfigured = $false
+    if ($null -ne $config) {
+        $wiredGuardConfigured = @(
+            $config.allowedDnsSuffixes +
+            $config.allowedWindowsDomains +
+            $config.allowedLocalIpCidrs +
+            $config.allowedGatewayCidrs +
+            $config.allowedDnsServerCidrs
+        ).Count -gt 0
+    }
+    $wifiApproved = Test-SasNorthwellWifiSsid -Ssid $effectiveSsid
+    $wiredApproved = $false
+    $classification = 'INCONCLUSIVE'
+    $reason = 'no approved Wi-Fi or wired evidence was detected'
+    $exitCode = 2
+
+    if ($null -eq $config) {
+        $classification = 'ENVIRONMENT_BLOCKED_POLICY'
+        $reason = 'the local network-guard configuration is malformed'
+        $exitCode = 3
+    }
+    elseif ($wifiApproved) {
+        $classification = 'OK_NETWORK_POSTURE'
+        $reason = 'approved Wi-Fi posture detected'
+        $exitCode = 0
+    }
+    else {
+        $wiredApproved = Test-SasNorthwellWiredEvidence -NetworkText $networkText
+        if ($wiredApproved) {
+            $classification = 'OK_NETWORK_POSTURE'
+            $reason = 'approved wired evidence detected'
+            $exitCode = 0
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace($effectiveSsid) -and $effectiveSsid -ne 'unknown') {
+            $classification = 'ENVIRONMENT_BLOCKED_GUEST_NETWORK'
+            $reason = 'connected Wi-Fi is not an approved enterprise SSID'
+        }
+    }
+
+    $result = [ordered]@{
+        schema_version = 'sas-cybernet-network-posture/v1'
+        generated_at = (Get-Date).ToUniversalTime().ToString('o')
+        classification = $classification
+        allowed_for_target_preflight = ($exitCode -eq 0)
+        reason = $reason
+        wifi_ssid = $effectiveSsid
+        wifi_approved = $wifiApproved
+        wired_approved = $wiredApproved
+        wired_guard_configured = $wiredGuardConfigured
+        network_activity_performed = $false
+        target_mutation_performed = $false
+        next_action = $(if ($exitCode -eq 0) {
+            'Use an approved staged target file for read-only network preflight.'
+        } elseif ($classification -eq 'ENVIRONMENT_BLOCKED_POLICY') {
+            'Correct the ignored local network-guard allowlist, then rerun this posture check.'
+        } else {
+            'Move to an approved enterprise Wi-Fi, VPN, or wired segment, then rerun this posture check before target preflight.'
+        })
+    }
+
+    $parent = Split-Path -Parent $OutputPath
+    if (-not (Test-Path -LiteralPath $parent -PathType Container)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    $result | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $OutputPath -Encoding UTF8
+    Write-Host "Network posture: $classification"
+    Write-Host "Result: $OutputPath"
+
+    if ($NoExitCode) { return [pscustomobject]$result }
+    if ($exitCode -ne 0) { exit $exitCode }
+}
+finally {
+    $env:SAS_NETWORK_GUARD_CONFIG = $originalGuardConfig
+    $env:SAS_REPO_ROOT = $originalRepoRoot
+}

--- a/tests/survey/run_offline_survey_tests.sh
+++ b/tests/survey/run_offline_survey_tests.sh
@@ -6,6 +6,7 @@ python3 tests/survey/test_cybernet_cleanup_report.py
 python3 Tests/survey/test_ad_probe_resilience_contracts.py
 python3 Tests/survey/test_ad_existence_bulk_contracts.py
 python3 Tests/survey/test_serial_network_preflight_contracts.py
+python3 Tests/survey/test_cybernet_network_posture_contracts.py
 python3 Tests/survey/test_probe_socket_access_contracts.py
 python3 Tests/survey/test_standard_corporate_tooling_contracts.py
 python3 Tests/survey/test_hotfix_command_registry_contracts.py


### PR DESCRIPTION
## Summary
- adds a local-only Cybernet network posture gate before target preflight
- classifies approved Wi-Fi/wired posture, guest/wrong segments, malformed policy, and inconclusive evidence
- writes ignored local JSON evidence and never contacts targets, scans networks, launches apps, or changes state

## Validation
- `Invoke-Pester -Path .\Tests\Pester\CybernetNetworkPosture.Tests.ps1 -Output Detailed`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\Test-Pester5Suite.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1`
- `C:\Program Files\Git\bin\bash.exe tests/survey/run_offline_survey_tests.sh`