### PR TITLE
docs(cybernet): define network posture profiles

### DIFF
--- a/Tests/survey/test_cybernet_network_profile_plan.py
+++ b/Tests/survey/test_cybernet_network_profile_plan.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Static contract for the multi-environment Cybernet posture plan."""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PLAN = ROOT / "docs" / "plans" / "cybernet-network-posture-profiles.plan.md"
+
+
+def test_profile_plan_is_explicit_and_fail_closed() -> None:
+    text = PLAN.read_text(encoding="utf-8")
+    for fragment in (
+        "corporate_wab",
+        "approved_lan",
+        "approved_vpn",
+        "unknown",
+        "Profile selection is an explicit toggle",
+        "profile_id",
+        "guard_configured",
+        "network_activity_performed",
+        "target_mutation_performed",
+        "raw-evidence artifact references",
+        "Human console status belongs on the host",
+        "unknown` and failed evidence remain fail-closed",
+        "No profile may collect secrets",
+    ):
+        assert fragment in text, f"missing profile-plan contract: {fragment}"
+
+
+if __name__ == "__main__":
+    test_profile_plan_is_explicit_and_fail_closed()
+    print("cybernet network profile plan contracts passed")

--- a/docs/plans/cybernet-network-posture-profiles.plan.md
+++ b/docs/plans/cybernet-network-posture-profiles.plan.md
@@ -1,0 +1,64 @@
+# Cybernet Network Posture Profiles Plan
+
+## Purpose
+
+Extend the local-only Cybernet posture gate into explicit environment profiles. The operator must be able to test the corporate/WAB environment, an approved local LAN, an approved VPN path, or an unknown/blocked environment without silently weakening the safety policy.
+
+The existing `scripts/Test-CybernetNetworkPosture.ps1` remains the local evidence collector and fail-closed gate. This plan defines the profile contract around it; it does not authorize target probes, subnet discovery, or target mutation.
+
+## Profile contract
+
+| Profile id | Intended environment | Required evidence | Default target actions | Failure classification |
+|---|---|---|---|---|
+| `corporate_wab` | Corporate/WAB segment | Approved SSID, wired allowlist, or approved enterprise VPN evidence | Read-only target preflight only | `ENVIRONMENT_BLOCKED_GUEST_NETWORK` or `ENVIRONMENT_BLOCKED_POLICY` |
+| `approved_lan` | Approved local test LAN | Explicit local profile allowlist for suffix, IP, gateway, and DNS evidence | Local-device inventory and explicitly allowed read-only checks | `ENVIRONMENT_BLOCKED_POLICY` or `INCONCLUSIVE` |
+| `approved_vpn` | Approved VPN path | Explicit VPN adapter, route, DNS, or domain evidence | Read-only target preflight only | `ENVIRONMENT_BLOCKED_POLICY` or `INCONCLUSIVE` |
+| `unknown` | Any unclassified environment | No trusted profile evidence | No target actions | `INCONCLUSIVE` |
+
+Profile selection is an explicit toggle/configuration input. It must not be inferred from a friendly SSID or used to bypass an allowlist. A selected profile is only eligible when its configured evidence passes.
+
+## Evidence and reporting contract
+
+Every posture result and evidence-derived English report should carry:
+
+- `profile_id` and profile display name
+- evidence source (`wifi`, `wired`, `vpn`, `fixture`, or `none`)
+- `guard_configured` versus empty/default guard state
+- classification and confidence (`proven`, `blocked`, or `inconclusive`)
+- `allowed_for_target_preflight`
+- permitted, skipped, and forbidden action classes
+- `network_activity_performed` and `target_mutation_performed`
+- raw-evidence artifact references separate from structured posture fields
+- exact `next_action`
+
+Human console status belongs on the host/information stream. Structured callers must receive only the posture object or JSON contract; mixed output is a harness defect.
+
+## Implementation slices
+
+1. Add a versioned profile configuration schema and an example containing no live addresses or credentials.
+2. Extend the posture gate with `ProfileId` and profile-specific evidence evaluation while preserving the current default behavior.
+3. Add fixture coverage for each profile, empty/default configuration, malformed configuration, and profile mismatch.
+4. Add profile fields to operator-report and handoff adapters, preserving raw/structured traceability.
+5. Expose a read-only agent/MCP capability that reports available profiles and the current evidence classification; it must not execute target actions.
+6. Run Windows fixture validation, then perform real target preflight only on an approved profile and approved target list.
+
+## Safety and proof boundaries
+
+- Profile selection never grants permission by itself.
+- `unknown` and failed evidence remain fail-closed.
+- Local LAN mode is not a license for subnet scanning; any discovery remains a separately authorized workflow.
+- No profile may collect secrets or persist live target data in tracked files.
+- Runtime proof must identify the selected profile, evidence artifacts, target scope, and skipped checks.
+
+## Validation commands
+
+```powershell
+Invoke-Pester -Path .\Tests\Pester\CybernetNetworkPosture.Tests.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1
+```
+
+```bash
+bash tests/survey/run_offline_survey_tests.sh
+```
+
+The first implementation PR should update the existing posture contract test before changing any target-facing workflow.

--- a/tests/survey/run_offline_survey_tests.sh
+++ b/tests/survey/run_offline_survey_tests.sh
@@ -7,6 +7,7 @@ python3 Tests/survey/test_ad_probe_resilience_contracts.py
 python3 Tests/survey/test_ad_existence_bulk_contracts.py
 python3 Tests/survey/test_serial_network_preflight_contracts.py
 python3 Tests/survey/test_cybernet_network_posture_contracts.py
+python3 Tests/survey/test_cybernet_network_profile_plan.py
 python3 Tests/survey/test_probe_socket_access_contracts.py
 python3 Tests/survey/test_standard_corporate_tooling_contracts.py
 python3 Tests/survey/test_hotfix_command_registry_contracts.py


### PR DESCRIPTION
## Summary
- defines explicit Cybernet posture profiles for corporate/WAB, approved LAN, VPN, and unknown environments
- specifies profile toggles, fail-closed behavior, evidence/report/handoff fields, and agent/MCP integration boundaries
- adds a static contract test to the offline survey validation runner

## Validation
- `python Tests/survey/test_cybernet_network_profile_plan.py`
- `C:\Program Files\Git\bin\bash.exe tests/survey/run_offline_survey_tests.sh`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tools\validate-ai-layer.ps1`
- `git diff --check`

This is a planning/contract slice stacked on PR #158 and contains no live probing or target mutation.