### PR TITLE
feat: standardize determinate progress reporting

### DIFF
--- a/Launch-SysAdminSuiteDashboard.Host.bat
+++ b/Launch-SysAdminSuiteDashboard.Host.bat
@@ -18,11 +18,11 @@ set "ROOT=%~dp0"
 
 call :find_bash
 if not defined BASH_EXE (
-    echo Git Bash was not found. Install Git for Windows or use the packaged dashboard field release.
+    echo [SAS][failed] Git Bash was not found. Install Git for Windows or use the packaged dashboard field release.
     exit /b 2
 )
 
-echo Preparing dashboard dependencies and host for first use...
+echo [SAS][running] Preparing dashboard dependencies and host for first use...
 "%BASH_EXE%" -lc "cd '%ROOT:\=/%' && bash scripts/ensure-dashboard-host.sh"
 set "ENSURE_RC=%errorlevel%"
 
@@ -35,8 +35,15 @@ if not "%ENSURE_RC%"=="0" (
     rem gap with the local-only Python dashboard fallback so a double-click still
     rem serves the dashboard instead of dead-ending to manual CLI usage.
     call :start_fallback
-    if defined FALLBACK_OK exit /b 0
-    if "%ENSURE_RC%"=="2" exit /b 2
+    if defined FALLBACK_OK (
+        echo [SAS][complete] Local Python dashboard fallback started.
+        exit /b 0
+    )
+    if "%ENSURE_RC%"=="2" (
+        echo [SAS][failed] Dashboard dependency preparation failed.
+        exit /b 2
+    )
+    echo [SAS][failed] Dashboard host preparation needs IT or admin attention.
     exit /b 3
 )
 
@@ -45,7 +52,11 @@ if not defined HOST_EXE (
     rem Host preparation reported success but no executable was located. Try the
     rem local-only Python dashboard fallback before failing.
     call :start_fallback
-    if defined FALLBACK_OK exit /b 0
+    if defined FALLBACK_OK (
+        echo [SAS][complete] Local Python dashboard fallback started.
+        exit /b 0
+    )
+    echo [SAS][failed] Host preparation completed but no dashboard executable was found.
     exit /b 3
 )
 
@@ -58,6 +69,7 @@ if exist "%ROOT%app\bin\SysAdminSuite.DashboardHost.exe" (
     )
 )
 start "" /B "%HOST_EXE%" %*
+echo [SAS][complete] Dashboard host process started.
 exit /b 0
 
 :find_host
@@ -84,9 +96,15 @@ set "PY_OK="
 where py >nul 2>nul && set "PY_OK=1"
 if not defined PY_OK where python >nul 2>nul && set "PY_OK=1"
 if not defined PY_OK where python3 >nul 2>nul && set "PY_OK=1"
-if not defined PY_OK goto :eof
-if not exist "%ROOT%server.py" goto :eof
-echo The .NET dashboard host is unavailable; starting the local Python dashboard fallback...
+if not defined PY_OK (
+    echo [SAS][skipped] Python fallback unavailable because no Python runtime was found.
+    goto :eof
+)
+if not exist "%ROOT%server.py" (
+    echo [SAS][skipped] Python fallback unavailable because server.py was not found.
+    goto :eof
+)
+echo [SAS][running] The .NET dashboard host is unavailable; starting the local Python dashboard fallback...
 start "SysAdminSuite Dashboard (fallback)" /MIN "%BASH_EXE%" -lc "cd '%ROOT:\=/%' && SAS_DASHBOARD_BIND=127.0.0.1 SAS_DASHBOARD_PORT=5000 bash scripts/sas-serve-dashboard-fallback.sh"
 set "FALLBACK_OK=1"
 goto :eof

--- a/Run-HarnessValidation.cmd
+++ b/Run-HarnessValidation.cmd
@@ -9,10 +9,14 @@ if %ERRORLEVEL% EQU 0 (
     set "SAS_PS=powershell.exe"
 )
 
-echo [SAS] Running harness validation through PowerShell...
+echo [SAS][running] Harness validator child process started.
 "%SAS_PS%" -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\validate-sysadmin-harness.ps1"
 set "SAS_EXIT=%ERRORLEVEL%"
 echo.
-echo [SAS] Exit code: %SAS_EXIT%
+if "%SAS_EXIT%"=="0" (
+    echo [SAS][complete] Harness validator finished successfully.
+) else (
+    echo [SAS][failed] Harness validator exited with code %SAS_EXIT%.
+)
 pause
 exit /b %SAS_EXIT%

--- a/Tests/Pester/SasProgress.Tests.ps1
+++ b/Tests/Pester/SasProgress.Tests.ps1
@@ -1,0 +1,40 @@
+$modulePath = Join-Path $PSScriptRoot '..\..\scripts\SasProgress.psm1'
+
+Describe 'SysAdminSuite PowerShell progress contract' {
+    BeforeAll {
+        Import-Module $modulePath -Force
+    }
+
+    It 'supports every required lifecycle state' {
+        $text = Get-Content -LiteralPath $modulePath -Raw
+        foreach ($state in @('running', 'waiting', 'complete', 'failed', 'skipped')) {
+            $text | Should -Match ([regex]::Escape("'$state'"))
+        }
+    }
+
+    It 'suppresses human progress without writing success output' {
+        $context = New-SasProgressContext -Activity 'contract' -Total 2 -NoProgress
+        $output = @(Write-SasProgressState -Context $context -State running -Status 'first' -Current 1)
+        $output.Count | Should -Be 0
+        $context.Current | Should -Be 1
+        $context.Terminal | Should -BeFalse
+    }
+
+    It 'marks <State> terminal' -TestCases @(
+        @{ State = 'complete' }
+        @{ State = 'failed' }
+        @{ State = 'skipped' }
+    ) {
+        param($State)
+        $context = New-SasProgressContext -Activity 'contract' -Total 1 -NoProgress
+        Write-SasProgressState -Context $context -State $State -Status 'terminal'
+        $context.Terminal | Should -BeTrue
+    }
+
+    It 'keeps waiting nonterminal' {
+        $context = New-SasProgressContext -Activity 'contract' -Total 2 -NoProgress
+        Write-SasProgressState -Context $context -State waiting -Status 'operator input' -Current 1
+        $context.Terminal | Should -BeFalse
+        $context.Current | Should -Be 1
+    }
+}

--- a/Tests/bash/test_progress_reporting_contracts.sh
+++ b/Tests/bash/test_progress_reporting_contracts.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+bash_helper="$repo_root/survey/lib/sas-progress.sh"
+ps_helper="$repo_root/scripts/SasProgress.psm1"
+docs="$repo_root/docs/PROGRESS_REPORTING.md"
+
+for path in "$bash_helper" "$ps_helper" "$docs"; do
+  [[ -f "$path" ]] || fail "missing progress contract file: $path"
+done
+
+for state in running waiting complete failed skipped; do
+  grep -Fq "$state" "$bash_helper" || fail "Bash helper missing $state"
+  grep -Fq "$state" "$ps_helper" || fail "PowerShell helper missing $state"
+  grep -Fqi "$state" "$docs" || fail "documentation missing $state"
+done
+
+grep -Fq '>&2' "$bash_helper" || fail 'Bash progress must use stderr'
+grep -Fq 'Write-Host' "$ps_helper" || fail 'PowerShell progress must avoid success output'
+grep -Fq 'NoProgress' "$ps_helper" || fail 'PowerShell helper missing -NoProgress'
+grep -Fq 'sas_progress_disable' "$bash_helper" || fail 'Bash helper missing suppression'
+
+for script in \
+  bash/transport/sas-network-preflight.sh \
+  bash/transport/sas-printer-probe.sh \
+  bash/transport/sas-smb-readonly-recon.sh \
+  bash/transport/sas-wmi-identity.sh \
+  bash/transport/sas-workstation-identity.sh; do
+  grep -Fq -- '--no-progress' "$repo_root/$script" || fail "$script missing --no-progress"
+  grep -Fq 'sas_progress_complete' "$repo_root/$script" || fail "$script missing complete state"
+  grep -Fq 'sas_progress_fail' "$repo_root/$script" || fail "$script missing failed state"
+done
+
+grep -Fq '[SAS][running]' "$repo_root/Launch-SysAdminSuiteDashboard.Host.bat" || fail 'dashboard launcher missing running state'
+grep -Fq '[SAS][complete]' "$repo_root/Launch-SysAdminSuiteDashboard.Host.bat" || fail 'dashboard launcher missing complete state'
+grep -Fq '[SAS][failed]' "$repo_root/Launch-SysAdminSuiteDashboard.Host.bat" || fail 'dashboard launcher missing failed state'
+grep -Fq '[SAS][skipped]' "$repo_root/Launch-SysAdminSuiteDashboard.Host.bat" || fail 'dashboard launcher missing skipped state'
+
+grep -Fq "case 'RunWaiting'" "$repo_root/dashboard/js/run-control.js" || fail 'dashboard lifecycle missing waiting state'
+grep -Fq "case 'RunSkipped'" "$repo_root/dashboard/js/run-control.js" || fail 'dashboard lifecycle missing skipped state'
+grep -Fq 'Probe failed before completion' "$repo_root/dashboard/relay.py" || fail 'relay child failure is not surfaced'
+
+grep -Fq '[SAS][running]' "$repo_root/Run-HarnessValidation.cmd" || fail 'validator wrapper missing running state'
+grep -Fq '[SAS][complete]' "$repo_root/Run-HarnessValidation.cmd" || fail 'validator wrapper missing complete state'
+grep -Fq '[SAS][failed]' "$repo_root/Run-HarnessValidation.cmd" || fail 'validator wrapper missing failed state'
+
+printf 'PASS: progress reporting contracts\n'

--- a/bash/transport/sas-network-preflight.sh
+++ b/bash/transport/sas-network-preflight.sh
@@ -11,6 +11,8 @@ if [[ ! -f "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh" ]]; then
 fi
 # shellcheck source=survey/lib/sas-network-guard.sh
 source "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh"
+# shellcheck source=survey/lib/sas-progress.sh
+source "$SAS_REPO_ROOT/survey/lib/sas-progress.sh"
 
 TARGETS=()
 TARGET_FILE=""
@@ -19,6 +21,7 @@ PORTS="135,139,445,3389,515,631,9100"
 TIMEOUT=3
 PING_MODE="${SAS_PING_MODE:-auto}"
 PASS_THRU=0
+NO_PROGRESS=0
 
 usage(){ cat <<'USAGE'
 SysAdminSuite Network Preflight
@@ -34,6 +37,7 @@ Options:
   --timeout SEC        Per-check timeout. Default: 3
   --ping-mode MODE     Ping implementation: auto, linux, or windows. Default: auto
   --pass-thru          Print CSV after writing
+  --no-progress        Suppress progress bars
   -h, --help           Show help
 
 Ping modes:
@@ -44,7 +48,7 @@ Ping modes:
 Read-only. No remote mutation.
 USAGE
 }
-fail(){ printf '[network-preflight] ERROR: %s\n' "$*" >&2; exit 1; }
+fail(){ sas_progress_fail "$*"; printf '[network-preflight] ERROR: %s\n' "$*" >&2; exit 1; }
 log(){ printf '[network-preflight] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
@@ -58,6 +62,7 @@ while [[ $# -gt 0 ]]; do
     --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
     --ping-mode) PING_MODE="${2:?missing value for --ping-mode}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
+    --no-progress) NO_PROGRESS=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
     -*) fail "Unknown option: $1" ;;
@@ -86,6 +91,10 @@ if [[ -n "$TARGET_FILE" ]]; then
 fi
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
 mkdir -p "$(dirname "$OUTPUT")"
+[[ "$NO_PROGRESS" -eq 1 ]] && sas_progress_disable
+sas_progress_start "${#TARGETS[@]}" "Network preflight"
+completed=0
+trap 'rc=$?; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi' EXIT
 
 IFS=',' read -r -a PORT_ARRAY <<< "$PORTS"
 
@@ -173,6 +182,7 @@ tcp_status(){
 {
   printf 'Timestamp,Target,ResolvedAddress,PingStatus,Port,PortStatus\n'
   for target in "${TARGETS[@]}"; do
+    sas_progress_update "$completed" "checking $target"
     ip="$(resolve_ip "$target")"
     ping="$(ping_status "${ip:-$target}")"
     for port in "${PORT_ARRAY[@]}"; do
@@ -181,8 +191,11 @@ tcp_status(){
       status="$(tcp_status "${ip:-$target}" "$port")"
       printf '"%s","%s","%s","%s","%s","%s"\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$target" "$ip" "$ping" "$port" "$status"
     done
+    completed=$((completed + 1))
+    sas_progress_update "$completed" "finished $target"
   done
 } > "$OUTPUT"
+sas_progress_complete "wrote $OUTPUT"
 
 log "Wrote preflight CSV: $OUTPUT"
 [[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-printer-probe.sh
+++ b/bash/transport/sas-printer-probe.sh
@@ -12,6 +12,8 @@ if [[ ! -f "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh" ]]; then
 fi
 # shellcheck source=survey/lib/sas-network-guard.sh
 source "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh"
+# shellcheck source=survey/lib/sas-progress.sh
+source "$SAS_REPO_ROOT/survey/lib/sas-progress.sh"
 
 TARGETS=()
 TARGET_FILE=""
@@ -21,6 +23,7 @@ TIMEOUT=3
 SNMP_ONLY=0
 SKIP_9100=0
 PASS_THRU=0
+NO_PROGRESS=0
 
 usage(){ cat <<'USAGE'
 SysAdminSuite Printer Probe
@@ -37,6 +40,7 @@ Options:
   --output PATH        Output CSV path
   --timeout SEC        Timeout. Default: 3
   --pass-thru          Print CSV after writing
+  --no-progress        Suppress progress bars
   -h, --help           Show help
 
 Output columns:
@@ -49,7 +53,7 @@ Risks:
   - Port 9100/ZPL should be used only where approved; use --skip-9100 if unsure.
 USAGE
 }
-fail(){ printf '[printer-probe] ERROR: %s\n' "$*" >&2; exit 1; }
+fail(){ sas_progress_fail "$*"; printf '[printer-probe] ERROR: %s\n' "$*" >&2; exit 1; }
 log(){ printf '[printer-probe] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
@@ -64,6 +68,7 @@ while [[ $# -gt 0 ]]; do
     --output) OUTPUT="${2:?missing value for --output}"; shift 2 ;;
     --timeout) TIMEOUT="${2:?missing value for --timeout}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
+    --no-progress) NO_PROGRESS=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
     -*) fail "Unknown option: $1" ;;
@@ -84,6 +89,10 @@ if [[ -n "$TARGET_FILE" ]]; then
 fi
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
 mkdir -p "$(dirname "$OUTPUT")"
+[[ "$NO_PROGRESS" -eq 1 ]] && sas_progress_disable
+sas_progress_start "${#TARGETS[@]}" "Printer identity probe"
+completed=0
+trap 'rc=$?; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi' EXIT
 IFS=',' read -r -a COMMUNITY_ARRAY <<< "$COMMUNITIES"
 
 norm_mac(){
@@ -155,6 +164,7 @@ csv_escape(){ local s="${1:-}" q='"'; s="${s//$q/$q$q}"; printf '"%s"' "$s"; }
 {
   printf 'Timestamp,Target,ResolvedAddress,PingStatus,MAC,Serial,Source,Notes\n'
   for target in "${TARGETS[@]}"; do
+    sas_progress_update "$completed" "checking $target"
     ip="$(resolve_ip "$target")"; [[ -z "$ip" ]] && ip="$target"
     ping="$(ping_status "$ip")"
     mac=""; serial=""; source=(); notes=()
@@ -175,7 +185,10 @@ csv_escape(){ local s="${1:-}" q='"'; s="${s//$q/$q$q}"; printf '"%s"' "$s"; }
     [[ -z "$serial" ]] && notes+=("Serial unavailable")
     [[ "$ping" != "Reachable" ]] && notes+=("Ping failed or ICMP blocked")
     csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$ip"; printf ','; csv_escape "$ping"; printf ','; csv_escape "$mac"; printf ','; csv_escape "$serial"; printf ','; csv_escape "$(IFS=' | '; echo "${source[*]:-}")"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
+    completed=$((completed + 1))
+    sas_progress_update "$completed" "finished $target"
   done
 } > "$OUTPUT"
+sas_progress_complete "wrote $OUTPUT"
 log "Wrote printer probe CSV: $OUTPUT"
 [[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-smb-readonly-recon.sh
+++ b/bash/transport/sas-smb-readonly-recon.sh
@@ -12,6 +12,8 @@ if [[ ! -f "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh" ]]; then
 fi
 # shellcheck source=survey/lib/sas-network-guard.sh
 source "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh"
+# shellcheck source=survey/lib/sas-progress.sh
+source "$SAS_REPO_ROOT/survey/lib/sas-progress.sh"
 
 TARGETS=()
 TARGET_FILE=""
@@ -25,6 +27,7 @@ SMB_USER=""
 SMB_PASS=""
 SMB_DOMAIN=""
 PASS_THRU=0
+NO_PROGRESS=0
 
 usage(){ cat <<'USAGE'
 SysAdminSuite SMB Read-Only Recon
@@ -45,6 +48,7 @@ Options:
   --smb-pass PASS       Optional SMB password. Prefer SAS_SMB_PASS
   --smb-domain DOMAIN   Optional SMB domain. Prefer SAS_SMB_DOMAIN
   --pass-thru           Print CSV after writing
+  --no-progress         Suppress progress bars
   -h, --help            Show help
 
 Environment variables:
@@ -71,7 +75,7 @@ Known limitations:
 USAGE
 }
 
-fail(){ printf '[smb-recon] ERROR: %s\n' "$*" >&2; exit 1; }
+fail(){ sas_progress_fail "$*"; printf '[smb-recon] ERROR: %s\n' "$*" >&2; exit 1; }
 log(){ printf '[smb-recon] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
@@ -91,6 +95,7 @@ while [[ $# -gt 0 ]]; do
     --smb-pass) SMB_PASS="${2:?missing value for --smb-pass}"; shift 2 ;;
     --smb-domain) SMB_DOMAIN="${2:?missing value for --smb-domain}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
+    --no-progress) NO_PROGRESS=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
     -*) fail "Unknown option: $1" ;;
@@ -115,6 +120,10 @@ if [[ -n "$TARGET_FILE" ]]; then
 fi
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
 mkdir -p "$(dirname "$OUTPUT")"
+[[ "$NO_PROGRESS" -eq 1 ]] && sas_progress_disable
+sas_progress_start "${#TARGETS[@]}" "SMB read-only recon"
+completed=0
+trap 'rc=$?; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi' EXIT
 IFS=',' read -r -a PATH_ARRAY <<< "$APPROVED_PATHS"
 
 smb_auth_args(){
@@ -152,6 +161,7 @@ classify(){
 {
   printf 'Timestamp,Target,Share,ApprovedPath,Reachable,ListStatus,ReadStatus,Evidence,ReconStatus,Notes\n'
   for target in "${TARGETS[@]}"; do
+    sas_progress_update "$completed" "checking $target"
     for raw_path in "${PATH_ARRAY[@]}"; do
       path="$(trim "$raw_path")"; [[ -z "$path" ]] && continue
       path="${path//\\//}"
@@ -187,7 +197,10 @@ classify(){
       [[ "$list_status" == "PathMissing" ]] && recon="EvidencePathMissing"
       csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$SHARE"; printf ','; csv_escape "$path"; printf ','; csv_escape "$reachable"; printf ','; csv_escape "$list_status"; printf ','; csv_escape "$read_status"; printf ','; csv_escape "$evidence"; printf ','; csv_escape "$recon"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
     done
+    completed=$((completed + 1))
+    sas_progress_update "$completed" "finished $target"
   done
 } > "$OUTPUT"
+sas_progress_complete "wrote $OUTPUT"
 log "Wrote SMB read-only recon CSV: $OUTPUT"
 [[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-wmi-identity.sh
+++ b/bash/transport/sas-wmi-identity.sh
@@ -12,6 +12,8 @@ if [[ ! -f "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh" ]]; then
 fi
 # shellcheck source=survey/lib/sas-network-guard.sh
 source "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh"
+# shellcheck source=survey/lib/sas-progress.sh
+source "$SAS_REPO_ROOT/survey/lib/sas-progress.sh"
 
 TARGETS=()
 TARGET_FILE=""
@@ -24,6 +26,7 @@ WMI_CLIENT="${SAS_WMI_CLIENT:-auto}"
 DEBUG="${SAS_WMI_DEBUG:-${SAS_DEBUG:-0}}"
 LOG_FILE="${SAS_WMI_LOG_FILE:-}"
 PASS_THRU=0
+NO_PROGRESS=0
 
 usage(){ cat <<'USAGE'
 SysAdminSuite WMI Identity Adapter
@@ -43,6 +46,7 @@ Options:
   --debug              Print safe diagnostic logging to stderr.
   --log-file PATH      Write safe diagnostic logging to a local file.
   --pass-thru          Print CSV after writing
+  --no-progress        Suppress progress bars
   -h, --help           Show help
 
 Environment variables:
@@ -71,7 +75,7 @@ Known limitations:
 USAGE
 }
 
-fail(){ printf '[wmi-identity] ERROR: %s\n' "$*" >&2; exit 1; }
+fail(){ sas_progress_fail "$*"; printf '[wmi-identity] ERROR: %s\n' "$*" >&2; exit 1; }
 log(){ printf '[wmi-identity] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
@@ -103,6 +107,7 @@ while [[ $# -gt 0 ]]; do
     --debug) DEBUG=1; shift ;;
     --log-file) LOG_FILE="${2:?missing value for --log-file}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
+    --no-progress) NO_PROGRESS=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
     -*) fail "Unknown option: $1" ;;
@@ -131,9 +136,14 @@ if [[ -n "$TARGET_FILE" ]]; then
 fi
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
 mkdir -p "$(dirname "$OUTPUT")"
+[[ "$NO_PROGRESS" -eq 1 ]] && sas_progress_disable
+sas_progress_start "${#TARGETS[@]}" "WMI identity"
+completed=0
+trap 'rc=$?; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi' EXIT
 
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+cleanup(){ local rc=$?; rm -rf "$TMP_DIR"; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi; }
+trap cleanup EXIT
 PS_WMI_SCRIPT="$TMP_DIR/sas-wmi-query.ps1"
 
 cat > "$PS_WMI_SCRIPT" <<'PS1'
@@ -320,11 +330,15 @@ diagnostic "tooling wmic=$(if has_cmd wmic; then printf found; else printf missi
 {
   printf 'Timestamp,Target,ObservedHostName,ObservedSerial,ObservedMACs,WmiStatus,Notes\n'
   for target in "${TARGETS[@]}"; do
+    sas_progress_update "$completed" "checking $target"
     result="$(collect_identity "$target")"
     IFS='|' read -r status host serial macs notes client <<< "$result"
     diagnostic "target=$target client=${client:-unknown} status=${status:-unknown} host_collected=$([[ -n "$host" ]] && printf yes || printf no) serial_collected=$([[ -n "$serial" ]] && printf yes || printf no) macs_collected=$([[ -n "$macs" ]] && printf yes || printf no) notes=$(sanitize_field "$notes")"
     csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$host"; printf ','; csv_escape "$serial"; printf ','; csv_escape "$macs"; printf ','; csv_escape "$status"; printf ','; csv_escape "$notes"; printf '\n'
+    completed=$((completed + 1))
+    sas_progress_update "$completed" "finished $target"
   done
 } > "$OUTPUT"
+sas_progress_complete "wrote $OUTPUT"
 log "Wrote WMI identity CSV: $OUTPUT"
 [[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/sas-workstation-identity.sh
+++ b/bash/transport/sas-workstation-identity.sh
@@ -12,6 +12,8 @@ if [[ ! -f "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh" ]]; then
 fi
 # shellcheck source=survey/lib/sas-network-guard.sh
 source "$SAS_REPO_ROOT/survey/lib/sas-network-guard.sh"
+# shellcheck source=survey/lib/sas-progress.sh
+source "$SAS_REPO_ROOT/survey/lib/sas-progress.sh"
 
 TARGETS=()
 TARGET_FILE=""
@@ -26,6 +28,7 @@ WMI_PASS=""
 WMI_DOMAIN=""
 WMI_ADAPTER=""
 PASS_THRU=0
+NO_PROGRESS=0
 
 usage(){ cat <<'USAGE'
 SysAdminSuite Workstation Identity Adapter
@@ -47,6 +50,7 @@ Options:
   --wmi-domain DOMAIN  Optional WMI domain. Prefer SAS_WMI_DOMAIN
   --wmi-adapter PATH   Optional WMI adapter path. Defaults to bash/transport/sas-wmi-identity.sh
   --pass-thru          Print CSV after writing
+  --no-progress        Suppress progress bars
   -h, --help           Show help
 
 Output columns:
@@ -63,7 +67,7 @@ Known limitation:
 USAGE
 }
 
-fail(){ printf '[workstation-identity] ERROR: %s\n' "$*" >&2; exit 1; }
+fail(){ sas_progress_fail "$*"; printf '[workstation-identity] ERROR: %s\n' "$*" >&2; exit 1; }
 log(){ printf '[workstation-identity] %s\n' "$*" >&2; }
 has_cmd(){ command -v "$1" >/dev/null 2>&1; }
 trim(){ local s="${1:-}"; s="${s#"${s%%[![:space:]]*}"}"; s="${s%"${s##*[![:space:]]}"}"; printf '%s' "$s"; }
@@ -87,6 +91,7 @@ while [[ $# -gt 0 ]]; do
     --wmi-domain) WMI_DOMAIN="${2:?missing value for --wmi-domain}"; shift 2 ;;
     --wmi-adapter) WMI_ADAPTER="${2:?missing value for --wmi-adapter}"; shift 2 ;;
     --pass-thru) PASS_THRU=1; shift ;;
+    --no-progress) NO_PROGRESS=1; shift ;;
     -h|--help) usage; exit 0 ;;
     --) shift; while [[ $# -gt 0 ]]; do TARGETS+=("$1"); shift; done ;;
     -*) fail "Unknown option: $1" ;;
@@ -113,8 +118,13 @@ if [[ -n "$TARGET_FILE" ]]; then
 fi
 [[ ${#TARGETS[@]} -gt 0 ]] || fail "No targets provided"
 mkdir -p "$(dirname "$OUTPUT")"
+[[ "$NO_PROGRESS" -eq 1 ]] && sas_progress_disable
+sas_progress_start "${#TARGETS[@]}" "Workstation identity"
+completed=0
+trap 'rc=$?; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi' EXIT
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+cleanup(){ local rc=$?; rm -rf "$TMP_DIR"; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi; }
+trap cleanup EXIT
 TARGETS_TMP="$TMP_DIR/targets.txt"
 WMI_OUT="$TMP_DIR/wmi_identity.csv"
 printf '%s\n' "${TARGETS[@]}" > "$TARGETS_TMP"
@@ -197,6 +207,7 @@ ssh_identity(){
 
 if [[ "$ALLOW_WMI" -eq 1 ]]; then
   wmi_args=("$WMI_ADAPTER" --targets-file "$TARGETS_TMP" --output "$WMI_OUT" --timeout "$TIMEOUT")
+  wmi_args+=(--no-progress)
   [[ -n "$WMI_USER" ]] && wmi_args+=(--wmi-user "$WMI_USER")
   [[ -n "$WMI_PASS" ]] && wmi_args+=(--wmi-pass "$WMI_PASS")
   [[ -n "$WMI_DOMAIN" ]] && wmi_args+=(--wmi-domain "$WMI_DOMAIN")
@@ -240,6 +251,7 @@ PY
 {
   printf 'Timestamp,Target,ResolvedAddress,PingStatus,DnsName,ObservedHostName,ObservedSerial,ObservedMACs,TransportUsed,IdentityStatus,Notes\n'
   for target in "${TARGETS[@]}"; do
+    sas_progress_update "$completed" "checking $target"
     ip="$(resolve_ip "$target")"; dns="$(resolve_name "${ip:-$target}")"; ping="$(ping_status "${ip:-$target}")"
     observed_host=""; observed_serial=""; observed_macs=""; transport=""; notes=()
     if [[ "$ALLOW_WMI" -eq 1 ]]; then
@@ -262,7 +274,10 @@ PY
     [[ "$ping" != "Reachable" ]] && notes+=("ICMP failed or blocked")
     status="$(identity_status "$ping" "$observed_host" "$observed_serial" "$observed_macs")"
     csv_escape "$(date '+%Y-%m-%d %H:%M:%S')"; printf ','; csv_escape "$target"; printf ','; csv_escape "$ip"; printf ','; csv_escape "$ping"; printf ','; csv_escape "$dns"; printf ','; csv_escape "$observed_host"; printf ','; csv_escape "$observed_serial"; printf ','; csv_escape "$observed_macs"; printf ','; csv_escape "$transport"; printf ','; csv_escape "$status"; printf ','; csv_escape "$(IFS='; '; echo "${notes[*]:-}")"; printf '\n'
+    completed=$((completed + 1))
+    sas_progress_update "$completed" "finished $target"
   done
 } > "$OUTPUT"
+sas_progress_complete "wrote $OUTPUT"
 log "Wrote workstation identity CSV: $OUTPUT"
 [[ "$PASS_THRU" -eq 1 ]] && cat "$OUTPUT"

--- a/bash/transport/tests/test_transport_contracts.sh
+++ b/bash/transport/tests/test_transport_contracts.sh
@@ -9,6 +9,7 @@ PRINTER="$ROOT_DIR/bash/transport/sas-printer-probe.sh"
 IDENTITY="$ROOT_DIR/bash/transport/sas-workstation-identity.sh"
 WMI="$ROOT_DIR/bash/transport/sas-wmi-identity.sh"
 SMB="$ROOT_DIR/bash/transport/sas-smb-readonly-recon.sh"
+PROGRESS="$ROOT_DIR/survey/lib/sas-progress.sh"
 
 fail(){ printf '[transport-tests] FAIL: %s\n' "$*" >&2; exit 1; }
 pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
@@ -18,22 +19,26 @@ pass(){ printf '[transport-tests] PASS: %s\n' "$*"; }
 [[ -f "$IDENTITY" ]] || fail "Missing workstation identity adapter"
 [[ -f "$WMI" ]] || fail "Missing WMI identity adapter"
 [[ -f "$SMB" ]] || fail "Missing SMB read-only recon adapter"
+[[ -f "$PROGRESS" ]] || fail "Missing shared progress helper"
 
 bash -n "$PREFLIGHT" || fail "Network preflight has Bash syntax errors"
 bash -n "$PRINTER" || fail "Printer probe has Bash syntax errors"
 bash -n "$IDENTITY" || fail "Identity adapter has Bash syntax errors"
 bash -n "$WMI" || fail "WMI adapter has Bash syntax errors"
 bash -n "$SMB" || fail "SMB adapter has Bash syntax errors"
+bash -n "$PROGRESS" || fail "Progress helper has Bash syntax errors"
 
 PREFLIGHT_HELP="$($PREFLIGHT --help)"
 [[ "$PREFLIGHT_HELP" == *"Read-only"* || "$PREFLIGHT_HELP" == *"read-only"* ]] || fail "Preflight help must document read-only posture"
 [[ "$PREFLIGHT_HELP" == *"--ports"* ]] || fail "Preflight help must document TCP port checks"
 [[ "$PREFLIGHT_HELP" == *"--targets-file"* ]] || fail "Preflight help must document target file input"
+[[ "$PREFLIGHT_HELP" == *"--no-progress"* ]] || fail "Preflight help must document progress suppression"
 
 PRINTER_HELP="$($PRINTER --help)"
 [[ "$PRINTER_HELP" == *"SNMP"* ]] || fail "Printer help must document SNMP"
 [[ "$PRINTER_HELP" == *"--skip-9100"* ]] || fail "Printer help must document 9100 risk control"
 [[ "$PRINTER_HELP" == *"ARP"* ]] || fail "Printer help must document ARP fallback"
+[[ "$PRINTER_HELP" == *"--no-progress"* ]] || fail "Printer help must document progress suppression"
 
 IDENTITY_HELP="$($IDENTITY --help)"
 [[ "$IDENTITY_HELP" == *"Read-only"* || "$IDENTITY_HELP" == *"read-only"* ]] || fail "Identity help must document read-only posture"
@@ -42,12 +47,66 @@ IDENTITY_HELP="$($IDENTITY --help)"
 [[ "$IDENTITY_HELP" == *"--allow-wmi"* ]] || fail "Identity help must require explicit WMI enablement"
 [[ "$IDENTITY_HELP" == *"Credentials are not written"* ]] || fail "Identity help must document credential output safety"
 [[ "$IDENTITY_HELP" == *"IdentityStatus"* ]] || fail "Identity help must document IdentityStatus output"
+[[ "$IDENTITY_HELP" == *"--no-progress"* ]] || fail "Identity help must document progress suppression"
 
 WMI_HELP="$($WMI --help)"
 [[ "$WMI_HELP" == *"Read-only"* || "$WMI_HELP" == *"read-only"* ]] || fail "WMI help must document read-only posture"
 [[ "$WMI_HELP" == *"SAS_WMI_USER"* ]] || fail "WMI help must document env credential path"
 [[ "$WMI_HELP" == *"No credentials are written"* ]] || fail "WMI help must document credential output safety"
 [[ "$WMI_HELP" == *"WmiStatus"* ]] || fail "WMI help must document WmiStatus output"
+[[ "$WMI_HELP" == *"--no-progress"* ]] || fail "WMI help must document progress suppression"
+
+PROGRESS_OUTPUT="$( {
+  # shellcheck source=survey/lib/sas-progress.sh
+  source "$PROGRESS"
+  sas_progress_start 2 "Contract operation"
+  sas_progress_update 1 "first item"
+  sas_progress_complete "all items finished"
+  } 2>&1 )"
+[[ "$PROGRESS_OUTPUT" == *"50% (1/2) running"* ]] || fail "Progress helper must show determinate item progress"
+[[ "$PROGRESS_OUTPUT" == *"100% (2/2) complete"* ]] || fail "Progress helper must show explicit completion"
+[[ "$PROGRESS_OUTPUT" == *"[############------------]"* ]] || fail "Progress helper must render a visible bar"
+
+FAILED_PROGRESS_OUTPUT="$( {
+  # shellcheck source=survey/lib/sas-progress.sh
+  source "$PROGRESS"
+  sas_progress_start 3 "Failed operation"
+  sas_progress_update 1 "first item"
+  sas_progress_fail "synthetic failure"
+  } 2>&1 )"
+[[ "$FAILED_PROGRESS_OUTPUT" == *"33% (1/3) failed"* ]] || fail "Progress helper must show explicit failure"
+
+WAITING_PROGRESS_OUTPUT="$( {
+  source "$PROGRESS"
+  sas_progress_start 2 "Waiting operation"
+  sas_progress_update 1 "prepared"
+  sas_progress_wait "approve the next step"
+  } 2>&1 )"
+[[ "$WAITING_PROGRESS_OUTPUT" == *"50% (1/2) waiting"* ]] || fail "Progress helper must show explicit waiting state"
+
+SKIPPED_PROGRESS_OUTPUT="$( {
+  source "$PROGRESS"
+  sas_progress_start 2 "Skipped operation"
+  sas_progress_skip "not required for this run"
+  } 2>&1 )"
+[[ "$SKIPPED_PROGRESS_OUTPUT" == *"0% (0/2) skipped"* ]] || fail "Progress helper must show explicit skipped state"
+
+MACHINE_STDOUT="$( {
+  source "$PROGRESS"
+  sas_progress_start 1 "Machine output contract"
+  printf '{\"result\":\"ok\"}\n'
+  sas_progress_complete
+  } 2>/dev/null )"
+[[ "$MACHINE_STDOUT" == '{"result":"ok"}' ]] || fail "Progress helper must not contaminate machine-readable stdout"
+
+NO_PROGRESS_OUTPUT="$( {
+  # shellcheck source=survey/lib/sas-progress.sh
+  source "$PROGRESS"
+  sas_progress_disable
+  sas_progress_start 1 "Suppressed operation"
+  sas_progress_complete
+  } 2>&1 )"
+[[ -z "$NO_PROGRESS_OUTPUT" ]] || fail "Disabled progress helper must remain silent"
 
 SMB_HELP="$($SMB --help)"
 [[ "$SMB_HELP" == *"Read-only"* || "$SMB_HELP" == *"read-only"* ]] || fail "SMB help must document read-only posture"
@@ -55,6 +114,7 @@ SMB_HELP="$($SMB --help)"
 [[ "$SMB_HELP" == *"Does not copy files to the target"* ]] || fail "SMB help must forbid remote writes"
 [[ "$SMB_HELP" == *"SAS_SMB_USER"* ]] || fail "SMB help must document env credential path"
 [[ "$SMB_HELP" == *"ReconStatus"* ]] || fail "SMB help must document ReconStatus output"
+[[ "$SMB_HELP" == *"--no-progress"* ]] || fail "SMB help must document progress suppression"
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -94,4 +154,5 @@ grep -Eq 'EvidencePathReachable|NeedsApprovedCredentialsOrPolicy|SMBUnavailable|
 
 pass "Bash syntax checks passed"
 pass "Help contracts passed"
+pass "Progress contracts passed"
 pass "Fixture CSV contracts passed"

--- a/dashboard/js/bundle.js
+++ b/dashboard/js/bundle.js
@@ -1473,9 +1473,9 @@ var detectFileType = _exports.detectFileType, parseFileContent = _exports.parseF
 //
 // Buttons express intent; lifecycle events prove current run reality.
 
-const ACTIVE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'stopping']);
-const STOPPABLE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'stopping']);
-const TERMINAL_STATES = new Set(['stopped', 'completed', 'failed', 'aborted', 'disconnected']);
+const ACTIVE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'waiting', 'stopping']);
+const STOPPABLE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'waiting', 'stopping']);
+const TERMINAL_STATES = new Set(['stopped', 'completed', 'failed', 'skipped', 'aborted', 'disconnected']);
 const VALID_SOURCES = new Set(['ui', 'relay-client', 'relay-server', 'script', 'dashboard-parser']);
 const EXTERNAL_COMMAND_KINDS = new Set(['Command generation']);
 const CTRL_C_STOP_HINT = 'To stop a copied command, press Ctrl+C in the terminal where it is running.';
@@ -1575,6 +1575,9 @@ function _reduce(run, event) {
     case 'RunProgress':
       if (!TERMINAL_STATES.has(next.state)) next.state = 'running';
       break;
+    case 'RunWaiting':
+      if (!TERMINAL_STATES.has(next.state)) next.state = 'waiting';
+      break;
     case 'StopRequested':
     case 'StopSent':
     case 'StopAcknowledged':
@@ -1592,6 +1595,10 @@ function _reduce(run, event) {
     case 'RunFailed':
       next.state = 'failed';
       next.lastError = _safeSummary(payload.message || event.summary);
+      next.endedAt = event.timestamp;
+      break;
+    case 'RunSkipped':
+      next.state = 'skipped';
       next.endedAt = event.timestamp;
       break;
     case 'RunAborted':

--- a/dashboard/js/run-control.js
+++ b/dashboard/js/run-control.js
@@ -2,9 +2,9 @@
 //
 // Buttons express intent; lifecycle events prove current run reality.
 
-const ACTIVE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'stopping']);
-const STOPPABLE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'stopping']);
-const TERMINAL_STATES = new Set(['stopped', 'completed', 'failed', 'aborted', 'disconnected']);
+const ACTIVE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'waiting', 'stopping']);
+const STOPPABLE_STATES = new Set(['requested', 'approved', 'starting', 'running', 'waiting', 'stopping']);
+const TERMINAL_STATES = new Set(['stopped', 'completed', 'failed', 'skipped', 'aborted', 'disconnected']);
 const VALID_SOURCES = new Set(['ui', 'relay-client', 'relay-server', 'script', 'dashboard-parser']);
 const EXTERNAL_COMMAND_KINDS = new Set(['Command generation']);
 const CTRL_C_STOP_HINT = 'To stop a copied command, press Ctrl+C in the terminal where it is running.';
@@ -104,6 +104,9 @@ function _reduce(run, event) {
     case 'RunProgress':
       if (!TERMINAL_STATES.has(next.state)) next.state = 'running';
       break;
+    case 'RunWaiting':
+      if (!TERMINAL_STATES.has(next.state)) next.state = 'waiting';
+      break;
     case 'StopRequested':
     case 'StopSent':
     case 'StopAcknowledged':
@@ -121,6 +124,10 @@ function _reduce(run, event) {
     case 'RunFailed':
       next.state = 'failed';
       next.lastError = _safeSummary(payload.message || event.summary);
+      next.endedAt = event.timestamp;
+      break;
+    case 'RunSkipped':
+      next.state = 'skipped';
       next.endedAt = event.timestamp;
       break;
     case 'RunAborted':

--- a/dashboard/relay.py
+++ b/dashboard/relay.py
@@ -502,6 +502,14 @@ async def handle_connection(ws, secret_token: str):
                     await run_probe(ws, pid, t, p, c, to, ev)
                 except Exception as exc:
                     log.warning("Probe %s ended unexpectedly: %s", pid, exc)
+                    try:
+                        await ws.send(json.dumps({
+                            "type": "error",
+                            "probeId": pid,
+                            "message": "Probe failed before completion",
+                        }))
+                    except Exception:
+                        log.debug("Probe %s failure could not be delivered to client", pid)
                 finally:
                     if state["probe_id"] == pid:
                         state["probe_id"] = None

--- a/dashboard/test_run_control_lifecycle.js
+++ b/dashboard/test_run_control_lifecycle.js
@@ -148,6 +148,16 @@ emitRunEvent(run.runId, 'RunFailed', {
 });
 assert(getRunState(run.runId).state === 'failed', 'failed-state', 'RunFailed did not move to failed');
 
+// running -> waiting -> running -> skipped
+_resetRunControlForTests();
+run = createRun({ kind: 'Operator-gated action', source: 'ui', targetsSummary: 'approval required', total: 1 });
+emitRunEvent(run.runId, 'RunStarted', { source: 'script', summary: 'Preparation started' });
+emitRunEvent(run.runId, 'RunWaiting', { source: 'script', summary: 'Waiting for operator approval' });
+assert(getRunState(run.runId).state === 'waiting', 'waiting-state', 'RunWaiting did not make the wait explicit');
+emitRunEvent(run.runId, 'RunStarted', { source: 'script', summary: 'Operator approved continuation' });
+emitRunEvent(run.runId, 'RunSkipped', { source: 'script', summary: 'Optional action not required' });
+assert(getRunState(run.runId).state === 'skipped', 'skipped-state', 'RunSkipped did not move to skipped');
+
 // Persistent global Stop exists outside the probe modal and dispatches StopRequested.
 _resetRunControlForTests();
 initRunControl();

--- a/docs/PROGRESS_REPORTING.md
+++ b/docs/PROGRESS_REPORTING.md
@@ -1,0 +1,31 @@
+# Progress reporting contract
+
+Long-running SysAdminSuite operator actions must report determinate progress when a total is known and must always name their lifecycle state. The required states are `running`, `waiting`, `complete`, `failed`, and `skipped`. Animation may supplement these states, but cannot replace them.
+
+Bash scripts source `survey/lib/sas-progress.sh`. Human progress goes to stderr so CSV, JSON, and other stdout output stays machine-readable. Accept `--no-progress` and call `sas_progress_disable`, or honor `SAS_PROGRESS=0` for noninteractive callers.
+
+PowerShell scripts import `scripts/SasProgress.psm1`. Create a context with `New-SasProgressContext`, pass `-NoProgress` when requested, and publish transitions with `Write-SasProgressState`. The helper uses the information/progress streams and does not emit success-stream objects. Callers remain responsible for mapping caught errors to `failed` before returning a nonzero exit code.
+
+## Covered entrypoints
+
+| Surface | Entrypoints | Coverage |
+|---|---|---|
+| Bash transport | `sas-network-preflight.sh`, `sas-printer-probe.sh`, `sas-smb-readonly-recon.sh`, `sas-wmi-identity.sh`, `sas-workstation-identity.sh` | Determinate per-target bars, completion/failure, stderr routing, `--no-progress` |
+| Dashboard bootstrap | `Launch-SysAdminSuiteDashboard.Host.bat`, `scripts/ensure-dashboard-host.sh` | Child/bootstrap running, complete, failed, fallback skipped, determinate bootstrap stages |
+| Dashboard relay | `dashboard/relay.py`, `dashboard/js/relay-client.js`, `dashboard/js/run-control.js` | Running/progress/completion/failure plus explicit waiting and skipped lifecycle states; unexpected relay failures reach the browser |
+| Harness validator | `Run-HarnessValidation.cmd` | PowerShell child process reports running, complete, or failed with its exit code |
+| PowerShell convention | `scripts/SasProgress.psm1` | Shared required-state, determinate-count, status-channel, and suppression behavior |
+
+## Inventoried but not converted in this bounded PR
+
+| Surface | Reason |
+|---|---|
+| `survey/sas-network-preflight.ps1` | Already has determinate `Write-Progress`; PR #144 owns the same file, so suppression and shared-helper adoption are deferred to avoid collision. |
+| `scripts/validate-sysadmin-harness.ps1` | PR #154 owns the validator implementation. Its non-overlapping `.cmd` child-process wrapper is covered here. |
+| Naabu, packet-probe, reconciliation, and deployment-audit pipelines | They have different totals and evidence semantics. Converting them safely needs per-workflow design and fixture coverage; no runtime behavior is changed here. |
+| App install, staging, mapping workers, QR tasks, and GUI launchers | These are mutation-capable or interactive Windows lanes. They need dedicated PowerShell/Bash adoption without changing authorization, teardown, or target behavior. |
+| Archived mapping scripts | Retained historical/reference tooling; inventory only, with no deprecation or deletion. |
+
+## Contract checks
+
+`Tests/bash/test_progress_reporting_contracts.sh` locks the shared states, status channels, suppression switches, covered entrypoints, dashboard child failure propagation, and launcher/validator lifecycle markers. `Tests/Pester/SasProgress.Tests.ps1` verifies PowerShell state and suppression behavior. New long-running entrypoints in the covered operational families must adopt a helper and be added to the covered table and contract test; otherwise they must be listed as uncovered with a concrete reason.

--- a/scripts/SasProgress.psm1
+++ b/scripts/SasProgress.psm1
@@ -1,0 +1,59 @@
+Set-StrictMode -Version Latest
+
+$script:SasProgressStates = @('running', 'waiting', 'complete', 'failed', 'skipped')
+
+function Test-SasProgressEnabled {
+    [CmdletBinding()]
+    param([switch]$NoProgress)
+
+    if ($NoProgress) { return $false }
+    return $env:SAS_PROGRESS -notmatch '^(0|false|no|off)$'
+}
+
+function New-SasProgressContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Activity,
+        [Parameter(Mandatory)][ValidateRange(1, 2147483647)][int]$Total,
+        [switch]$NoProgress
+    )
+
+    [pscustomobject]@{
+        Activity = $Activity
+        Total = $Total
+        Current = 0
+        Enabled = Test-SasProgressEnabled -NoProgress:$NoProgress
+        Terminal = $false
+    }
+}
+
+function Write-SasProgressState {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][psobject]$Context,
+        [Parameter(Mandatory)][ValidateSet('running', 'waiting', 'complete', 'failed', 'skipped')][string]$State,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string]$Status,
+        [ValidateRange(0, 2147483647)][int]$Current = $Context.Current
+    )
+
+    if ($Context.Terminal) { return }
+    $bounded = [Math]::Min([Math]::Max($Current, 0), [int]$Context.Total)
+    if ($State -eq 'complete') { $bounded = [int]$Context.Total }
+    $Context.Current = $bounded
+    $percent = [int][Math]::Floor(($bounded / [double]$Context.Total) * 100)
+    $line = '[{0}/{1}] {2,-8} {3} - {4}%' -f $bounded, $Context.Total, $State, $Status, $percent
+
+    if ($Context.Enabled) {
+        # Write-Host uses the information stream, keeping success output available
+        # for CSV/JSON/objects consumed by callers.
+        Write-Host $line
+        Write-Progress -Activity $Context.Activity -Status $line -PercentComplete $percent
+    }
+
+    if ($State -in @('complete', 'failed', 'skipped')) {
+        if ($Context.Enabled) { Write-Progress -Activity $Context.Activity -Completed }
+        $Context.Terminal = $true
+    }
+}
+
+Export-ModuleMember -Function Test-SasProgressEnabled, New-SasProgressContext, Write-SasProgressState

--- a/scripts/ensure-dashboard-host.sh
+++ b/scripts/ensure-dashboard-host.sh
@@ -9,10 +9,13 @@ CONFIGURATION="Release"
 RUNTIME_IDENTIFIER="win-x64"
 PUBLISH_DIR="${REPO_ROOT}/app/bin"
 PROJECT="${REPO_ROOT}/src/SysAdminSuite.DashboardHost/SysAdminSuite.DashboardHost.csproj"
+# shellcheck source=survey/lib/sas-progress.sh
+source "${REPO_ROOT}/survey/lib/sas-progress.sh"
+trap 'rc=$?; if (( rc != 0 )); then sas_progress_fail "stopped with exit $rc"; fi' EXIT
 
 usage() {
   cat <<'USAGE'
-Usage: bash scripts/ensure-dashboard-host.sh [--dry-run]
+Usage: bash scripts/ensure-dashboard-host.sh [--dry-run] [--no-progress]
 
 Ensures the dashboard host can run on this Windows workstation. Existing host
 executables are reused. If the host is missing on a source checkout, the script
@@ -21,16 +24,18 @@ ensures the .NET 8 SDK, publishes the host into app/bin/, and ensures required
 
 Options:
   --dry-run   Print planned actions only
+  --no-progress  Suppress human progress; status logs still use stderr
   -h, --help  Show help
 USAGE
 }
 
 log() { printf '[ensure-dashboard-host] %s\n' "$*" >&2; }
-fail() { printf '[ensure-dashboard-host] ERROR: %s\n' "$*" >&2; exit "${2:-1}"; }
+fail() { sas_progress_fail "$1"; printf '[ensure-dashboard-host] ERROR: %s\n' "$1" >&2; exit "${2:-1}"; }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=1; shift ;;
+    --no-progress) sas_progress_disable; shift ;;
     -h|--help) usage; exit 0 ;;
     *) fail "Unknown argument: $1" ;;
   esac
@@ -93,21 +98,30 @@ publish_host() {
 }
 
 if host_path="$(find_host)"; then
+  sas_progress_start 2 "Dashboard host bootstrap"
+  sas_progress_update 1 "existing host located"
   log "Found dashboard host: $host_path"
   ensure_runtime
+  sas_progress_complete "runtime ready; host reused"
   printf '%s\n' "$host_path"
   exit 0
 fi
 
+sas_progress_start 3 "Dashboard host bootstrap"
 log "Dashboard host missing; preparing source checkout for first use."
+sas_progress_update 0 "ensuring .NET SDK"
 ensure_sdk
+sas_progress_update 1 "publishing dashboard host"
 publish_host
+sas_progress_update 2 "ensuring .NET runtime"
 ensure_runtime
 
 if [[ "$DRY_RUN" -eq 1 ]]; then
+  sas_progress_complete "dry-run plan complete"
   printf '%s\n' "${PUBLISH_DIR}/SysAdminSuite.DashboardHost.exe"
   exit 0
 fi
 
 host_path="$(find_host)" || fail "Dashboard host could not be built or located" 3
+sas_progress_complete "dashboard host ready"
 printf '%s\n' "$host_path"

--- a/survey/lib/sas-progress.sh
+++ b/survey/lib/sas-progress.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Shared, line-oriented progress bars for SysAdminSuite Bash workflows.
+# Progress is always written to stderr so CSV/JSON stdout remains machine-readable.
+
+SAS_PROGRESS="${SAS_PROGRESS:-1}"
+SAS_PROGRESS_WIDTH="${SAS_PROGRESS_WIDTH:-24}"
+[[ "$SAS_PROGRESS_WIDTH" =~ ^[1-9][0-9]*$ ]] || SAS_PROGRESS_WIDTH=24
+SAS_PROGRESS_ACTIVE=0
+SAS_PROGRESS_CURRENT=0
+SAS_PROGRESS_TOTAL=0
+SAS_PROGRESS_LABEL="SysAdminSuite operation"
+
+sas_progress_enabled() {
+  case "${SAS_PROGRESS:-1}" in
+    0|false|FALSE|no|NO|off|OFF) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+sas_progress_disable() {
+  SAS_PROGRESS=0
+  SAS_PROGRESS_ACTIVE=0
+}
+
+sas_progress_render() {
+  local current="$1" total="$2" state="$3" percent filled empty bar padding
+  sas_progress_enabled || return 0
+  [[ "$current" =~ ^[0-9]+$ && "$total" =~ ^[1-9][0-9]*$ ]] || return 0
+  (( current > total )) && current="$total"
+  percent=$(( current * 100 / total ))
+  filled=$(( current * SAS_PROGRESS_WIDTH / total ))
+  empty=$(( SAS_PROGRESS_WIDTH - filled ))
+  printf -v bar '%*s' "$filled" ''
+  bar="${bar// /#}"
+  printf -v padding '%*s' "$empty" ''
+  padding="${padding// /-}"
+  printf '[%s%s] %3d%% (%d/%d) %-8s %s%s\n' \
+    "$bar" "$padding" "$percent" "$current" "$total" "$state" "$SAS_PROGRESS_LABEL" \
+    "${4:+ — $4}" >&2
+}
+
+sas_progress_start() {
+  local total="$1" label="${2:-SysAdminSuite operation}"
+  [[ "$total" =~ ^[1-9][0-9]*$ ]] || return 0
+  SAS_PROGRESS_ACTIVE=1
+  SAS_PROGRESS_CURRENT=0
+  SAS_PROGRESS_TOTAL="$total"
+  SAS_PROGRESS_LABEL="$label"
+  sas_progress_render 0 "$total" running "started"
+}
+
+sas_progress_update() {
+  local current="$1" detail="${2:-working}"
+  [[ "$SAS_PROGRESS_ACTIVE" -eq 1 ]] || return 0
+  SAS_PROGRESS_CURRENT="$current"
+  sas_progress_render "$current" "$SAS_PROGRESS_TOTAL" running "$detail"
+}
+
+sas_progress_wait() {
+  local detail="${1:-waiting for operator input}"
+  [[ "$SAS_PROGRESS_ACTIVE" -eq 1 ]] || return 0
+  sas_progress_render "$SAS_PROGRESS_CURRENT" "$SAS_PROGRESS_TOTAL" waiting "$detail"
+}
+
+sas_progress_complete() {
+  local detail="${1:-finished successfully}"
+  [[ "$SAS_PROGRESS_ACTIVE" -eq 1 ]] || return 0
+  SAS_PROGRESS_CURRENT="$SAS_PROGRESS_TOTAL"
+  sas_progress_render "$SAS_PROGRESS_TOTAL" "$SAS_PROGRESS_TOTAL" complete "$detail"
+  SAS_PROGRESS_ACTIVE=0
+}
+
+sas_progress_fail() {
+  local detail="${1:-stopped before completion}"
+  [[ "$SAS_PROGRESS_ACTIVE" -eq 1 ]] || return 0
+  sas_progress_render "$SAS_PROGRESS_CURRENT" "$SAS_PROGRESS_TOTAL" failed "$detail"
+  SAS_PROGRESS_ACTIVE=0
+}
+
+sas_progress_skip() {
+  local detail="${1:-not required}"
+  [[ "$SAS_PROGRESS_ACTIVE" -eq 1 ]] || return 0
+  sas_progress_render "$SAS_PROGRESS_CURRENT" "$SAS_PROGRESS_TOTAL" skipped "$detail"
+  SAS_PROGRESS_ACTIVE=0
+}


### PR DESCRIPTION
## Summary
- adds shared determinate progress helpers for Bash and active PowerShell
- preserves machine-readable CSV/JSON/stdout by routing human progress to status channels
- covers five Bash transport probes, dashboard bootstrap/launcher/relay lifecycle, and the harness validator child-process wrapper
- requires explicit running, waiting, complete, failed, and skipped states with noninteractive suppression
- documents covered and deferred operational entrypoints and adds adoption contracts

## Why
Long-running operator actions could appear stalled or end without an unambiguous lifecycle state. This establishes one bounded progress contract without changing probe results, evidence semantics, target scope, network policy, or mutation behavior.

## Operator impact
Operators receive determinate counts where totals are known and explicit terminal states. Bash callers can use `--no-progress` or `SAS_PROGRESS=0`; PowerShell callers can use `-NoProgress`. Human progress does not contaminate machine-readable success output.

## Validation
PASS:
- rebased onto current `main` at `b3143eb` (branch 1 ahead / 0 behind before push)
- dashboard bundle regenerated successfully
- dashboard run-control lifecycle: 23 passed, 0 failed
- relay cancellation unit tests: 4 passed
- `dashboard/relay.py` parser/compile check
- PowerShell parser checks for the helper and Pester contract
- direct Windows PowerShell lifecycle/suppression contract
- dashboard/launcher/validator static progress contracts
- `git diff --check origin/main...HEAD`

SKIP:
- Bash syntax, focused progress contracts, and existing transport contracts: Git Bash cannot create its signal pipe inside the Codex Windows sandbox
- Pester execution: Pester 6 fails before loading tests because its temporary HKCU registry write is sandbox-denied
- relay WebSocket E2E: optional `websockets` dependency is unavailable from the configured package index

## Proof boundary
Static checks and local unit/parser proof only. No live target, field-network, deployment, mapping, or mutation proof was performed or inferred.